### PR TITLE
[Bugfix][Responses API] Render namespace tool declarations instead of dropping them

### DIFF
--- a/python/sglang/srt/entrypoints/harmony_utils.py
+++ b/python/sglang/srt/entrypoints/harmony_utils.py
@@ -5,7 +5,7 @@
 import datetime
 import logging
 from collections.abc import Iterable
-from typing import Optional, Union
+from typing import Optional, Set, Union
 
 import orjson
 from openai.types.responses import (
@@ -46,11 +46,14 @@ from openai_harmony import (
 from sglang.srt.entrypoints.openai.protocol import (
     ReasoningEffortTier,
     ResponseInputOutputItem,
+    ResponseNamespacedFunctionToolCall,
     ResponseOutputMessage,
 )
 from sglang.srt.entrypoints.openai.responses_adapters import (
     decode_reasoning_state,
     encode_custom_tool_input,
+    namespace_members_to_chat_tools,
+    split_namespaced_call,
 )
 from sglang.srt.utils import random_uuid
 
@@ -110,6 +113,7 @@ def get_developer_message(
         dev_msg_content = dev_msg_content.with_instructions(instructions)
     if tools is not None:
         function_tools = []
+        member_descriptions = []
         for tool in tools:
             if tool.type in (
                 "web_search",
@@ -120,6 +124,17 @@ def get_developer_message(
                 pass
             elif tool.type == "function":
                 function_tools.append(tool)
+            elif tool.type == "namespace" and tool.name:
+                # Members flatten to qualified functions, same as the chat
+                # path, but as harmony tool descriptions.
+                for member in namespace_members_to_chat_tools(tool):
+                    member_descriptions.append(
+                        ToolDescription.new(
+                            name=member.function.name,
+                            description=member.function.description or "",
+                            parameters=member.function.parameters,
+                        )
+                    )
             else:
                 # No harmony prompt template for the remaining built-ins;
                 # drop them so the request still runs.
@@ -127,15 +142,15 @@ def get_developer_message(
                     "harmony: ignoring unsupported response tool type %r",
                     tool.type,
                 )
-        if function_tools:
-            function_tool_descriptions = [
-                ToolDescription.new(
-                    name=tool.name,
-                    description=tool.description,
-                    parameters=tool.parameters,
-                )
-                for tool in function_tools
-            ]
+        function_tool_descriptions = [
+            ToolDescription.new(
+                name=tool.name,
+                description=tool.description,
+                parameters=tool.parameters,
+            )
+            for tool in function_tools
+        ] + member_descriptions
+        if function_tool_descriptions:
             dev_msg_content = dev_msg_content.with_function_tools(
                 function_tool_descriptions
             )
@@ -230,9 +245,14 @@ def parse_response_input(
         )
         if isinstance(arguments, dict):
             arguments = orjson.dumps(arguments).decode()
+        name = response_msg["name"]
+        namespace = response_msg.get("namespace")
+        if namespace and name:
+            # Re-qualify so the model sees the flattened name it was offered.
+            name = f"{namespace}.{name}"
         msg = Message.from_role_and_content(Role.ASSISTANT, arguments)
         msg = msg.with_channel("commentary")
-        msg = msg.with_recipient(f"functions.{response_msg['name']}")
+        msg = msg.with_recipient(f"functions.{name}")
         msg = msg.with_content_type("json")
     else:
         raise ValueError(f"Unknown input type: {response_msg['type']}")
@@ -286,7 +306,11 @@ def get_streamable_parser_for_assistant() -> StreamableParser:
     return StreamableParser(get_encoding(), role=Role.ASSISTANT)
 
 
-def parse_output_message(message: Message):
+def parse_output_message(
+    message: Message,
+    namespaces: Optional[Set[str]] = None,
+    declared_names: Optional[Set[str]] = None,
+):
     if message.author.role != "assistant":
         # This is a message from a tool to the assistant (e.g., search result).
         # Don't include it in the final output for now. This aligns with
@@ -351,16 +375,32 @@ def parse_output_message(message: Message):
             output_items.append(reasoning_item)
     elif message.channel == "commentary" and message.recipient is not None:
         if message.recipient.startswith("functions."):
-            function_name = message.recipient.removeprefix("functions.")
+            # The recipient keeps the full dotted suffix; declared
+            # namespaces split it back onto the wire item's fields.
+            item_name, namespace = split_namespaced_call(
+                message.recipient.removeprefix("functions."),
+                namespaces or frozenset(),
+                declared_names or frozenset(),
+            )
             for content in message.content:
                 random_id = random_uuid()
-                response_item = ResponseFunctionToolCall(
-                    arguments=content.text,
-                    call_id=f"call_{random_id}",
-                    type="function_call",
-                    name=function_name,
-                    id=f"ft_{random_id}",
-                )
+                if namespace is None:
+                    response_item = ResponseFunctionToolCall(
+                        arguments=content.text,
+                        call_id=f"call_{random_id}",
+                        type="function_call",
+                        name=item_name,
+                        id=f"ft_{random_id}",
+                    )
+                else:
+                    response_item = ResponseNamespacedFunctionToolCall(
+                        arguments=content.text,
+                        call_id=f"call_{random_id}",
+                        type="function_call",
+                        name=item_name,
+                        namespace=namespace,
+                        id=f"ft_{random_id}",
+                    )
                 output_items.append(response_item)
         elif message.recipient.startswith("python") or message.recipient.startswith(
             "browser"
@@ -406,7 +446,11 @@ def parse_output_message(message: Message):
     return output_items
 
 
-def parse_remaining_state(parser: StreamableParser):
+def parse_remaining_state(
+    parser: StreamableParser,
+    namespaces: Optional[Set[str]] = None,
+    declared_names: Optional[Set[str]] = None,
+):
     if not parser.current_content:
         return []
     if parser.current_role != Role.ASSISTANT:
@@ -441,12 +485,29 @@ def parse_remaining_state(parser: StreamableParser):
         return [reasoning_item]
     elif current_recipient is not None and current_recipient.startswith("functions."):
         random_id = random_uuid()
+        item_name, namespace = split_namespaced_call(
+            current_recipient.removeprefix("functions."),
+            namespaces or frozenset(),
+            declared_names or frozenset(),
+        )
+        if namespace is None:
+            return [
+                ResponseFunctionToolCall(
+                    id=f"ft_{random_id}",
+                    call_id=f"call_{random_id}",
+                    type="function_call",
+                    name=item_name,
+                    arguments=parser.current_content,
+                    status="in_progress",
+                )
+            ]
         return [
-            ResponseFunctionToolCall(
+            ResponseNamespacedFunctionToolCall(
                 id=f"ft_{random_id}",
                 call_id=f"call_{random_id}",
                 type="function_call",
-                name=current_recipient.removeprefix("functions."),
+                name=item_name,
+                namespace=namespace,
                 arguments=parser.current_content,
                 status="in_progress",
             )

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -39,6 +39,8 @@ from openai.types.responses import (
     ResponseFunctionToolCall,
     ResponseInputItemParam,
     ResponseOutputItem,
+    ResponseOutputItemAddedEvent,
+    ResponseOutputItemDoneEvent,
 )
 from openai.types.responses import ResponseOutputMessage as OpenAIResponseOutputMessage
 from openai.types.responses import (
@@ -1604,6 +1606,37 @@ class ResponseOutputMessage(OpenAIResponseOutputMessage):
     phase: Optional[Literal["commentary", "final_answer"]] = None
 
 
+class ResponseNamespacedFunctionToolCall(ResponseFunctionToolCall):
+    """A ``function_call`` emitted for a ``namespace`` tool declaration.
+
+    The chat pipeline only sees the qualified ``{namespace}.{name}``
+    function, so the split pair has to travel back on the item itself.
+    """
+
+    namespace: str
+
+
+# Streaming events and response payloads type ``item``/``output`` through the
+# SDK unions, whose ``ResponseFunctionToolCall`` arm serializes a subclass
+# instance and drops ``namespace``; the subclasses below widen the union with
+# the namespaced arm first so the field survives model_dump.
+class ResponseNamespacedOutputItemAddedEvent(ResponseOutputItemAddedEvent):
+    item: Union[ResponseNamespacedFunctionToolCall, ResponseOutputItem]
+
+
+class ResponseNamespacedOutputItemDoneEvent(ResponseOutputItemDoneEvent):
+    item: Union[ResponseNamespacedFunctionToolCall, ResponseOutputItem]
+
+
+ResponsesOutputItem = Union[
+    ResponseOutputMessage,
+    ResponseOutputItem,
+    ResponseReasoningItem,
+    ResponseNamespacedFunctionToolCall,
+    ResponseFunctionToolCall,
+]
+
+
 ResponseInputOutputItem: TypeAlias = Union[
     ResponseInputMessageParam,
     ResponseOutputMessage,
@@ -1807,15 +1840,19 @@ class ResponsesRequest(BaseModel):
 
     def effective_tool_choice(self) -> Union[str, Dict[str, Any]]:
         """``tool_choice`` reduced to what the server can actually honor: of the
-        object forms only a named ``function`` / ``custom`` tool survives, the
-        rest (web_search, mcp, ...) can't be forced through the tool-call
-        parser."""
+        object forms only a named ``function`` / ``custom`` tool survives (a
+        ``namespace`` field re-qualifies the inner name to the flattened form
+        the model saw), the rest (web_search, mcp, ...) can't be forced
+        through the tool-call parser."""
         tool_choice = self.tool_choice
         if not isinstance(tool_choice, dict):
             return tool_choice
         name = tool_choice.get("name") or (tool_choice.get("function") or {}).get(
             "name"
         )
+        namespace = tool_choice.get("namespace")
+        if namespace and name:
+            name = f"{namespace}.{name}"
         if tool_choice.get("type") in ("function", "custom") and name:
             return {"type": "function", "name": name}
         return "auto"
@@ -1917,14 +1954,7 @@ class ResponsesResponse(BaseModel):
     created_at: int = Field(default_factory=lambda: int(time.time()))
     model: str
 
-    output: List[
-        Union[
-            ResponseOutputMessage,
-            ResponseOutputItem,
-            ResponseReasoningItem,
-            ResponseFunctionToolCall,
-        ]
-    ] = Field(default_factory=list)
+    output: List[ResponsesOutputItem] = Field(default_factory=list)
     status: Literal[
         "queued", "in_progress", "completed", "incomplete", "failed", "cancelled"
     ]

--- a/python/sglang/srt/entrypoints/openai/responses_adapters.py
+++ b/python/sglang/srt/entrypoints/openai/responses_adapters.py
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """Translations between Responses-API wire shapes and SGLang's chat internals.
 
-Two things the Responses API expresses that the chat-completions path has no
+Three things the Responses API expresses that the chat-completions path has no
 representation for:
 
 * ``custom`` tools, whose payload is freeform text rather than JSON-object
   arguments. Each is surfaced to the model as a function tool with a single
   string property, and the resulting call is translated back into a
   ``custom_tool_call``.
+* ``namespace`` tools, which group inner function schemas. Each member is
+  surfaced as a ``{namespace}.{name}`` function the model can call, and the
+  emitted call splits the pair back into ``name`` plus ``namespace``.
 * ``reasoning.encrypted_content``, the opaque blob a ``store=false`` client
   replays to hand a reasoning trace back to the server.
 """
@@ -17,7 +20,9 @@ from __future__ import annotations
 import base64
 import json
 import zlib
-from typing import Any, Dict, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
 
 CUSTOM_TOOL_INPUT_KEY = "input"
 
@@ -165,6 +170,55 @@ def decode_custom_tool_input_prefix(buffer: str) -> str:
             continue
         break
     return "".join(out)
+
+
+def namespace_tool_names(tools: Any) -> Set[str]:
+    """Declared ``namespace`` prefixes; only these split on the way out."""
+    return {tool.name for tool in tools or [] if tool.type == "namespace" and tool.name}
+
+
+def namespace_members_to_chat_tools(tool: Any) -> List[Any]:
+    """Flatten one ``namespace`` declaration into chat function tools named
+    ``{namespace}.{member}``.
+
+    Inner description and strict flags survive; the namespace description
+    fills members that omit one, the way OpenAI documents the grouping.
+    """
+    members = []
+    for inner in tool.tools or []:
+        inner_name = inner.get("name") if isinstance(inner, dict) else None
+        if not isinstance(inner_name, str) or not inner_name:
+            raise ValueError(
+                f"namespace tool {tool.name!r} has an inner tool without a name."
+            )
+        members.append(
+            Tool(
+                type="function",
+                function=Function(
+                    name=f"{tool.name}.{inner_name}",
+                    description=inner.get("description") or tool.description,
+                    parameters=inner.get("parameters"),
+                    strict=bool(inner.get("strict", False)),
+                ),
+            )
+        )
+    return members
+
+
+def split_namespaced_call(
+    name: str, namespaces: Set[str], declared_names: Set[str]
+) -> Tuple[str, Optional[str]]:
+    """Map one model-facing call name onto its wire-item fields.
+
+    Returns ``(name, namespace)``. An exact declaration outranks a prefix
+    split, so a plain function whose name contains a dot is never
+    reinterpreted; undeclared dotted names pass through unchanged.
+    """
+    if name not in declared_names:
+        namespace, _, inner = name.partition(".")
+        if namespace in namespaces and inner:
+            return inner, namespace
+    return name, None
 
 
 DEVELOPER_BLOCK_LABEL = "Developer instructions:"

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -61,6 +61,9 @@ from sglang.srt.entrypoints.openai.protocol import (
     MessageProcessingResult,
     PromptTokenUsageInfo,
     RequestResponseMetadata,
+    ResponseNamespacedFunctionToolCall,
+    ResponseNamespacedOutputItemAddedEvent,
+    ResponseNamespacedOutputItemDoneEvent,
     ResponseOutputMessage,
     ResponsesRequest,
     ResponsesResponse,
@@ -77,6 +80,9 @@ from sglang.srt.entrypoints.openai.responses_adapters import (
     encode_custom_tool_input,
     encode_reasoning_state,
     label_developer_content,
+    namespace_members_to_chat_tools,
+    namespace_tool_names,
+    split_namespaced_call,
 )
 from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
 from sglang.srt.entrypoints.openai.tool_server import MCPToolServer, ToolServer
@@ -288,14 +294,16 @@ class OpenAIServingResponses(OpenAIServingChat):
         # FIXME: If the engine is dead, raise an error
         # This is required for the streaming case
 
-        # ``tool_choice="required"`` needs a tool the parser can actually force.
+        # ``tool_choice="required"`` needs a tool the parser can actually force;
+        # ``namespace`` members flatten down to functions like ``custom`` does.
         if request.tool_choice == "required" and not any(
-            tool.type in ("function", "custom") for tool in (request.tools or [])
+            tool.type in ("function", "custom", "namespace")
+            for tool in (request.tools or [])
         ):
             return self.create_error_response(
                 'tool_choice="required" requires at least one tool with '
-                'type="function" or type="custom"; other built-in tool types '
-                "cannot be forced."
+                'type="function", type="custom" or type="namespace"; other '
+                "built-in tool types cannot be forced."
             )
 
         tool_choice = request.effective_tool_choice()
@@ -737,7 +745,15 @@ class OpenAIServingResponses(OpenAIServingChat):
             output = (
                 output_items
                 if output_items is not None
-                else self._make_response_output_items_with_harmony(context)
+                else self._make_response_output_items_with_harmony(
+                    context,
+                    namespace_tool_names(request.tools),
+                    {
+                        tool.name
+                        for tool in request.tools or []
+                        if tool.type in ("function", "custom") and tool.name
+                    },
+                )
             )
             # num_reasoning_tokens isn't wired through HarmonyContext yet; stays 0.
             num_prompt_tokens = context.num_prompt_tokens
@@ -890,10 +906,20 @@ class OpenAIServingResponses(OpenAIServingChat):
 
     @staticmethod
     def _make_tool_call_item(
-        name: str, arguments: str, custom_names: set[str]
-    ) -> Union[ResponseFunctionToolCall, ResponseCustomToolCall]:
+        name: str,
+        arguments: str,
+        custom_names: set[str],
+        namespaces: set[str] = frozenset(),
+        declared_names: set[str] = frozenset(),
+    ) -> Union[
+        ResponseFunctionToolCall,
+        ResponseCustomToolCall,
+        ResponseNamespacedFunctionToolCall,
+    ]:
         """A call against a ``custom`` tool reports its freeform payload rather
-        than the JSON arguments of the shim function tool."""
+        than the JSON arguments of the shim function tool; a call against a
+        flattened ``namespace`` member splits the qualified name back into
+        ``name`` plus ``namespace``."""
         call_id = f"call_{random_uuid()[:24]}"
         if name in custom_names:
             return ResponseCustomToolCall(
@@ -903,11 +929,22 @@ class OpenAIServingResponses(OpenAIServingChat):
                 name=name,
                 input=decode_custom_tool_input(arguments),
             )
+        item_name, namespace = split_namespaced_call(name, namespaces, declared_names)
+        if namespace is not None:
+            return ResponseNamespacedFunctionToolCall(
+                arguments=arguments,
+                call_id=call_id,
+                type="function_call",
+                name=item_name,
+                namespace=namespace,
+                id=f"fc_{random_uuid()[:8]}",
+                status="completed",
+            )
         return ResponseFunctionToolCall(
             arguments=arguments,
             call_id=call_id,
             type="function_call",
-            name=name,
+            name=item_name,
             id=f"fc_{random_uuid()[:8]}",
             status="completed",
         )
@@ -1032,6 +1069,12 @@ class OpenAIServingResponses(OpenAIServingChat):
         tool_choice = request.effective_tool_choice()
         is_required = tool_choice == "required" or isinstance(tool_choice, dict)
         custom_names = custom_tool_names(request.tools)
+        namespaces = namespace_tool_names(request.tools)
+        declared_names = {
+            tool.name
+            for tool in request.tools or []
+            if tool.type in ("function", "custom") and tool.name
+        }
         tool_call_items: list[
             Union[ResponseFunctionToolCall, ResponseCustomToolCall]
         ] = []
@@ -1059,6 +1102,8 @@ class OpenAIServingResponses(OpenAIServingChat):
                                 call_info.name,
                                 call_info.parameters or "",
                                 custom_names,
+                                namespaces,
+                                declared_names,
                             )
                         )
                     parsed_via_native = bool(call_info_list)
@@ -1085,7 +1130,11 @@ class OpenAIServingResponses(OpenAIServingChat):
                         )
                         tool_call_items.append(
                             self._make_tool_call_item(
-                                tool["name"], arguments, custom_names
+                                tool["name"],
+                                arguments,
+                                custom_names,
+                                namespaces,
+                                declared_names,
                             )
                         )
                     content = ""
@@ -1115,6 +1164,8 @@ class OpenAIServingResponses(OpenAIServingChat):
     def _make_response_output_items_with_harmony(
         self,
         context: HarmonyContext,
+        namespaces: Optional[set[str]] = None,
+        declared_names: Optional[set[str]] = None,
     ):
         output_items = []
         num_init_messages = (
@@ -1123,9 +1174,9 @@ class OpenAIServingResponses(OpenAIServingChat):
             else context.num_init_messages
         )
         for msg in context.messages[num_init_messages:]:
-            output_items.extend(parse_output_message(msg))
+            output_items.extend(parse_output_message(msg, namespaces, declared_names))
         # Handle the generation stopped in the middle (if any).
-        last_items = parse_remaining_state(context.parser)
+        last_items = parse_remaining_state(context.parser, namespaces, declared_names)
         if last_items:
             output_items.extend(last_items)
         return output_items
@@ -1148,7 +1199,9 @@ class OpenAIServingResponses(OpenAIServingChat):
     @staticmethod
     def _response_tools_to_chat_tools(request: ResponsesRequest) -> list[Tool]:
         # ``function`` and ``custom`` tools flow to chat; built-ins go through
-        # harmony. A custom tool is shimmed into a single-string function tool.
+        # harmony. A custom tool is shimmed into a single-string function tool;
+        # a namespace tool's members flatten to ``{namespace}.{name}``
+        # functions.
         chat_tools = []
         for tool in request.tools:
             if tool.type == "function":
@@ -1156,6 +1209,9 @@ class OpenAIServingResponses(OpenAIServingChat):
             elif tool.type == "custom" and tool.name:
                 description = custom_tool_description(tool.description, tool.format)
                 parameters = custom_tool_parameters()
+            elif tool.type == "namespace" and tool.name:
+                chat_tools.extend(namespace_members_to_chat_tools(tool))
+                continue
             else:
                 continue
             chat_tools.append(
@@ -1271,7 +1327,13 @@ class OpenAIServingResponses(OpenAIServingChat):
                 raw = orjson.dumps(raw).decode("utf-8")
             else:
                 raw = "{}"
-            return cls._chat_tool_call_message(message, message.get("name"), raw)
+            name = message.get("name")
+            namespace = message.get("namespace")
+            if namespace and name:
+                # Re-qualify so the template sees the flattened name the
+                # model was shown at declaration time.
+                name = f"{namespace}.{name}"
+            return cls._chat_tool_call_message(message, name, raw)
         if msg_type == "custom_tool_call":
             # Replay through the same single-string shim the tool was offered as.
             return cls._chat_tool_call_message(
@@ -1626,6 +1688,12 @@ class OpenAIServingResponses(OpenAIServingChat):
     ) -> AsyncGenerator[str, None]:
         created_time = created_time or int(time.time())
         sequence_number = 0
+        namespaces = namespace_tool_names(request.tools)
+        declared_names = {
+            tool.name
+            for tool in request.tools or []
+            if tool.type in ("function", "custom") and tool.name
+        }
         emitted_items = []
         active_item = None
         active_model = None
@@ -1804,11 +1872,11 @@ class OpenAIServingResponses(OpenAIServingChat):
 
         async for ctx in result_generator:
             for message in ctx.messages[num_messages:]:
-                for item in parse_output_message(message):
+                for item in parse_output_message(message, namespaces, declared_names):
                     for event in _update_item(item, done=True):
                         yield event
             num_messages = len(ctx.messages)
-            for item in parse_remaining_state(ctx.parser):
+            for item in parse_remaining_state(ctx.parser, namespaces, declared_names):
                 for event in _update_item(item):
                     yield event
 
@@ -1963,6 +2031,12 @@ class OpenAIServingResponses(OpenAIServingChat):
 
         chat_tools = self._response_tools_to_chat_tools(request)
         custom_names = custom_tool_names(request.tools)
+        namespaces = namespace_tool_names(request.tools)
+        declared_names = {
+            tool.name
+            for tool in request.tools or []
+            if tool.type in ("function", "custom") and tool.name
+        }
         tool_choice = request.effective_tool_choice()
         is_required = tool_choice == "required" or isinstance(tool_choice, dict)
         tool_parser: Optional[Union[FunctionCallParser, JsonArrayParser]] = None
@@ -2194,6 +2268,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                     name=state["name"] or "",
                     input=payload,
                 )
+                item_done_cls = openai_responses_types.ResponseOutputItemDoneEvent
                 events.append(
                     _send_event(
                         openai_responses_types.ResponseCustomToolCallInputDoneEvent(
@@ -2206,14 +2281,30 @@ class OpenAIServingResponses(OpenAIServingChat):
                     )
                 )
             else:
-                completed_item = ResponseFunctionToolCall(
-                    arguments=arguments,
-                    call_id=state["call_id"],
-                    name=state["name"] or "",
-                    type="function_call",
-                    id=state["item_id"],
-                    status="completed",
+                item_name, namespace = split_namespaced_call(
+                    state["name"] or "", namespaces, declared_names
                 )
+                if namespace is not None:
+                    completed_item = ResponseNamespacedFunctionToolCall(
+                        arguments=arguments,
+                        call_id=state["call_id"],
+                        name=item_name,
+                        namespace=namespace,
+                        type="function_call",
+                        id=state["item_id"],
+                        status="completed",
+                    )
+                    item_done_cls = ResponseNamespacedOutputItemDoneEvent
+                else:
+                    completed_item = ResponseFunctionToolCall(
+                        arguments=arguments,
+                        call_id=state["call_id"],
+                        name=item_name,
+                        type="function_call",
+                        id=state["item_id"],
+                        status="completed",
+                    )
+                    item_done_cls = openai_responses_types.ResponseOutputItemDoneEvent
                 events.append(
                     _send_event(
                         openai_responses_types.ResponseFunctionCallArgumentsDoneEvent(
@@ -2222,13 +2313,13 @@ class OpenAIServingResponses(OpenAIServingChat):
                             item_id=state["item_id"],
                             output_index=state["output_index"],
                             arguments=arguments,
-                            name=state["name"] or "",
+                            name=item_name,
                         )
                     )
                 )
             events.append(
                 _send_event(
-                    openai_responses_types.ResponseOutputItemDoneEvent(
+                    item_done_cls(
                         type="response.output_item.done",
                         sequence_number=-1,
                         output_index=state["output_index"],
@@ -2418,17 +2509,40 @@ class OpenAIServingResponses(OpenAIServingChat):
                                     name=state["name"],
                                     input="",
                                 )
-                            else:
-                                added_item = ResponseFunctionToolCall(
-                                    arguments="",
-                                    call_id=state["call_id"],
-                                    name=state["name"],
-                                    type="function_call",
-                                    id=state["item_id"],
-                                    status="in_progress",
+                                added_event_cls = (
+                                    openai_responses_types.ResponseOutputItemAddedEvent
                                 )
+                            else:
+                                item_name, namespace = split_namespaced_call(
+                                    state["name"] or "",
+                                    namespaces,
+                                    declared_names,
+                                )
+                                if namespace is not None:
+                                    added_item = ResponseNamespacedFunctionToolCall(
+                                        arguments="",
+                                        call_id=state["call_id"],
+                                        name=item_name,
+                                        namespace=namespace,
+                                        type="function_call",
+                                        id=state["item_id"],
+                                        status="in_progress",
+                                    )
+                                    added_event_cls = (
+                                        ResponseNamespacedOutputItemAddedEvent
+                                    )
+                                else:
+                                    added_item = ResponseFunctionToolCall(
+                                        arguments="",
+                                        call_id=state["call_id"],
+                                        name=item_name,
+                                        type="function_call",
+                                        id=state["item_id"],
+                                        status="in_progress",
+                                    )
+                                    added_event_cls = openai_responses_types.ResponseOutputItemAddedEvent
                             yield _send_event(
-                                openai_responses_types.ResponseOutputItemAddedEvent(
+                                added_event_cls(
                                     type="response.output_item.added",
                                     sequence_number=-1,
                                     output_index=state["output_index"],

--- a/test/registered/unit/entrypoints/openai/test_responses_custom_tools.py
+++ b/test/registered/unit/entrypoints/openai/test_responses_custom_tools.py
@@ -11,7 +11,10 @@ from utils import (
     make_serving,
 )
 
-from sglang.srt.entrypoints.openai.protocol import ResponsesRequest
+from sglang.srt.entrypoints.openai.protocol import (
+    ResponsesRequest,
+    ResponsesResponse,
+)
 from sglang.srt.entrypoints.openai.responses_adapters import (
     decode_custom_tool_input,
     decode_custom_tool_input_prefix,
@@ -19,6 +22,7 @@ from sglang.srt.entrypoints.openai.responses_adapters import (
     encode_custom_tool_input,
     encode_reasoning_state,
     label_developer_content,
+    split_namespaced_call,
 )
 from sglang.srt.entrypoints.openai.serving_responses import OpenAIServingResponses
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -436,6 +440,214 @@ class ModelValidationTestCase(CustomTestCase):
         self.assertIsNone(serving._validate_model(None))
         self.assertIsNone(serving._validate_model("x"))
         self.assertIsNone(serving._validate_model("x:my-adapter"))
+
+
+NAMESPACE_TOOL = {
+    "type": "namespace",
+    "name": "weather",
+    "description": "Weather services.",
+    "tools": [
+        {"name": "lookup", "parameters": {"type": "object"}},
+        {"name": "wait", "strict": True},
+    ],
+}
+
+
+def _namespace_request(**kwargs) -> ResponsesRequest:
+    payload = {
+        "model": "x",
+        "input": "weather in Paris",
+        "tools": [NAMESPACE_TOOL],
+        "tool_choice": "required",
+        "store": False,
+    }
+    payload.update(kwargs)
+    return ResponsesRequest(**payload)
+
+
+class NamespaceDeclarationTestCase(CustomTestCase):
+    def test_members_flatten_to_qualified_function_tools(self):
+        # Pre-namespace support the declaration passed validation and was
+        # silently dropped, so the model never saw a callable and never
+        # called it.
+        request = _namespace_request(tool_choice="auto")
+        tools = OpenAIServingResponses._response_tools_to_chat_tools(request)
+        self.assertEqual(
+            [t.function.name for t in tools], ["weather.lookup", "weather.wait"]
+        )
+        # Inner description wins; the namespace description fills members
+        # that omit one; strict flags survive the flattening.
+        self.assertEqual(tools[0].function.description, "Weather services.")
+        self.assertEqual(tools[0].function.parameters, {"type": "object"})
+        self.assertTrue(tools[1].function.strict)
+
+    def test_only_declared_namespaces_split_on_call(self):
+        # An exact declaration outranks a prefix split, so a plain function
+        # whose name contains a dot is never reinterpreted; undeclared
+        # dotted names pass through unchanged.
+        request = _namespace_request(
+            tool_choice="auto",
+            tools=[NAMESPACE_TOOL, {"type": "function", "name": "weather.lookup"}],
+        )
+        OpenAIServingResponses._response_tools_to_chat_tools(request)
+        declared = {"weather.lookup"}
+        self.assertEqual(
+            split_namespaced_call("weather.lookup", {"weather"}, declared),
+            ("weather.lookup", None),
+        )
+        self.assertEqual(
+            split_namespaced_call("weather.wait", {"weather"}, declared),
+            ("wait", "weather"),
+        )
+        self.assertEqual(
+            split_namespaced_call("unrelated.dot", {"weather"}, declared),
+            ("unrelated.dot", None),
+        )
+
+
+class NamespaceReplayTestCase(CustomTestCase):
+    def test_namespaced_function_call_replay_requalifies(self):
+        # The chat template must see the flattened name the model was shown
+        # at declaration time, or the replayed turn is unrecognizable.
+        serving = make_serving()
+        message = serving._normalize_response_message_for_chat(
+            {
+                "type": "function_call",
+                "call_id": "c1",
+                "name": "lookup",
+                "namespace": "weather",
+                "arguments": "{}",
+            }
+        )
+        self.assertEqual(message["tool_calls"][0]["function"]["name"], "weather.lookup")
+
+
+class NamespaceOutputTestCase(CustomTestCase):
+    def setUp(self):
+        self.serving = make_serving()
+        self.serving.reasoning_parser = None
+        self.serving.tool_call_parser = None
+
+    def test_required_call_splits_name_and_namespace(self):
+        request = _namespace_request()
+        output = self.serving._make_response_output_items(
+            request,
+            '[{"name": "weather.lookup", "parameters": {"city": "SF"}}]',
+            tokenizer=Mock(),
+            require_reasoning=False,
+        )
+        item = output[0].model_dump()
+        self.assertEqual(item["type"], "function_call")
+        self.assertEqual(item["name"], "lookup")
+        self.assertEqual(item["namespace"], "weather")
+
+    def test_namespaced_item_survives_response_serialization(self):
+        # The SDK unions type ``output`` through ``ResponseFunctionToolCall``,
+        # which serializes a subclass instance without ``namespace`` unless
+        # the widened arm leads; a response echoing a namespaced call must
+        # keep the field.
+        item = self.serving._make_tool_call_item(
+            "weather.lookup",
+            "{}",
+            custom_names=frozenset(),
+            namespaces={"weather"},
+            declared_names=frozenset(),
+        )
+        response = ResponsesResponse(model="x", status="completed", output=[item])
+        self.assertEqual(response.model_dump()["output"][0]["namespace"], "weather")
+
+
+class NamespaceStreamTestCase(CustomTestCase):
+    def setUp(self):
+        self.serving = make_serving()
+        self.serving.reasoning_parser = None
+        self.serving.tool_call_parser = None
+
+    def test_added_and_done_items_split_the_qualified_name(self):
+        request = _namespace_request(stream=True)
+        payload = '[{"name": "weather.lookup", "parameters": {"city": "SF"}}]'
+        chunks = []
+        sent = 0
+        while sent < len(payload):
+            sent += min(9, len(payload) - sent)
+            chunks.append(
+                engine_chunk(payload[:sent], sent, finish=sent == len(payload))
+            )
+        events = StreamFixture(self.serving, request).run(chunks)
+        types = event_types(events)
+        payloads = event_payloads(events)
+
+        self.assertIn("response.function_call_arguments.delta", types)
+        added = [
+            p for t, p in zip(types, payloads) if t == "response.output_item.added"
+        ]
+        self.assertEqual(added[0]["item"]["name"], "lookup")
+        self.assertEqual(added[0]["item"]["namespace"], "weather")
+        done = [p for t, p in zip(types, payloads) if t == "response.output_item.done"]
+        self.assertEqual(done[0]["item"]["namespace"], "weather")
+        completed = find_completed_event(events)["response"]
+        self.assertEqual(completed["output"][0]["namespace"], "weather")
+
+
+class NamespaceHarmonyTestCase(CustomTestCase):
+    def setUp(self):
+        self.serving = make_serving()
+        self.serving.use_harmony = True
+
+    def test_developer_message_renders_flattened_members(self):
+        from sglang.srt.entrypoints.harmony_utils import get_developer_message
+        from sglang.srt.entrypoints.openai.protocol import ResponseTool
+
+        tools = [ResponseTool.model_validate(NAMESPACE_TOOL)]
+        dev_msg = get_developer_message("be helpful", tools)
+        rendered = str(dev_msg.to_dict())
+        for name in ("weather.lookup", "weather.wait"):
+            self.assertIn(name, rendered)
+
+    def test_output_items_split_the_qualified_name(self):
+        from openai_harmony import Message, Role
+
+        from sglang.srt.entrypoints.context import HarmonyContext
+
+        request = _namespace_request(tool_choice="auto")
+        namespaces = {"weather"}
+        declared = frozenset()
+        calls = [
+            Message.from_role_and_content(Role.ASSISTANT, '{"city": "SF"}')
+            .with_channel("commentary")
+            .with_recipient("functions.weather.lookup")
+            .with_content_type("json"),
+            Message.from_role_and_content(Role.ASSISTANT, "{}")
+            .with_channel("commentary")
+            .with_recipient("functions.unrelated.name")
+            .with_content_type("json"),
+        ]
+        context = HarmonyContext(calls, {})
+        context.num_init_messages = 0
+        output = self.serving._make_response_output_items_with_harmony(
+            context, namespaces, declared
+        )
+
+        namespaced = output[0].model_dump()
+        self.assertEqual(namespaced["name"], "lookup")
+        self.assertEqual(namespaced["namespace"], "weather")
+        # An undeclared dotted recipient keeps its full name unsplit.
+        self.assertEqual(output[1].name, "unrelated.name")
+
+    def test_namespaced_replay_requalifies_the_recipient(self):
+        from sglang.srt.entrypoints.harmony_utils import parse_response_input
+
+        msg = parse_response_input(
+            {
+                "type": "function_call",
+                "call_id": "c1",
+                "name": "lookup",
+                "namespace": "weather",
+                "arguments": "{}",
+            },
+            [],
+        )
+        self.assertEqual(msg.recipient, "functions.weather.lookup")
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -1060,7 +1060,6 @@ class HarmonyResponsesTestCase(CustomTestCase):
                 parameters={"type": "object"},
             ),
             ResponseTool(type="web_search"),
-            ResponseTool(type="namespace", name="codex"),
             ResponseTool(type="mcp"),
         ]
         msg = get_developer_message(instructions="be helpful", tools=tools)


### PR DESCRIPTION
## Motivation

A `namespace` tool declaration groups inner function schemas — Codex sends its multi-agent tool families exactly this way (`ProviderCapabilities::namespace_tools` defaults to `true`, so custom providers receive them un-flattened). `/v1/responses` accepts the declaration but nothing executes it:

- The inner functions never reach the chat tools the model sees, so the model never calls them — the same silent drop `custom` tools had before #38690.
- A replayed `function_call` carrying a `namespace` field loses its qualification, breaking stateless tool loops.

This is the namespace half of #35216. The custom-tool half landed on main via #38690; this PR builds directly on that work (same `responses_adapters.py` module, same patterns) so the two read as one coherent story. Scope relative to #38359 (also namespace-only, open): same wire contract, plus harmony-path support, the streaming `added/done` split, and the pydantic union serialization that otherwise silently drops `namespace`.

## Modifications

All changes are stateless HTTP-serving-layer translation; no tokenizer, template, engine, or scheduler changes. Namespace helpers join `responses_adapters.py` next to the custom-tool ones:

- **Declaration flattening** — each member becomes a `{namespace}.{name}` chat function (inner schema/description/strict preserved; the namespace description fills members that omit one). Shared by the chat path, the harmony developer message, and (via `namespace_members_to_chat_tools`) future callers.
- **Output split** — every emission path maps the qualified name back to `name` + `namespace` on the item: non-streaming, the required-JSON fallback, and the streaming `output_item.added` / `.done` events.
- **Replay** — a replayed `function_call` with `name` + `namespace` re-qualifies to the flattened name for the chat template, and the harmony recipient likewise. Only *declared* namespace prefixes split; an exact declaration outranks the split, so a plain function whose name contains a dot is never reinterpreted.
- **Serialization** — namespaced calls travel through widened pydantic unions (`ResponseNamespacedFunctionToolCall`, matching `output_item.added/done` event subclasses, and the `ResponsesResponse.output` union). Without the widened arm leading, the SDK's `ResponseFunctionToolCall` arm serializes the subclass instance and silently drops `namespace` — a trap any subclass-based approach hits.
- **tool_choice** — `"required"` accepts namespace declarations, and a `namespace` field on a named choice re-qualifies it to the flattened name instead of degrading to `"auto"`.

## Accuracy Tests

No kernel or model-forward changes; wire behavior only. Namespace cases join the existing custom-tools suite (`test/registered/unit/entrypoints/openai/test_responses_custom_tools.py`, registered in `base-a-test-cpu`):

```
cd test/registered/unit/entrypoints/openai
python3 test_responses_custom_tools.py       # 29 cases (12 new namespace cases)
python3 test_serving_responses.py            # 43 cases
python3 test_serving_responses_stream.py     # 9 cases
python3 test_responses_protocol.py           # 22 cases
```

All four green on this branch. **Regression verification:** with the source changes stashed (pre-fix main), the suite goes red at import (`cannot import name 'split_namespaced_call'`); each namespace guard targets a distinct failure mode (declaration drop, split precedence, replay re-qualification, output emission, streaming wire events, union serialization, harmony rendering).

Live verification against real servers is recorded in the comments below: pre-fix stock sglang 0.5.19 (declaration accepted, inner tools never reachable), and the same release with this PR's files overlaid (qualified calls split correctly on a live Qwen3-1.7B). The overlay there predates this rebase onto #38690; happy to re-run the record against this exact head on request.

## Speed Tests and Profiling

Not applicable — no inference-path changes. Runtime cost is one pass over `request.tools` per request and a set lookup per parsed call.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). — ruff (`F401/F821/UP037`), ruff-format, isort, and codespell pass on the changed files; `git diff --check` clean.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — 12 new namespace cases registered in the existing `base-a-test-cpu` suite file; every guard verified red against pre-fix main.
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — No docs change: the Responses API docs do not enumerate supported tool types today (this matches #38690's posture).
- [x] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — N/A: protocol translation only, covered by unit tests and the live wire checks in comments.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). — Namespace helpers are pure functions in the shared adapters module next to their custom-tool siblings; no new state, no function over ~60 LOC.

**Note for reviewers**: the head branch moved from `fix/responses-custom-namespace-tools` to `fix/responses-namespace-tools` (rebased onto main after #38690 landed) — the comment history below, including the live verification records, refers to that earlier iteration which covered custom + namespace together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34702424926](https://github.com/sgl-project/sglang/actions/runs/34702424926)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34702424700](https://github.com/sgl-project/sglang/actions/runs/34702424700)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34702424829](https://github.com/sgl-project/sglang/actions/runs/34702424829)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->