### PR TITLE
Add a provider hook for prefill-buffer ceilings

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -68,6 +68,7 @@ from sglang.srt.arg_groups.model_override_base import (  # noqa: F401
     resolving_view,
     use_mla_backend,
 )
+from sglang.srt.arg_groups.prefill_buffer_ceiling import prefill_buffer_ceiling_of
 
 logger = logging.getLogger(__name__)
 from sglang.srt.environ import envs
@@ -1873,7 +1874,10 @@ def cutedsl_moe_max_num_tokens(server_args: Any) -> int:
 
 def max_prefill_buffer_tokens(server_args: Any) -> int:
     """Prefill-buffer ceiling: chunked_prefill_size, except PP dynamic
-    chunking can grow chunks toward max_prefill_tokens and probe at 1.25x."""
+    chunking can grow chunks toward max_prefill_tokens and probe at 1.25x.
+
+    Records with a registered ceiling provider (see
+    ``register_prefill_buffer_ceiling``) answer through it."""
     cfg = resolving_view(server_args)
     chunked = (
         cfg.chunked_prefill_size
@@ -1883,7 +1887,10 @@ def max_prefill_buffer_tokens(server_args: Any) -> int:
     tokens = chunked
     if cfg.enable_dynamic_chunking and cfg.pp_size > 1 and chunked:
         tokens = max(tokens, cfg.max_prefill_tokens or 0, math.ceil(chunked * 1.25))
-    return tokens
+    record = server_args
+    if isinstance(server_args, (ResolvedView, ResolvingConfig)):
+        record = record_of(server_args)
+    return prefill_buffer_ceiling_of(record, tokens)
 
 
 def mamba_cache_chunk_size(server_args: Any) -> int:

--- a/python/sglang/srt/arg_groups/prefill_buffer_ceiling.py
+++ b/python/sglang/srt/arg_groups/prefill_buffer_ceiling.py
@@ -1,0 +1,35 @@
+"""Dependency-free hook shared by pre- and post-publish prefill-buffer sizing."""
+
+from typing import Any, Callable, Optional
+
+_prefill_buffer_ceiling_fn: Optional[Callable[[Any, int], int]] = None
+
+
+def register_prefill_buffer_ceiling(
+    fn: Callable[[Any, int], int],
+) -> Callable[[Any, int], int]:
+    """Register one provider; repeating the same registration is harmless.
+
+    The provider receives ``(record, default_ceiling)`` and returns the ceiling,
+    keeping ``default_ceiling`` for records it does not handle. ``record`` is
+    the original argument record, never a view: its fields remain raw inputs.
+    Read resolution declarations through ``resolving_view(record)`` from
+    ``arg_groups.model_override_base``. The provider must not mutate the record
+    and must use the same sizing policy before and after publication.
+
+    Registering a different provider raises instead of replacing the first.
+    """
+    global _prefill_buffer_ceiling_fn
+    if _prefill_buffer_ceiling_fn is not None and _prefill_buffer_ceiling_fn is not fn:
+        raise RuntimeError(
+            "A different prefill-buffer ceiling provider is already registered"
+        )
+    _prefill_buffer_ceiling_fn = fn
+    return fn
+
+
+def prefill_buffer_ceiling_of(record: Any, default_ceiling: int) -> int:
+    """Return the provider's ceiling, or the default when none is registered."""
+    if _prefill_buffer_ceiling_fn is None:
+        return default_ceiling
+    return _prefill_buffer_ceiling_fn(record, default_ceiling)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1107,9 +1107,15 @@ class Scheduler(
         self.init_all_cuda_graphs()
 
         model_runner = self.tp_worker.model_runner
-        with torch.get_device_module(model_runner.device).stream(
+        device_module = torch.get_device_module(model_runner.device)
+        self.schedule_stream = None if use_mlx() else device_module.Stream(priority=0)
+        # Match run_batch / _pp_launch_batch so warmup allocations stay reusable.
+        forward_stream = (
             model_runner.forward_stream
-        ):
+            if self.enable_overlap or self.ps.pp_size > 1 or use_mlx()
+            else self.schedule_stream
+        )
+        with device_module.stream(forward_stream):
             if self.draft_worker is None:
                 model_runner.prewarm_sampling()
             else:
@@ -1847,7 +1853,6 @@ class Scheduler(
     def run_event_loop(self) -> None:
         """Run the scheduler's event loop.
 
-        Sets up the schedule stream and dispatches to the appropriate event loop.
         The event loop blocks until shutdown.
         """
         # Engine init (graph capture, warmups) is done; from here on any
@@ -1862,10 +1867,9 @@ class Scheduler(
             dispatch_event_loop(self)
             return
 
-        self.schedule_stream = self.device_module.Stream(priority=0)
         if self.device == "cpu":
             self.schedule_stream.synchronize = lambda: None  # No-op for CPU
-        elif is_cuda() or _is_hip:
+        elif (is_cuda() or _is_hip) and (self.enable_overlap or self.ps.pp_size > 1):
             # CUDA/HIP streams come from a fixed round-robin pool. Redraw if this
             # stream aliases forward_stream, which would eliminate scheduler
             # overlap. Only CUDA/HIP streams expose a ``cuda_stream`` handle;

--- a/python/sglang/srt/model_executor/runner_utils/pool.py
+++ b/python/sglang/srt/model_executor/runner_utils/pool.py
@@ -45,6 +45,7 @@ class GraphPoolBorrowState:
     active_user: Optional[str] = None
     stub: Optional[BumpArenaStub] = None
     mem_pool: Optional[torch.cuda.MemPool] = None
+    stream: Optional[torch.cuda.Stream] = None
     disabled_reason: Optional[str] = None
     static_runs: Optional[list[tuple[int, int]]] = None
     check_pending: bool = False
@@ -279,6 +280,7 @@ def _teardown_borrow_pool() -> None:
     torch.cuda.synchronize()
     torch.empty(1, device="cuda")
     state.mem_pool = None
+    state.stream = None
 
 
 _PRECARVE_MIN_RUN_BYTES = 64 << 20
@@ -312,6 +314,8 @@ def _precarve_run_segments(runs: list[tuple[int, int]]) -> None:
 def borrow_graph_pool(user: str) -> Iterator[None]:
     """Route this thread's torch allocations onto the graph pool's free runs.
 
+    All borrows must use the stream that first creates the borrow pool, so
+    the caching allocator can reuse its pre-carved segments.
     Tensors allocated inside must be released before the next graph replay,
     which rewrites their bytes; the next replay (or pool teardown) raises if
     any are still referenced. An allocation no run can hold raises the
@@ -322,7 +326,13 @@ def borrow_graph_pool(user: str) -> Iterator[None]:
         yield
         return
     with graph_pool_user_scope(user):
+        stream = torch.cuda.current_stream()
         if state.mem_pool is not None:
+            if stream != state.stream:
+                raise RuntimeError(
+                    "Graph-pool borrow must use the stream that created the borrow pool: "
+                    f"expected {state.stream}, got {stream}"
+                )
             # Return completed cross-stream frees to the cache. The allocator
             # processes their events on a later allocation.
             torch.empty(1, device="cuda")
@@ -346,6 +356,7 @@ def borrow_graph_pool(user: str) -> Iterator[None]:
             # stream-ordered deferred frees remain allocator-managed. Capture
             # retires it because capture changes the underlying free extents.
             state.mem_pool = torch.cuda.MemPool(state.stub.allocator)
+            state.stream = stream
             with torch.cuda.use_mem_pool(state.mem_pool):
                 _precarve_run_segments(runs)
             # Only growth beyond the precarve is worth another log line.

--- a/python/sglang/srt/model_executor/runner_utils/pool.py
+++ b/python/sglang/srt/model_executor/runner_utils/pool.py
@@ -288,6 +288,16 @@ _PRECARVE_SMALL_RESERVE_BYTES = 32 << 20
 _PRECARVE_GRANULARITY = 2 << 20
 
 
+def graph_pool_borrow_can_fit(nbytes: int) -> bool:
+    """Whether one free run fits the payload plus allocator padding and reserve."""
+    if nbytes <= 0:
+        return False
+    required = (
+        nbytes + _PRECARVE_GRANULARITY - 1
+    ) // _PRECARVE_GRANULARITY * _PRECARVE_GRANULARITY + _PRECARVE_SMALL_RESERVE_BYTES
+    return graph_pool_borrow_largest_run() >= required
+
+
 def _precarve_run_segments(runs: list[tuple[int, int]]) -> None:
     """Seed coalescible segments on the stream that will allocate borrows."""
     for _, run_bytes in runs:

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -57,6 +57,8 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import msgspec
 
+from sglang.srt.arg_groups.prefill_buffer_ceiling import prefill_buffer_ceiling_of
+
 if TYPE_CHECKING:
     from sglang.srt.model_executor.runner_utils.pool import GraphPoolBorrowState
     from sglang.srt.server_args import ServerArgs
@@ -1788,13 +1790,13 @@ def max_prefill_buffer_tokens() -> int:
     """The prefill-buffer ceiling: ``chunked_prefill_size``, except PP dynamic
     chunking can grow chunks toward ``max_prefill_tokens`` and probe at 1.25x.
 
-    Every input is a published leaf (``schedule`` plus the configured PP size),
-    so this derives from the bags and follows a post-publish override;
+    The default derives from published leaves (``schedule`` plus the configured
+    PP size), so it follows post-publish overrides;
     ``overrides.max_prefill_buffer_tokens`` is the pre-publish equivalent and
-    ``TestDerivedPredicatesAgreeAcrossTiers`` pins the two equal.
+    ``TestDerivedPredicatesAgreeAcrossTiers`` pins the two equal. Records with
+    a registered ceiling provider (see ``register_prefill_buffer_ceiling``)
+    answer through it.
     """
-    import math
-
     schedule = get_schedule()
     chunked = (
         schedule.chunked_prefill_size
@@ -1806,7 +1808,7 @@ def max_prefill_buffer_tokens() -> int:
         tokens = max(
             tokens, schedule.max_prefill_tokens or 0, math.ceil(chunked * 1.25)
         )
-    return tokens
+    return prefill_buffer_ceiling_of(get_server_args(), tokens)
 
 
 def pre_capture_activation_reserve_mb(gpu_mem: float | None) -> float:

--- a/test/registered/unit/model_executor/model_runner_components/test_startup_weight_load.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_startup_weight_load.py
@@ -17,6 +17,7 @@ maybe_stub_sgl_kernel()
 from sglang.srt.configs.device_config import DeviceConfig
 from sglang.srt.configs.load_config import LoadConfig, LoadFormat
 from sglang.srt.configs.model_config import ModelImpl
+from sglang.srt.managers.scheduler import Scheduler
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.model_executor.cuda_graph_config import Backend, CudaGraphConfig
 from sglang.srt.model_executor.model_runner import ModelRunner
@@ -728,9 +729,9 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
         reset_context()
         self.addCleanup(reset_context)
 
-    def _scheduler(self, worker, trace, *, mode, draft_worker=None):
-        from sglang.srt.managers.scheduler import Scheduler
-
+    def _scheduler(
+        self, worker, trace, *, mode, draft_worker=None, enable_overlap=True, pp_size=1
+    ):
         # The schedule reads the mode from the bags, so the test states it by
         # publishing a record rather than by standing one in.
         reset_context()
@@ -739,6 +740,8 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
             role="scheduler",
         )
         scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_overlap = enable_overlap
+        scheduler.ps = SimpleNamespace(pp_size=pp_size)
         scheduler.init_tp_model_worker = lambda: setattr(scheduler, "tp_worker", worker)
         scheduler.maybe_init_draft_worker = lambda: setattr(
             scheduler, "draft_worker", draft_worker
@@ -748,7 +751,9 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
         scheduler.init_all_cuda_graphs = lambda: trace.append("capture")
         return scheduler
 
-    def _run_startup(self, mode, *, use_draft_worker=False):
+    def _run_startup(
+        self, mode, *, use_draft_worker=False, enable_overlap=True, pp_size=1, mlx=False
+    ):
         trace = []
         worker = _SchedulerWorker(trace, post_capture_active=True)
         draft_worker = (
@@ -764,6 +769,14 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
             trace,
             mode=mode,
             draft_worker=draft_worker,
+            enable_overlap=enable_overlap,
+            pp_size=pp_size,
+        )
+        schedule_stream = object()
+        expected_stream = (
+            worker.model_runner.forward_stream
+            if enable_overlap or pp_size > 1 or mlx
+            else schedule_stream
         )
 
         class StreamContext:
@@ -774,7 +787,7 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
                 trace.append("stream_exit")
 
         def stream_context(stream):
-            self.assertIs(stream, worker.model_runner.forward_stream)
+            self.assertIs(stream, expected_stream)
             return StreamContext()
 
         def stop_after_startup():
@@ -783,6 +796,7 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
         scheduler.spec_algorithm = SimpleNamespace(is_none=stop_after_startup)
 
         with (
+            patch("sglang.srt.managers.scheduler.use_mlx", return_value=mlx),
             patch(
                 "sglang.srt.managers.scheduler.get_exec",
                 return_value=SimpleNamespace(
@@ -794,12 +808,15 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
             ),
             patch(
                 "sglang.srt.managers.scheduler.torch.get_device_module",
-                return_value=SimpleNamespace(stream=stream_context),
+                return_value=SimpleNamespace(
+                    stream=stream_context, Stream=lambda priority: schedule_stream
+                ),
             ),
             self.assertRaisesRegex(RuntimeError, "stop after startup"),
         ):
             scheduler.init_model_worker()
 
+        self.assertIs(scheduler.schedule_stream, None if mlx else schedule_stream)
         worker.model_runner.post_capture_resize_kv_pool.assert_called_once_with(
             draft_runners=(worker.model_runner,) if use_draft_worker else ()
         )
@@ -818,6 +835,18 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
                 "resize",
             ],
         )
+
+    def test_sampling_warmup_uses_the_serving_stream(self):
+        for enable_overlap, pp_size, mlx in (
+            (False, 1, False),
+            (False, 2, False),
+            (True, 1, False),
+            (False, 1, True),
+        ):
+            with self.subTest(enable_overlap=enable_overlap, pp_size=pp_size, mlx=mlx):
+                self._run_startup(
+                    "serial", enable_overlap=enable_overlap, pp_size=pp_size, mlx=mlx
+                )
 
     def test_overlap_starts_before_capture_and_finalizes_after(self):
         self.assertEqual(

--- a/test/registered/unit/model_executor/runner_utils/test_graph_pool_borrow.py
+++ b/test/registered/unit/model_executor/runner_utils/test_graph_pool_borrow.py
@@ -114,6 +114,7 @@ class TestGraphPoolBorrow(CustomTestCase):
             patch.object(self.state, "mem_pool", None),
             patch.object(pool.torch.cuda, "MemPool"),
             patch.object(pool.torch.cuda, "use_mem_pool"),
+            patch.object(pool.torch.cuda, "current_stream"),
             patch.object(pool.torch.cuda, "memory_snapshot", return_value=snapshot),
             pool.borrow_graph_pool(user="test"),
         ):
@@ -127,15 +128,18 @@ class TestGraphPoolBorrow(CustomTestCase):
     def test_high_cursor_keeps_reusable_cached_segments(self):
         stub = MagicMock(cursor_bytes=600, freed_bytes=0)
         mem_pool = MagicMock()
+        stream = object()
 
         with (
             patch.object(pool, "graph_pool_borrow_enabled", return_value=True),
             patch.object(self.state, "stub", stub),
             patch.object(self.state, "mem_pool", mem_pool),
+            patch.object(self.state, "stream", stream),
             patch.object(self.state, "extents_total", 1000),
             patch.object(pool, "_teardown_borrow_pool") as teardown,
             patch.object(pool.torch, "empty"),
             patch.object(pool.torch.cuda, "use_mem_pool"),
+            patch.object(pool.torch.cuda, "current_stream", return_value=stream),
         ):
             with pool.borrow_graph_pool(user="test"):
                 pass
@@ -282,9 +286,35 @@ class TestGraphPoolBorrow(CustomTestCase):
                 self.assertEqual(c.data_ptr(), recycled_address)
                 del b, c
 
+            self.assertEqual(self.state.stream, torch.cuda.current_stream())
+            with (
+                torch.cuda.stream(stream),
+                self.assertRaisesRegex(
+                    RuntimeError, "stream that created the borrow pool"
+                ),
+            ):
+                with pool.borrow_graph_pool(user="wrong stream"):
+                    self.fail("cross-stream borrowing must fail before allocating")
+            self.assertIsNone(self.state.active_user)
+            with pool.borrow_graph_pool(user="same stream"):
+                reused = torch.empty(40 << 20, dtype=torch.uint8, device="cuda")
+                self.assertEqual(reused.data_ptr(), recycled_address)
+                del reused
+
             # Captures retire the persistent borrow pool. Its storage aliases
             # existing graph-pool runs, so the reserved footprint is unchanged.
             pool._teardown_borrow_pool()
+            self.assertIsNone(self.state.stream)
+            with torch.cuda.stream(stream), pool.borrow_graph_pool(user="new pool"):
+                self.assertEqual(self.state.stream, stream)
+                reused = torch.empty(40 << 20, dtype=torch.uint8, device="cuda")
+                self.assertTrue(on_a_run(reused))
+                del reused
+            pool._teardown_borrow_pool()
+            with pool.graph_pool_replay_scope():
+                graph.replay()
+            torch.cuda.synchronize()
+            self.assertTrue(torch.equal(y, torch.ones_like(y)))
 
         self.assertEqual(torch.cuda.memory_reserved(device_id), reserved_before)
         del graph, y

--- a/test/registered/unit/model_executor/runner_utils/test_graph_pool_borrow.py
+++ b/test/registered/unit/model_executor/runner_utils/test_graph_pool_borrow.py
@@ -76,6 +76,25 @@ class TestGraphPoolBorrow(CustomTestCase):
             self.assertEqual(pool.graph_pool_borrow_largest_run(), 0)
             self.assertEqual(snapshot.call_count, 3)
 
+    def test_borrow_capacity_includes_rounding_and_small_pool_reserve(self):
+        for payload, largest_run, expected in (
+            (-1, 64 << 20, False),
+            (0, 64 << 20, False),
+            (1, 0, False),
+            (1, 32 << 20, False),
+            (1, 34 << 20, True),
+            (2 << 20, 34 << 20, True),
+            ((2 << 20) + 1, 34 << 20, False),
+            ((2 << 20) + 1, 36 << 20, True),
+        ):
+            with (
+                self.subTest(payload=payload, largest_run=largest_run),
+                patch.object(
+                    pool, "graph_pool_borrow_largest_run", return_value=largest_run
+                ),
+            ):
+                self.assertEqual(pool.graph_pool_borrow_can_fit(payload), expected)
+
     def test_graph_replay_fails_during_active_pool_borrow(self):
         graph = Mock()
         backend = object.__new__(FullCudaGraphBackend)

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -19,7 +19,9 @@ import msgspec.structs
 
 import sglang as _sglang
 import sglang.srt.server_args as server_args_module
+from sglang.srt.arg_groups import prefill_buffer_ceiling
 from sglang.srt.arg_groups.arg_utils import NS, A, Arg
+from sglang.srt.arg_groups.model_override_base import resolving_view
 from sglang.srt.arg_groups.overrides import (
     attention_backends_of,
 )
@@ -44,7 +46,9 @@ from sglang.srt.runtime_context import (
     get_exec,
     get_flags,
     get_parallel,
+    get_schedule,
     get_server_args,
+    max_prefill_buffer_tokens,
     max_speculative_num_draft_tokens,
     publish,
     publish_role,
@@ -1203,6 +1207,46 @@ class TestDerivedPredicatesAgreeAcrossTiers(_IsolatedServerArgs):
                                 max_prefill_buffer_tokens_of(args),
                                 max_prefill_buffer_tokens(),
                             )
+
+    def test_prefill_buffer_ceiling_hook_honored_across_tiers(self):
+        args = _FakeResolvedArgs(
+            chunked_prefill_size=8192,
+            enable_dynamic_chunking=True,
+            pp_size=4,
+            max_prefill_tokens=16384,
+        )
+
+        def provider(record, default_ceiling):
+            self.assertIs(record, args)
+            return default_ceiling + 5
+
+        with patch.object(prefill_buffer_ceiling, "_prefill_buffer_ceiling_fn", None):
+            register = prefill_buffer_ceiling.register_prefill_buffer_ceiling
+            self.assertEqual(max_prefill_buffer_tokens_of(args), 16384)
+            self.assertIs(register(provider), provider)
+            register(provider)
+            with self.assertRaisesRegex(RuntimeError, "already registered"):
+                register(lambda record, default_ceiling: default_ceiling)
+            for record_or_view in (args, resolving_view(args), resolved_view(args)):
+                self.assertEqual(max_prefill_buffer_tokens_of(record_or_view), 16389)
+            get_context().set_server_args(args)
+            self.assertEqual(max_prefill_buffer_tokens(), 16389)
+            with get_schedule().override(max_prefill_tokens=32768):
+                self.assertEqual(max_prefill_buffer_tokens(), 32773)
+            self.assertEqual(args.max_prefill_tokens, 16384)
+
+    def test_prefill_buffer_ceiling_provider_can_preserve_defaults(self):
+        args = _FakeResolvedArgs(chunked_prefill_size=4096)
+
+        def provider(record, default_ceiling):
+            return default_ceiling
+
+        with patch.object(prefill_buffer_ceiling, "_prefill_buffer_ceiling_fn", None):
+            prefill_buffer_ceiling.register_prefill_buffer_ceiling(provider)
+            for record_or_view in (args, resolving_view(args), resolved_view(args)):
+                self.assertEqual(max_prefill_buffer_tokens_of(record_or_view), 4096)
+            get_context().set_server_args(args)
+            self.assertEqual(max_prefill_buffer_tokens(), 4096)
 
     def test_activation_reserve_matches_the_member(self):
         from types import SimpleNamespace


### PR DESCRIPTION
**Problem:** Serving extensions can require a different prefill-buffer ceiling, but argument resolution and runtime sizing must agree to allocate buffers safely. Replacing module functions is fragile for callers that already imported them.

**Fix:** Add `register_prefill_buffer_ceiling`: one dependency-free provider receives the original argument record and computed default. Both sizing paths call it; providers preserve the default for records they do not handle and must use a consistent, non-mutating policy. Re-registering the same callable is harmless; conflicting providers fail explicitly. Default behavior is unchanged.

**Tested:** All applicable pre-commit checks pass.

<details>
<summary>Command and real test output</summary>

```text
python -m pytest -q test/registered/unit/test_runtime_context.py test/registered/unit/test_runtime_context_config_bags.py test/registered/unit/test_runtime_context_override.py test/registered/unit/server_args
431 passed, 22 warnings, 268 subtests passed in 42.68s
```

</details>

Full model-serving and throughput benchmarks were not run.

**Dependency:** Depends on https://github.com/sgl-project/sglang/pull/39180; branch is based on `oss/graph-pool-single-stream` at `33cbe6a425`. Targets `main`, so the PR diff includes its parents until they merge. [This change only](https://github.com/cctry/sglang/commit/d9ac0d2cd5c2f6cddfa7fd75c0c1c7f8d69c3b89).

## Original commits

- `04899fb7d78c18f17de38415c13611cd6d7b567d`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34721900767](https://github.com/sgl-project/sglang/actions/runs/34721900767)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34721900705](https://github.com/sgl-project/sglang/actions/runs/34721900705)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34721900768](https://github.com/sgl-project/sglang/actions/runs/34721900768)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->