### PR TITLE
Expose a capacity check for graph-pool borrows

### DIFF
--- a/python/sglang/srt/model_executor/runner_utils/pool.py
+++ b/python/sglang/srt/model_executor/runner_utils/pool.py
@@ -288,6 +288,16 @@ _PRECARVE_SMALL_RESERVE_BYTES = 32 << 20
 _PRECARVE_GRANULARITY = 2 << 20
 
 
+def graph_pool_borrow_can_fit(nbytes: int) -> bool:
+    """Whether one free run fits the payload plus allocator padding and reserve."""
+    if nbytes <= 0:
+        return False
+    required = (
+        nbytes + _PRECARVE_GRANULARITY - 1
+    ) // _PRECARVE_GRANULARITY * _PRECARVE_GRANULARITY + _PRECARVE_SMALL_RESERVE_BYTES
+    return graph_pool_borrow_largest_run() >= required
+
+
 def _precarve_run_segments(runs: list[tuple[int, int]]) -> None:
     """Seed coalescible segments on the stream that will allocate borrows."""
     for _, run_bytes in runs:

--- a/test/registered/unit/model_executor/runner_utils/test_graph_pool_borrow.py
+++ b/test/registered/unit/model_executor/runner_utils/test_graph_pool_borrow.py
@@ -76,6 +76,25 @@ class TestGraphPoolBorrow(CustomTestCase):
             self.assertEqual(pool.graph_pool_borrow_largest_run(), 0)
             self.assertEqual(snapshot.call_count, 3)
 
+    def test_borrow_capacity_includes_rounding_and_small_pool_reserve(self):
+        for payload, largest_run, expected in (
+            (-1, 64 << 20, False),
+            (0, 64 << 20, False),
+            (1, 0, False),
+            (1, 32 << 20, False),
+            (1, 34 << 20, True),
+            (2 << 20, 34 << 20, True),
+            ((2 << 20) + 1, 34 << 20, False),
+            ((2 << 20) + 1, 36 << 20, True),
+        ):
+            with (
+                self.subTest(payload=payload, largest_run=largest_run),
+                patch.object(
+                    pool, "graph_pool_borrow_largest_run", return_value=largest_run
+                ),
+            ):
+                self.assertEqual(pool.graph_pool_borrow_can_fit(payload), expected)
+
     def test_graph_replay_fails_during_active_pool_borrow(self):
         graph = Mock()
         backend = object.__new__(FullCudaGraphBackend)


### PR DESCRIPTION
**Problem:** Total free graph memory does not tell a caller whether one temporary allocation fits.

**Fix:** Add `graph_pool_borrow_can_fit(nbytes)`, using the largest free run with allocator rounding and small-pool reserve. Nonpositive sizes return false.

**Tested:** GB300, PyTorch 2.11 / CUDA 13.0. All applicable pre-commit checks pass.

<details>
<summary>Command and real test output</summary>

```text
python -m pytest -q test/registered/unit/model_executor/runner_utils/test_graph_pool_borrow.py
16 passed, 21 warnings, 12 subtests passed in 14.59s
```

</details>

Full model-serving and throughput benchmarks were not run.

**Dependency:** Depends on https://github.com/sgl-project/sglang/pull/39177; branch is based on `oss/graph-pool-borrow-state` at `3d428dbcae`. Targets `main`, so the PR diff includes its parents until they merge. [This change only](https://github.com/cctry/sglang/commit/a6d0236e39cd09cdd3cc3ec5a875a6eff89eef2f).

## Original commits

- `3ec127e5c08f5c2ef95625a9908e40344ed1c069`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34721898265](https://github.com/sgl-project/sglang/actions/runs/34721898265)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34721898199](https://github.com/sgl-project/sglang/actions/runs/34721898199)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34721898241](https://github.com/sgl-project/sglang/actions/runs/34721898241)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->