### PR TITLE
[CI] Fix DeepGEMM sanitizer setup and Blackwell test timeouts

### DIFF
--- a/.github/workflows/release-whl-deepgemm.yml
+++ b/.github/workflows/release-whl-deepgemm.yml
@@ -100,9 +100,11 @@ jobs:
           - arch_label: sm90
             runner: 8-gpu-h200
             wheel_arch: x86_64
+            timeout: 120
           - arch_label: sm100
             runner: 8-gpu-b200
             wheel_arch: x86_64
+            timeout: 240
           # The sm120 tests require a runner with RTX 6000. It causes OOM on 5090 runners.
           # - arch_label: sm120
           #   runner: 1-gpu-5090
@@ -110,8 +112,9 @@ jobs:
           - arch_label: sm100-aarch64
             runner: 4-gpu-gb300
             wheel_arch: aarch64
+            timeout: 240
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 120
+    timeout-minutes: ${{ matrix.timeout }}
     steps:
       - uses: actions/checkout@v4
 
@@ -141,6 +144,36 @@ jobs:
           python3 -m pip install numpy
           python3 -m pip install dist/*.whl
           python3 -c "import deep_gemm; print('deep_gemm:', deep_gemm.__file__)"
+
+      - name: Install Compute Sanitizer 2025.4.1
+        env:
+          WHEEL_ARCH: ${{ matrix.wheel_arch }}
+        run: |
+          set -euo pipefail
+          # CUDA 13.1.1's standalone sanitizer fixes Python tensor retention in
+          # host backtraces. Keep the wheel and runtime on CUDA 13.0.
+          case "${WHEEL_ARCH}" in
+            x86_64)
+              sanitizer_arch=linux-x86_64
+              sanitizer_sha256=b9637777a31cd0f0ffe1e965523e8b0d382019b8496855fd688c886988583cf4
+              ;;
+            aarch64)
+              sanitizer_arch=linux-sbsa
+              sanitizer_sha256=1dc68ccb146032bcdc9d932569c865d68e3966ecf136940ca38fd7d5abfda4ac
+              ;;
+            *) echo "Unsupported sanitizer architecture: ${WHEEL_ARCH}" >&2; exit 1 ;;
+          esac
+          archive="cuda_sanitizer_api-${sanitizer_arch}-13.1.118-archive"
+          install_dir="${RUNNER_TEMP}/deepgemm-compute-sanitizer"
+          mkdir -p "${install_dir}"
+          curl -fsSL --retry 3 \
+            "https://developer.download.nvidia.com/compute/cuda/redist/cuda_sanitizer_api/${sanitizer_arch}/${archive}.tar.xz" \
+            -o "${install_dir}/${archive}.tar.xz"
+          echo "${sanitizer_sha256}  ${install_dir}/${archive}.tar.xz" | sha256sum -c -
+          tar -xJf "${install_dir}/${archive}.tar.xz" -C "${install_dir}"
+          sanitizer="${install_dir}/${archive}/bin/compute-sanitizer"
+          "${sanitizer}" --version
+          echo "COMPUTE_SANITIZER=${sanitizer}" >> "${GITHUB_ENV}"
 
       - name: Run DeepGEMM test suite
         run: |


### PR DESCRIPTION
## Motivation

In [DeepGEMM release run 34661868930](https://github.com/sgl-project/sglang/actions/runs/34661868930), H200 passed the ordinary attention tests but ran out of memory in the PyTorch MQA reference under memcheck. The test job uses the runner's unpinned system sanitizer; this failure matches the Python memory leak fixed in [Compute Sanitizer 2025.4.1](https://docs.nvidia.com/compute-sanitizer/ReleaseNotes/index.html#updates-in-2025-4-1). The runner's exact sanitizer version was not printed.

B200 and GB300 both exceeded the existing two-hour job limit while running the expanded test suite.

## Modifications

- Install standalone Compute Sanitizer 2025.4.1 from NVIDIA's CUDA 13.1.1 redistribution (component 13.1.118), with separate x86_64 and ARM SBSA downloads and pinned SHA256 checksums.
- Print the selected tool's version and export `COMPUTE_SANITIZER` through `GITHUB_ENV` so DeepGEMM's test runner uses it. The CUDA 13.0 wheel/runtime and all sanitizer checks are retained.
- Set B200 and GB300 test job timeouts to 240 minutes; retain H200's 120-minute timeout.

## Accuracy Tests

- Downloaded both archives and verified official manifest sizes/SHA256, packaged launcher paths, ELF architectures, and embedded version 2025.4.1.0.
- Workflow syntax and expressions passed actionlint with the existing custom runner labels configured. The exact added shell step passed ShellCheck and `bash -n`.
- `pre-commit run --files .github/workflows/release-whl-deepgemm.yml` and `git diff --check` passed.
- Full GPU release validation has not been rerun for this PR. The publishing workflow was not dispatched as a test.

## Speed Tests and Profiling

Not applicable: test environment setup and timeout configuration only.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34670182744](https://github.com/sgl-project/sglang/actions/runs/34670182744)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34670182466](https://github.com/sgl-project/sglang/actions/runs/34670182466)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->