### PR TITLE
[CUDA Graph] Deduplicate using the live executable

### DIFF
--- a/python/sglang/srt/model_executor/runner_backend/cuda_graph_dedup_mixin.py
+++ b/python/sglang/srt/model_executor/runner_backend/cuda_graph_dedup_mixin.py
@@ -43,20 +43,6 @@ def maybe_cuda_result(result):
     return None if int(result[0]) != 0 else checkCudaErrors(result)
 
 
-def kernel_name(params) -> str:
-    assert cuda_drv is not None
-    for handle, getter in (
-        (getattr(params, "kern", None), cuda_drv.cuKernelGetName),
-        (getattr(params, "func", None), cuda_drv.cuFuncGetName),
-    ):
-        if handle is None or int(handle) == 0:
-            continue
-        name = maybe_cuda_result(getter(handle))
-        if name is not None:
-            return name.decode("utf-8", "replace")
-    return f"func:{int(getattr(params, 'func', 0))}"
-
-
 def kernel_attrs(node) -> tuple[tuple[str, object], ...]:
     assert cuda_drv is not None
     attrs = []
@@ -107,10 +93,13 @@ def kernel_attrs(node) -> tuple[tuple[str, object], ...]:
 def kernel_node_payload(node):
     assert cuda_drv is not None
     params = checkCudaErrors(cuda_drv.cuGraphKernelNodeGetParams(node))
