### PR TITLE
[CUDA Graph] Own and bound graph-pool borrowing

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1107,9 +1107,15 @@ class Scheduler(
         self.init_all_cuda_graphs()
 
         model_runner = self.tp_worker.model_runner
-        with torch.get_device_module(model_runner.device).stream(
+        device_module = torch.get_device_module(model_runner.device)
+        self.schedule_stream = None if use_mlx() else device_module.Stream(priority=0)
+        # Match run_batch / _pp_launch_batch so warmup allocations stay reusable.
+        forward_stream = (
             model_runner.forward_stream
-        ):
+            if self.enable_overlap or self.ps.pp_size > 1 or use_mlx()
+            else self.schedule_stream
+        )
+        with device_module.stream(forward_stream):
             if self.draft_worker is None:
                 model_runner.prewarm_sampling()
             else:
@@ -1847,7 +1853,6 @@ class Scheduler(
     def run_event_loop(self) -> None:
         """Run the scheduler's event loop.
 
-        Sets up the schedule stream and dispatches to the appropriate event loop.
         The event loop blocks until shutdown.
         """
         # Engine init (graph capture, warmups) is done; from here on any
@@ -1862,10 +1867,9 @@ class Scheduler(
             dispatch_event_loop(self)
             return
 
-        self.schedule_stream = self.device_module.Stream(priority=0)
         if self.device == "cpu":
             self.schedule_stream.synchronize = lambda: None  # No-op for CPU
-        elif is_cuda() or _is_hip:
+        elif (is_cuda() or _is_hip) and (self.enable_overlap or self.ps.pp_size > 1):
             # CUDA/HIP streams come from a fixed round-robin pool. Redraw if this
             # stream aliases forward_stream, which would eliminate scheduler
             # overlap. Only CUDA/HIP streams expose a ``cuda_stream`` handle;

--- a/python/sglang/srt/model_executor/runner_utils/pool.py
+++ b/python/sglang/srt/model_executor/runner_utils/pool.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
+from dataclasses import dataclass, field
+from functools import cache
 from typing import Any, Iterator, Optional
 
 import torch
@@ -31,21 +33,51 @@ from sglang.srt.utils import is_cuda
 from sglang.srt.utils.cuda_vmm_utils import BumpArenaStub
 
 logger = logging.getLogger(__name__)
-_active_graph_pool_user: Optional[str] = None
-_borrow_stub: Optional[BumpArenaStub] = None
-_borrow_mem_pool: Optional[torch.cuda.MemPool] = None
-_borrow_disabled_reason: Optional[str] = None
-_borrow_static_runs: Optional[list[tuple[int, int]]] = None
-_borrow_extents_total = 0
-_largest_logged_graph_pool_borrow = 0
 
+_MIB = 1 << 20
 _CAPTURE_STREAM_NAME = "cuda_graph_capture"
+
+
+@dataclass(eq=False)
+class GraphPoolBorrowState:
+    """Mutable borrowing state and free-run cache for one runtime."""
+
+    active_user: Optional[str] = None
+    stub: Optional[BumpArenaStub] = None
+    mem_pool: Optional[torch.cuda.MemPool] = None
+    stream: Optional[torch.cuda.Stream] = None
+    disabled_reason: Optional[str] = None
+    static_runs: Optional[list[tuple[int, int]]] = None
+    check_pending: bool = False
+    extents_total: int = 0
+    largest_logged_borrow: int = 0
+    snapshot_free_runs: Any = field(
+        default_factory=lambda: cache(find_free_graph_pool_runs), init=False, repr=False
+    )
+
+
+def _get_graph_pool_borrow_state() -> GraphPoolBorrowState:
+    resources = get_resources()
+    if resources.graph_pool_borrow is None:
+        resources.graph_pool_borrow = GraphPoolBorrowState()
+    return resources.graph_pool_borrow
+
+
+def _log_graph_pool_borrow_capacity(runs: list[tuple[int, int]]) -> None:
+    total_bytes = sum(nbytes for _, nbytes in runs)
+    largest_bytes = max((nbytes for _, nbytes in runs), default=0)
+    logger.info(
+        "Graph pool borrow capacity: %.1f MiB available, largest contiguous "
+        "region %.1f MiB, %d regions",
+        total_bytes / _MIB,
+        largest_bytes / _MIB,
+        len(runs),
+    )
 
 
 def disable_graph_pool_borrow(reason: str) -> None:
     """Disable borrowing when graph storage is managed outside the shared pool."""
-    global _borrow_disabled_reason
-    _borrow_disabled_reason = reason
+    _get_graph_pool_borrow_state().disabled_reason = reason
     _teardown_borrow_pool()
     logger.info("Graph pool borrow disabled: %s", reason)
 
@@ -57,17 +89,13 @@ def set_graph_pool_borrow_runs(runs: list[tuple[int, int]]) -> None:
     remain stable for the process lifetime. Registering an empty list disables
     borrowing.
     """
-    global _borrow_static_runs
+    state = _get_graph_pool_borrow_state()
     static_runs = sorted(runs, key=lambda run: run[1], reverse=True)[
         : BumpArenaStub.MAX_EXTENTS
     ]
     _teardown_borrow_pool()
-    _borrow_static_runs = static_runs
-    logger.info(
-        "Graph pool borrow runs pinned: runs=%d free=%d",
-        len(_borrow_static_runs),
-        sum(nbytes for _, nbytes in _borrow_static_runs),
-    )
+    state.static_runs = static_runs
+    _log_graph_pool_borrow_capacity(state.static_runs)
 
 
 def get_global_graph_memory_pool() -> Optional[Any]:
@@ -134,31 +162,32 @@ class GraphPoolPrecarve:
 
 
 def graph_pool_borrow_enabled() -> bool:
+    state = _get_graph_pool_borrow_state()
     if (
-        _borrow_disabled_reason is not None
+        state.disabled_reason is not None
         or not envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.get()
         or not is_cuda()
     ):
         return False
-    if _borrow_static_runs is not None:
-        return len(_borrow_static_runs) > 0
+    if state.static_runs is not None:
+        return len(state.static_runs) > 0
     return get_global_graph_memory_pool() is not None
 
 
 @contextmanager
 def graph_pool_user_scope(user: str) -> Iterator[None]:
-    global _active_graph_pool_user
+    state = _get_graph_pool_borrow_state()
     # Graph replay silently overwrites aliases of its allocator-free blocks.
-    if _active_graph_pool_user is not None:
+    if state.active_user is not None:
         raise RuntimeError(
-            f"graph pool already has live user {_active_graph_pool_user!r}; "
+            f"graph pool already has live user {state.active_user!r}; "
             f"cannot use it for {user!r}"
         )
-    _active_graph_pool_user = user
+    state.active_user = user
     try:
         yield
     finally:
-        _active_graph_pool_user = None
+        state.active_user = None
 
 
 @contextmanager
@@ -167,6 +196,8 @@ def graph_pool_replay_scope() -> Iterator[None]:
         yield
         return
     with graph_pool_user_scope("CUDA graph"):
+        if _get_graph_pool_borrow_state().check_pending:
+            _raise_on_live_borrows("graph replay")
         yield
 
 
@@ -205,68 +236,146 @@ def find_free_graph_pool_runs(pool_id: Any) -> list[tuple[int, int]]:
     return runs
 
 
+def graph_pool_borrow_largest_run() -> int:
+    """Largest contiguous free extent a single borrow can occupy, in bytes."""
+    if not graph_pool_borrow_enabled():
+        return 0
+    state = _get_graph_pool_borrow_state()
+    if state.static_runs is not None:
+        return state.static_runs[0][1]
+    runs = state.snapshot_free_runs(get_global_graph_memory_pool())
+    return runs[0][1] if runs else 0
+
+
+def _raise_on_live_borrows(event: str) -> None:
+    """Reject borrows that graph replay or pool teardown would overwrite."""
+    state = _get_graph_pool_borrow_state()
+    state.check_pending = False
+    if state.mem_pool is None:
+        return
+    live = sum(
+        block["size"]
+        for segment in torch.cuda.memory_snapshot(
+            state.mem_pool.id, include_traces=False
+        )
+        for block in segment["blocks"]
+        if block["state"] == "active_allocated"
+    )
+    if live:
+        raise RuntimeError(
+            f"Graph-pool borrow leak at {event}: {live} bytes still referenced"
+        )
+
+
 def _teardown_borrow_pool() -> None:
     """Retire the persistent borrow pool after draining deferred frees."""
-    global _borrow_mem_pool
-    if _borrow_mem_pool is None:
+    state = _get_graph_pool_borrow_state()
+    state.snapshot_free_runs.cache_clear()
+    if state.mem_pool is None:
         return
+    if state.check_pending:
+        _raise_on_live_borrows("borrow pool teardown")
     # Borrowed blocks that saw cross-stream use can remain in event limbo.
     # Synchronize, then drive allocator event processing before dropping the pool.
     torch.cuda.synchronize()
     torch.empty(1, device="cuda")
-    _borrow_mem_pool = None
+    state.mem_pool = None
+    state.stream = None
+
+
+_PRECARVE_MIN_RUN_BYTES = 64 << 20
+# Left uncarved per run so 2 MiB small-pool segments keep a home.
+_PRECARVE_SMALL_RESERVE_BYTES = 32 << 20
+# The caching allocator rounds large segment requests up to 2 MiB.
+_PRECARVE_GRANULARITY = 2 << 20
+
+
+def graph_pool_borrow_can_fit(nbytes: int) -> bool:
+    """Whether one free run fits the payload plus allocator padding and reserve."""
+    if nbytes <= 0:
+        return False
+    required = (
+        nbytes + _PRECARVE_GRANULARITY - 1
+    ) // _PRECARVE_GRANULARITY * _PRECARVE_GRANULARITY + _PRECARVE_SMALL_RESERVE_BYTES
+    return graph_pool_borrow_largest_run() >= required
+
+
+def _precarve_run_segments(runs: list[tuple[int, int]]) -> None:
+    """Seed coalescible segments on the stream that will allocate borrows."""
+    for _, run_bytes in runs:
+        seed = (
+            (run_bytes - _PRECARVE_SMALL_RESERVE_BYTES) // _PRECARVE_GRANULARITY
+        ) * _PRECARVE_GRANULARITY
+        if seed >= _PRECARVE_MIN_RUN_BYTES:
+            torch.empty(seed, dtype=torch.uint8, device="cuda")
 
 
 @contextmanager
 def borrow_graph_pool(user: str) -> Iterator[None]:
     """Route this thread's torch allocations onto the graph pool's free runs.
 
-    Tensors allocated inside must not survive the current step: the next graph
-    replay may overwrite their bytes. An allocation no run can hold raises the
+    All borrows must use the stream that first creates the borrow pool, so
+    the caching allocator can reuse its pre-carved segments.
+    Tensors allocated inside must be released before the next graph replay,
+    which rewrites their bytes; the next replay (or pool teardown) raises if
+    any are still referenced. An allocation no run can hold raises the
     allocator's normal OOM. This is a no-op while borrowing is disabled.
     """
-    global _borrow_stub, _borrow_mem_pool, _borrow_extents_total
-    global _largest_logged_graph_pool_borrow
+    state = _get_graph_pool_borrow_state()
     if not graph_pool_borrow_enabled():
         yield
         return
     with graph_pool_user_scope(user):
-        if _borrow_mem_pool is not None:
+        stream = torch.cuda.current_stream()
+        if state.mem_pool is not None:
+            if stream != state.stream:
+                raise RuntimeError(
+                    "Graph-pool borrow must use the stream that created the borrow pool: "
+                    f"expected {state.stream}, got {stream}"
+                )
             # Return completed cross-stream frees to the cache. The allocator
             # processes their events on a later allocation.
             torch.empty(1, device="cuda")
-            if _borrow_stub.freed_bytes:
-                # Rebuild if the caching allocator released an arena segment.
-                # A high cursor alone means the cache owns reusable segments;
-                # rebuilding discards them and can turn the next large borrow
-                # into a fragmented cold-allocation OOM.
+            if state.stub.freed_bytes:
+                # The bump arena cannot reuse segments returned by empty_cache().
                 _teardown_borrow_pool()
-        if _borrow_mem_pool is None:
-            if _borrow_stub is None:
-                _borrow_stub = BumpArenaStub()
+        if state.mem_pool is None:
+            if state.stub is None:
+                state.stub = BumpArenaStub()
                 # Runs are sorted largest first, so first fit would carve every
                 # small allocation out of the run a probability matrix needs.
-                _borrow_stub.set_best_fit(True)
-            if _borrow_static_runs is not None:
-                runs = _borrow_static_runs
+                state.stub.set_best_fit(True)
+            if state.static_runs is not None:
+                runs = state.static_runs
             else:
-                runs = find_free_graph_pool_runs(get_global_graph_memory_pool())[
+                runs = state.snapshot_free_runs(get_global_graph_memory_pool())[
                     : BumpArenaStub.MAX_EXTENTS
                 ]
-            _borrow_stub.set_extents(runs)
+            state.stub.set_extents(runs)
             # Keep one caching layer across borrows so normal block reuse and
             # stream-ordered deferred frees remain allocator-managed. Capture
             # retires it because capture changes the underlying free extents.
-            _borrow_mem_pool = torch.cuda.MemPool(_borrow_stub.allocator)
-            _borrow_extents_total = sum(run_bytes for _, run_bytes in runs)
+            state.mem_pool = torch.cuda.MemPool(state.stub.allocator)
+            state.stream = stream
+            with torch.cuda.use_mem_pool(state.mem_pool):
+                _precarve_run_segments(runs)
+            # Only growth beyond the precarve is worth another log line.
+            state.largest_logged_borrow = state.stub.cursor_bytes
+            state.extents_total = sum(run_bytes for _, run_bytes in runs)
+            _log_graph_pool_borrow_capacity(runs)
             logger.info(
-                "Graph pool borrow extents: runs=%d free=%d",
-                len(runs),
-                _borrow_extents_total,
+                "Graph pool borrow pre-carved: %.1f MiB",
+                state.stub.cursor_bytes / _MIB,
             )
-        with torch.cuda.use_mem_pool(_borrow_mem_pool):
+        with torch.cuda.use_mem_pool(state.mem_pool):
             yield
-        consumed = _borrow_stub.cursor_bytes
-        if consumed > _largest_logged_graph_pool_borrow:
-            logger.info("Graph pool borrow: consumed=%d", consumed)
-            _largest_logged_graph_pool_borrow = consumed
+        state.check_pending = True
+        consumed = state.stub.cursor_bytes
+        if consumed > state.largest_logged_borrow:
+            logger.info(
+                "Graph pool borrow high-water mark: %.1f MiB used of %.1f MiB "
+                "available",
+                consumed / _MIB,
+                state.extents_total / _MIB,
+            )
+            state.largest_logged_borrow = consumed

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -58,6 +58,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 import msgspec
 
 if TYPE_CHECKING:
+    from sglang.srt.model_executor.runner_utils.pool import GraphPoolBorrowState
     from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
@@ -607,6 +608,7 @@ class Resources(_FlagGroupBase):
     # CUDA graph memory pool shared across the prefill and decode graph
     # backends (created lazily by model_executor.runner_utils.pool).
     graph_memory_pool: Any = None
+    graph_pool_borrow: GraphPoolBorrowState | None = None
     # EPLB: per-process recorder and the publish-once location metadata
     # (owning accessors live in sglang.srt.eplb).
     expert_distribution_recorder: Any = None

--- a/test/registered/unit/model_executor/model_runner_components/test_startup_weight_load.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_startup_weight_load.py
@@ -17,6 +17,7 @@ maybe_stub_sgl_kernel()
 from sglang.srt.configs.device_config import DeviceConfig
 from sglang.srt.configs.load_config import LoadConfig, LoadFormat
 from sglang.srt.configs.model_config import ModelImpl
+from sglang.srt.managers.scheduler import Scheduler
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.model_executor.cuda_graph_config import Backend, CudaGraphConfig
 from sglang.srt.model_executor.model_runner import ModelRunner
@@ -728,9 +729,9 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
         reset_context()
         self.addCleanup(reset_context)
 
-    def _scheduler(self, worker, trace, *, mode, draft_worker=None):
-        from sglang.srt.managers.scheduler import Scheduler
-
+    def _scheduler(
+        self, worker, trace, *, mode, draft_worker=None, enable_overlap=True, pp_size=1
+    ):
         # The schedule reads the mode from the bags, so the test states it by
         # publishing a record rather than by standing one in.
         reset_context()
@@ -739,6 +740,8 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
             role="scheduler",
         )
         scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_overlap = enable_overlap
+        scheduler.ps = SimpleNamespace(pp_size=pp_size)
         scheduler.init_tp_model_worker = lambda: setattr(scheduler, "tp_worker", worker)
         scheduler.maybe_init_draft_worker = lambda: setattr(
             scheduler, "draft_worker", draft_worker
@@ -748,7 +751,9 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
         scheduler.init_all_cuda_graphs = lambda: trace.append("capture")
         return scheduler
 
-    def _run_startup(self, mode, *, use_draft_worker=False):
+    def _run_startup(
+        self, mode, *, use_draft_worker=False, enable_overlap=True, pp_size=1
+    ):
         trace = []
         worker = _SchedulerWorker(trace, post_capture_active=True)
         draft_worker = (
@@ -764,6 +769,8 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
             trace,
             mode=mode,
             draft_worker=draft_worker,
+            enable_overlap=enable_overlap,
+            pp_size=pp_size,
         )
 
         class StreamContext:
@@ -773,8 +780,15 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
             def __exit__(self, *_args):
                 trace.append("stream_exit")
 
+        schedule_stream = object()
+
         def stream_context(stream):
-            self.assertIs(stream, worker.model_runner.forward_stream)
+            expected_stream = (
+                worker.model_runner.forward_stream
+                if enable_overlap or pp_size > 1
+                else schedule_stream
+            )
+            self.assertIs(stream, expected_stream)
             return StreamContext()
 
         def stop_after_startup():
@@ -794,7 +808,9 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
             ),
             patch(
                 "sglang.srt.managers.scheduler.torch.get_device_module",
-                return_value=SimpleNamespace(stream=stream_context),
+                return_value=SimpleNamespace(
+                    stream=stream_context, Stream=lambda priority: schedule_stream
+                ),
             ),
             self.assertRaisesRegex(RuntimeError, "stop after startup"),
         ):
@@ -804,6 +820,13 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
             draft_runners=(worker.model_runner,) if use_draft_worker else ()
         )
         return trace
+
+    def test_warmup_stream_matches_batch_execution(self):
+        for enable_overlap, pp_size in ((False, 1), (True, 1), (False, 2)):
+            with self.subTest(enable_overlap=enable_overlap, pp_size=pp_size):
+                self._run_startup(
+                    "serial", enable_overlap=enable_overlap, pp_size=pp_size
+                )
 
     def test_serial_path_skips_overlap_hooks(self):
         self.assertEqual(

--- a/test/registered/unit/model_executor/runner_utils/test_graph_pool_borrow.py
+++ b/test/registered/unit/model_executor/runner_utils/test_graph_pool_borrow.py
@@ -17,32 +17,20 @@ from sglang.srt.speculative.dflash_worker_v2 import DFlashWorkerV2
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=13, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-small")
 
 
 class TestGraphPoolBorrow(CustomTestCase):
     def setUp(self):
         super().setUp()
-        self._reset_borrow_state()
+        self.state = pool.GraphPoolBorrowState()
+        self.enterContext(pool.get_resources().override(graph_pool_borrow=self.state))
 
     def tearDown(self):
-        try:
-            if torch.cuda.is_available():
-                pool._teardown_borrow_pool()
-                torch.cuda.synchronize()
-                torch.cuda.empty_cache()
-        finally:
-            self._reset_borrow_state()
-
-    @staticmethod
-    def _reset_borrow_state():
-        pool._active_graph_pool_user = None
-        pool._borrow_stub = None
-        pool._borrow_mem_pool = None
-        pool._borrow_disabled_reason = None
-        pool._borrow_static_runs = None
-        pool._borrow_extents_total = 0
-        pool._largest_logged_graph_pool_borrow = 0
+        if torch.cuda.is_available():
+            pool._teardown_borrow_pool()
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
 
     def test_mixed_segment_runs_exclude_live_blocks(self):
         """A mixed segment's free runs are borrowable, but a returned run must
@@ -63,6 +51,50 @@ class TestGraphPoolBorrow(CustomTestCase):
             runs = pool.find_free_graph_pool_runs((0, 1))
         self.assertEqual(sorted(runs), [(0x1000, 4096), (0x3000, 4096)])
 
+    def test_free_run_snapshot_lifetime_follows_borrow_state(self):
+        runs = [{"blocks": [{"state": "inactive", "address": 0x1000, "size": 8192}]}]
+        with (
+            envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
+            patch.object(pool, "is_cuda", return_value=True),
+            patch.object(pool, "get_global_graph_memory_pool", return_value=(1, 2)),
+            patch.object(
+                pool.torch.cuda, "memory_snapshot", side_effect=[runs, [], runs]
+            ) as snapshot,
+        ):
+            self.assertEqual(pool.graph_pool_borrow_largest_run(), 8192)
+            self.assertEqual(pool.graph_pool_borrow_largest_run(), 8192)
+            snapshot.assert_called_once_with((1, 2), include_traces=False)
+            pool._teardown_borrow_pool()
+            self.assertEqual(pool.graph_pool_borrow_largest_run(), 0)
+            self.assertEqual(snapshot.call_count, 2)
+            with pool.get_resources().override(graph_pool_borrow=None):
+                self.assertEqual(pool.graph_pool_borrow_largest_run(), 8192)
+            self.assertEqual(pool.graph_pool_borrow_largest_run(), 0)
+            self.assertEqual(snapshot.call_count, 3)
+
+    def test_borrow_capacity_requires_one_padded_extent(self):
+        mib = 1 << 20
+        with (
+            envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
+            patch.object(pool, "is_cuda", return_value=True),
+            patch.object(pool, "get_global_graph_memory_pool", return_value=None),
+        ):
+            pool.set_graph_pool_borrow_runs([(0x1000, 64 * mib), (0x5000, 64 * mib)])
+            for nbytes, expected in (
+                (-1, False),
+                (0, False),
+                (1, True),
+                (32 * mib, True),
+                (32 * mib + 1, False),
+                (64 * mib, False),
+            ):
+                with self.subTest(nbytes=nbytes):
+                    self.assertEqual(pool.graph_pool_borrow_can_fit(nbytes), expected)
+            with envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(False):
+                self.assertFalse(pool.graph_pool_borrow_can_fit(1))
+            pool.set_graph_pool_borrow_runs([])
+            self.assertFalse(pool.graph_pool_borrow_can_fit(1))
+
     def test_graph_replay_fails_during_active_pool_borrow(self):
         graph = Mock()
         backend = object.__new__(FullCudaGraphBackend)
@@ -78,12 +110,11 @@ class TestGraphPoolBorrow(CustomTestCase):
         with (
             envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
             patch.object(pool, "get_global_graph_memory_pool", return_value=(1, 2)),
-            patch.object(
-                pool, "_borrow_stub", MagicMock(cursor_bytes=0, freed_bytes=0)
-            ),
-            patch.object(pool, "_borrow_mem_pool", None),
+            patch.object(self.state, "stub", MagicMock(cursor_bytes=0, freed_bytes=0)),
+            patch.object(self.state, "mem_pool", None),
             patch.object(pool.torch.cuda, "MemPool"),
             patch.object(pool.torch.cuda, "use_mem_pool"),
+            patch.object(pool.torch.cuda, "current_stream"),
             patch.object(pool.torch.cuda, "memory_snapshot", return_value=snapshot),
             pool.borrow_graph_pool(user="test"),
         ):
@@ -97,15 +128,18 @@ class TestGraphPoolBorrow(CustomTestCase):
     def test_high_cursor_keeps_reusable_cached_segments(self):
         stub = MagicMock(cursor_bytes=600, freed_bytes=0)
         mem_pool = MagicMock()
+        stream = object()
 
         with (
             patch.object(pool, "graph_pool_borrow_enabled", return_value=True),
-            patch.object(pool, "_borrow_stub", stub),
-            patch.object(pool, "_borrow_mem_pool", mem_pool),
-            patch.object(pool, "_borrow_extents_total", 1000),
+            patch.object(self.state, "stub", stub),
+            patch.object(self.state, "mem_pool", mem_pool),
+            patch.object(self.state, "stream", stream),
+            patch.object(self.state, "extents_total", 1000),
             patch.object(pool, "_teardown_borrow_pool") as teardown,
             patch.object(pool.torch, "empty"),
             patch.object(pool.torch.cuda, "use_mem_pool"),
+            patch.object(pool.torch.cuda, "current_stream", return_value=stream),
         ):
             with pool.borrow_graph_pool(user="test"):
                 pass
@@ -126,7 +160,7 @@ class TestGraphPoolBorrow(CustomTestCase):
         runs = [(0x1000, 4096), (0x2000, 8192)]
 
         def reset_static_runs():
-            pool._borrow_static_runs = None
+            self.state.static_runs = None
 
         with patch.object(
             pool, "_teardown_borrow_pool", side_effect=reset_static_runs
@@ -134,7 +168,7 @@ class TestGraphPoolBorrow(CustomTestCase):
             pool.set_graph_pool_borrow_runs(runs)
 
         teardown.assert_called_once_with()
-        self.assertEqual(pool._borrow_static_runs, [(0x2000, 8192), (0x1000, 4096)])
+        self.assertEqual(self.state.static_runs, [(0x2000, 8192), (0x1000, 4096)])
 
     def test_eagle_non_greedy_probabilities_do_not_borrow_graph_pool(self):
         def fake_sampling(**kwargs):
@@ -221,7 +255,6 @@ class TestGraphPoolBorrow(CustomTestCase):
         with (
             envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
             patch.object(pool, "get_global_graph_memory_pool", return_value=handle),
-            patch.object(pool, "_borrow_mem_pool", None),
         ):
             runs = pool.find_free_graph_pool_runs(handle)
             self.assertGreaterEqual(len(runs), 2)
@@ -253,12 +286,118 @@ class TestGraphPoolBorrow(CustomTestCase):
                 self.assertEqual(c.data_ptr(), recycled_address)
                 del b, c
 
+            self.assertEqual(self.state.stream, torch.cuda.current_stream())
+            with (
+                torch.cuda.stream(stream),
+                self.assertRaisesRegex(
+                    RuntimeError, "stream that created the borrow pool"
+                ),
+            ):
+                with pool.borrow_graph_pool(user="wrong stream"):
+                    self.fail("cross-stream borrowing must fail before allocating")
+            self.assertIsNone(self.state.active_user)
+            with pool.borrow_graph_pool(user="same stream"):
+                reused = torch.empty(40 << 20, dtype=torch.uint8, device="cuda")
+                self.assertEqual(reused.data_ptr(), recycled_address)
+                del reused
+
             # Captures retire the persistent borrow pool. Its storage aliases
             # existing graph-pool runs, so the reserved footprint is unchanged.
             pool._teardown_borrow_pool()
+            self.assertIsNone(self.state.stream)
+            with torch.cuda.stream(stream), pool.borrow_graph_pool(user="new pool"):
+                self.assertEqual(self.state.stream, stream)
+                reused = torch.empty(40 << 20, dtype=torch.uint8, device="cuda")
+                self.assertTrue(on_a_run(reused))
+                del reused
+            pool._teardown_borrow_pool()
+            with pool.graph_pool_replay_scope():
+                graph.replay()
+            torch.cuda.synchronize()
+            self.assertTrue(torch.equal(y, torch.ones_like(y)))
 
         self.assertEqual(torch.cuda.memory_reserved(device_id), reserved_before)
         del graph, y
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_borrow_recovers_from_arena_fragmentation(self):
+        handle = torch.cuda.graph_pool_handle()
+        graph = torch.cuda.CUDAGraph()
+        seed = torch.zeros(8, device="cuda")
+        stream = torch.cuda.Stream()
+        with (
+            torch.cuda.stream(stream),
+            torch.cuda.graph(graph, pool=handle, stream=stream),
+        ):
+            transient = torch.empty(200 << 20, dtype=torch.uint8, device="cuda")
+            keep = seed + 1
+            del transient
+        torch.cuda.synchronize()
+
+        address, run_bytes = pool.find_free_graph_pool_runs(handle)[0]
+        self.assertEqual(run_bytes, 200 << 20)
+        with (
+            envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
+            patch.object(pool, "get_global_graph_memory_pool", return_value=handle),
+        ):
+            # Unseeded 24/32/40 MiB segments strand 192 MiB before the 42 MiB request.
+            for rows in (1500, 2000, 2500, 2600):
+                with self.subTest(rows=rows), pool.borrow_graph_pool(user="test"):
+                    first = torch.empty(
+                        (rows, 4096), dtype=torch.float32, device="cuda"
+                    )
+                    second = torch.empty(
+                        (rows, 4096), dtype=torch.float32, device="cuda"
+                    )
+                    self.assertTrue(
+                        all(
+                            address <= tensor.data_ptr()
+                            and tensor.data_ptr() + tensor.nbytes <= address + run_bytes
+                            for tensor in (first, second)
+                        )
+                    )
+                    del first, second
+            pool._teardown_borrow_pool()
+        del graph, keep
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_replay_raises_when_borrowed_tensor_is_still_referenced(self):
+        """Reject borrowed tensors that replay would silently overwrite."""
+        handle = torch.cuda.graph_pool_handle()
+        graph = torch.cuda.CUDAGraph()
+        seed = torch.zeros(8, device="cuda")
+        stream = torch.cuda.Stream()
+        with (
+            torch.cuda.stream(stream),
+            torch.cuda.graph(graph, pool=handle, stream=stream),
+        ):
+            transient = torch.empty(48 << 20, dtype=torch.uint8, device="cuda")
+            keep = seed + 1
+            del transient
+        torch.cuda.synchronize()
+
+        with (
+            envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
+            patch.object(pool, "get_global_graph_memory_pool", return_value=handle),
+        ):
+            with pool.borrow_graph_pool(user="leaky"):
+                leaked = torch.empty(1 << 20, device="cuda")
+            with self.assertRaisesRegex(
+                RuntimeError,
+                f"graph replay: {leaked.nbytes} bytes",
+            ):
+                with pool.graph_pool_replay_scope():
+                    pass
+
+            # A fresh borrow re-arms the replay check after releasing the leak.
+            del leaked
+            with pool.borrow_graph_pool(user="clean"):
+                released = torch.empty(1 << 20, device="cuda")
+            del released
+            with pool.graph_pool_replay_scope():
+                pass
+            pool._teardown_borrow_pool()
+        del graph, keep
 
     @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
     def test_static_borrow_runs_serve_without_a_pool_snapshot(self):
@@ -281,8 +420,6 @@ class TestGraphPoolBorrow(CustomTestCase):
         with (
             envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
             patch.object(pool, "get_global_graph_memory_pool", return_value=None),
-            patch.object(pool, "_borrow_static_runs", None),
-            patch.object(pool, "_borrow_mem_pool", None),
         ):
             pool.set_graph_pool_borrow_runs(runs)
             self.assertTrue(pool.graph_pool_borrow_enabled())
@@ -295,6 +432,7 @@ class TestGraphPoolBorrow(CustomTestCase):
                     )
                 )
                 del borrowed
+            pool._teardown_borrow_pool()
 
         del graph, y
 
@@ -352,18 +490,20 @@ class TestGraphPoolBorrow(CustomTestCase):
         with (
             envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
             patch.object(pool, "get_global_graph_memory_pool", return_value=handle),
-            patch.object(pool, "_borrow_mem_pool", None),
         ):
             for _ in range(3):
                 with pool.borrow_graph_pool(user="test"):
                     borrowed = torch.empty(16 << 20, dtype=torch.uint8, device="cuda")
+                    # Stream-keyed segments allow side-stream copies, not allocations.
+                    sink = torch.empty_like(borrowed)
                     with torch.cuda.stream(side):
-                        widened = borrowed.to(torch.int32)
+                        sink.copy_(borrowed)
                     borrowed.record_stream(side)
-                    del borrowed, widened
+                    del borrowed, sink
             # Regression: this used to fail with "Trying to free a pointer not
             # allocated here" after a deferred free was re-issued too early.
             torch.cuda.empty_cache()
+            pool._teardown_borrow_pool()
 
         del graph, y
 


### PR DESCRIPTION
**Problem:** Transient graph-pool allocations can strand usable space in small segments, and reusing that space on a different stream or before borrowed tensors are released is unsafe.

**Fix:** Give each runtime one borrow state that owns its allocator, free-run snapshot, and allocation stream. Seed reusable segments, expose a capacity query that includes allocator padding and reserve, align scheduler warmup with execution, and reject live borrows before replay.

**Tested:** 165 tests passed on GB300, including fragmentation recovery in a 200 MiB extent, allocation reuse, wrong-stream rejection, replay leak detection, and scheduler warmup routing. Pre-commit passed. Model-serving benchmarks and non-CUDA backend integration were not run; no throughput claim.

<details>
<summary>Commands and actual output</summary>

With CUDA 13.0, the checkout's `python/` and `sgl-model-gateway/bindings/python/src` on `PYTHONPATH`, and `libcrypto.so.3`, `libssl.so.3`, and `libnuma.so.1` preloaded:

```bash
python -m pytest -q --disable-warnings \
  test/registered/unit/model_executor/runner_utils/test_graph_pool_borrow.py \
  test/registered/unit/model_executor/model_runner_components/test_startup_weight_load.py \
  test/registered/unit/test_runtime_context.py \
  test/registered/unit/test_runtime_context_config_bags.py \
  test/registered/unit/test_runtime_context_override.py
pre-commit run
```

```text
165 passed, 21 warnings, 179 subtests passed in 13.34s
```

</details>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34674243047](https://github.com/sgl-project/sglang/actions/runs/34674243047)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34674242980](https://github.com/sgl-project/sglang/actions/runs/34674242980)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34674243061](https://github.com/sgl-project/sglang/actions/runs/34674243061)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->