+    # Grid dimensions vary across buckets and are validated by the exec update.
+    # The handles subsume the kernel name; they are here because
+    # cuGraphKernelNodeGetAttribute cannot read preferred cluster dimension back
+    # and cudaGraphExecUpdate reports success when it changes (sgl-project/sglang#37657).
+    # Once the driver reports that mismatch, the handles can go too.
     return (
-        kernel_name(params),
         (int(params.kern), int(params.func)),
-        (int(params.gridDimX), int(params.gridDimY), int(params.gridDimZ)),
         (int(params.blockDimX), int(params.blockDimY), int(params.blockDimZ)),
         int(params.sharedMemBytes),
         kernel_attrs(node),
@@ -186,7 +175,6 @@ def graph_signature(raw_graph: int):
 class GraphExecGroup:
     graph_exec: int
     current_raw_graph: int
-    compat_exec: int | None
     graphs: list[DedupedCudaGraph] = field(default_factory=list)
 
 
@@ -227,9 +215,10 @@ class DedupedCudaGraphRegistry:
 
         group = self.groups.get(signature)
         if group is not None:
-            assert group.compat_exec is not None
-            ok, detail = dedup_update(group.compat_exec, graph.raw_graph)
+            # An incompatible cudaGraphExecUpdate does not modify the executable.
+            ok, detail = dedup_update(group.graph_exec, graph.raw_graph)
             assert ok, f"CUDA graph dedup register update failed ({detail})"
+            group.current_raw_graph = graph.raw_graph
             graph.group = group
             group.graphs.append(graph)
             return graph
@@ -237,7 +226,6 @@ class DedupedCudaGraphRegistry:
         group = GraphExecGroup(
             graph_exec=self.instantiate(graph.raw_graph),
             current_raw_graph=graph.raw_graph,
-            compat_exec=self.instantiate(graph.raw_graph),
             graphs=[graph],
         )
         graph.group = group
@@ -245,13 +233,7 @@ class DedupedCudaGraphRegistry:
         return graph
 
     def seal(self) -> None:
-        if self.sealed:
-            return
         self.sealed = True
-        for group in self.groups.values():
-            if group.compat_exec is not None:
-                self.destroy_exec(group.compat_exec)
-                group.compat_exec = None
 
     def stats(self) -> tuple[int, int]:
         return sum(len(group.graphs) for group in self.groups.values()), len(
@@ -281,9 +263,6 @@ class DedupedCudaGraphRegistry:
         self.sealed = True
 
         for group in self.groups.values():
-            if group.compat_exec is not None:
-                self.destroy_exec(group.compat_exec)
-                group.compat_exec = None
             self.destroy_exec(group.graph_exec)
             for graph in group.graphs:
                 if graph.original_graph is not None:


### PR DESCRIPTION
**Problem:** Each dedup group instantiates an extra executable just to check compatibility, while grid dimensions and redundant kernel names keep compatible captures apart.

**Fix:** Validate registration against the live executable and track the graph it now represents. A rejected CUDA update preserves that executable. Leave grid validation to the update; retain kernel handles and launch attributes in the signature.

**Tested:** 17 upstream tests passed. On GB300, three grid sizes shared exactly one executable; an incompatible update was rejected, six subsequent alternating replays were correct, and cleanup destroyed the executable once. Pre-commit passed. Model-serving accuracy and performance benchmarks were not run.

<details>
<summary>Commands and actual output</summary>

With CUDA 13.0, the checkout's `python/` and `sgl-model-gateway/bindings/python/src` on `PYTHONPATH`, and `libcrypto.so.3`, `libssl.so.3`, and `libnuma.so.1` preloaded:

```bash
python -m pytest -q --disable-warnings \
  test/registered/unit/model_executor/runner_backend/test_full_cuda_graph_backend.py \
  test/registered/unit/model_executor/test_prefill_cuda_graph_runner_helpers.py
pre-commit run --files python/sglang/srt/model_executor/runner_backend/cuda_graph_dedup_mixin.py
```

```text
17 passed, 21 warnings, 2 subtests passed in 9.68s
PASS: 3 grid sizes share 1 CUDA executable; exactly 1 instantiation
PASS: incompatible update rejected; registry state preserved
PASS: 6 alternating replays remain correct after rejected update
PASS: close destroys the sole executable once and is idempotent
```

The CUDA check was run as `python B-cuda-check.py` with this script:

```python
from unittest.mock import patch

import torch

from sglang.srt.model_executor.runner_backend import cuda_graph_dedup_mixin as dedup

registry = dedup.DedupedCudaGraphRegistry()
stream = torch.cuda.Stream()
inputs = [torch.ones(n, device="cuda") for n in (1024, 8192, 32768)]
outputs = [torch.empty_like(value) for value in inputs]
bad_input = torch.ones(1024, device="cuda")
bad_output = torch.empty_like(bad_input)
torch.cuda.synchronize()
raw_graphs = []
for value, output in zip(inputs, outputs):
    graph = torch.cuda.CUDAGraph(keep_graph=True)
    with torch.cuda.graph(graph, stream=stream):
        torch.add(value, 3, out=output)
    raw_graphs.append(graph)
bad_graph = torch.cuda.CUDAGraph(keep_graph=True)
with torch.cuda.graph(bad_graph, stream=stream):
    torch.add(bad_input, 3, out=bad_output)
    bad_output.mul_(2)
torch.cuda.synchronize()
with patch.object(registry, "instantiate", wraps=registry.instantiate) as instantiate:
    graphs = [registry.register(graph) for graph in raw_graphs]
    assert registry.stats() == (3, 1), registry.stats()
    assert instantiate.call_count == 1, instantiate.call_count
print("PASS: 3 grid sizes share 1 CUDA executable; exactly 1 instantiation")
group = graphs[0].group
current = group.current_raw_graph
signature = dedup.graph_signature(raw_graphs[0].raw_cuda_graph())
with patch.object(dedup, "graph_signature", return_value=signature):
    try:
        registry.register(bad_graph)
    except AssertionError as error:
        assert "register update failed" in str(error), str(error)
    else:
        raise AssertionError("incompatible two-node graph unexpectedly accepted")
assert group.current_raw_graph == current
assert registry.stats() == (3, 1)
print("PASS: incompatible update rejected; registry state preserved")
registry.seal()
registry.seal()
for index in (2, 0, 1, 0, 2, 1):
    inputs[index].fill_(index + 7)
    graphs[index].replay()
    torch.cuda.synchronize()
    torch.testing.assert_close(outputs[index], torch.full_like(outputs[index], index + 10))
print("PASS: 6 alternating replays remain correct after rejected update")
with patch.object(registry, "destroy_exec", wraps=registry.destroy_exec) as destroy:
    registry.close()
    registry.close()
    assert destroy.call_count == 1, destroy.call_count
bad_graph.reset()
print("PASS: close destroys the sole executable once and is idempotent")
```

</details>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34674268995](https://github.com/sgl-project/sglang/actions/runs/34674268995)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34674268883](https://github.com/sgl-project/sglang/actions/runs/34674268883)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34674269025](https://github.com/sgl-project/sglang/actions/runs/34674269025)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->