### PR TITLE
[Runtime] Add a prefill-buffer ceiling provider API

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -68,6 +68,7 @@ from sglang.srt.arg_groups.model_override_base import (  # noqa: F401
     resolving_view,
     use_mla_backend,
 )
+from sglang.srt.arg_groups.prefill_buffer_ceiling import prefill_buffer_ceiling_of
 
 logger = logging.getLogger(__name__)
 from sglang.srt.environ import envs
@@ -1846,7 +1847,10 @@ def cutedsl_moe_max_num_tokens(server_args: Any) -> int:
 
 def max_prefill_buffer_tokens(server_args: Any) -> int:
     """Prefill-buffer ceiling: chunked_prefill_size, except PP dynamic
-    chunking can grow chunks toward max_prefill_tokens and probe at 1.25x."""
+    chunking can grow chunks toward max_prefill_tokens and probe at 1.25x.
+
+    Records with a registered ceiling provider (see
+    ``register_prefill_buffer_ceiling``) answer through it."""
     cfg = resolving_view(server_args)
     chunked = (
         cfg.chunked_prefill_size
@@ -1856,7 +1860,10 @@ def max_prefill_buffer_tokens(server_args: Any) -> int:
     tokens = chunked
     if cfg.enable_dynamic_chunking and cfg.pp_size > 1 and chunked:
         tokens = max(tokens, cfg.max_prefill_tokens or 0, math.ceil(chunked * 1.25))
-    return tokens
+    record = server_args
+    if isinstance(server_args, (ResolvedView, ResolvingConfig)):
+        record = record_of(server_args)
+    return prefill_buffer_ceiling_of(record, tokens)
 
 
 def mamba_cache_chunk_size(server_args: Any) -> int:

--- a/python/sglang/srt/arg_groups/prefill_buffer_ceiling.py
+++ b/python/sglang/srt/arg_groups/prefill_buffer_ceiling.py
@@ -1,0 +1,35 @@
+"""Dependency-free hook shared by pre- and post-publish prefill-buffer sizing."""
+
+from typing import Any, Callable, Optional
+
+_prefill_buffer_ceiling_fn: Optional[Callable[[Any, int], int]] = None
+
+
+def register_prefill_buffer_ceiling(
+    fn: Callable[[Any, int], int],
+) -> Callable[[Any, int], int]:
+    """Register one provider; repeating the same registration is harmless.
+
+    The provider receives ``(record, default_ceiling)`` and returns the ceiling,
+    keeping ``default_ceiling`` for records it does not handle. ``record`` is
+    the original argument record, never a view: its fields remain raw inputs.
+    Read resolution declarations through ``resolving_view(record)`` from
+    ``arg_groups.model_override_base``. The provider must not mutate the record
+    and must use the same sizing policy before and after publication.
+
+    Registering a different provider raises instead of replacing the first.
+    """
+    global _prefill_buffer_ceiling_fn
+    if _prefill_buffer_ceiling_fn is not None and _prefill_buffer_ceiling_fn is not fn:
+        raise RuntimeError(
+            "A different prefill-buffer ceiling provider is already registered"
+        )
+    _prefill_buffer_ceiling_fn = fn
+    return fn
+
+
+def prefill_buffer_ceiling_of(record: Any, default_ceiling: int) -> int:
+    """Return the provider's ceiling, or the default when none is registered."""
+    if _prefill_buffer_ceiling_fn is None:
+        return default_ceiling
+    return _prefill_buffer_ceiling_fn(record, default_ceiling)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1107,9 +1107,15 @@ class Scheduler(
         self.init_all_cuda_graphs()
 
         model_runner = self.tp_worker.model_runner
-        with torch.get_device_module(model_runner.device).stream(
+        device_module = torch.get_device_module(model_runner.device)
+        self.schedule_stream = None if use_mlx() else device_module.Stream(priority=0)
+        # Match run_batch / _pp_launch_batch so warmup allocations stay reusable.
+        forward_stream = (
             model_runner.forward_stream
-        ):
+            if self.enable_overlap or self.ps.pp_size > 1 or use_mlx()
+            else self.schedule_stream
+        )
+        with device_module.stream(forward_stream):
             if self.draft_worker is None:
                 model_runner.prewarm_sampling()
             else:
@@ -1847,7 +1853,6 @@ class Scheduler(
     def run_event_loop(self) -> None:
         """Run the scheduler's event loop.
 
-        Sets up the schedule stream and dispatches to the appropriate event loop.
         The event loop blocks until shutdown.
         """
         # Engine init (graph capture, warmups) is done; from here on any
@@ -1862,10 +1867,9 @@ class Scheduler(
             dispatch_event_loop(self)
             return
 
-        self.schedule_stream = self.device_module.Stream(priority=0)
         if self.device == "cpu":
             self.schedule_stream.synchronize = lambda: None  # No-op for CPU
-        elif is_cuda() or _is_hip:
+        elif (is_cuda() or _is_hip) and (self.enable_overlap or self.ps.pp_size > 1):
             # CUDA/HIP streams come from a fixed round-robin pool. Redraw if this
             # stream aliases forward_stream, which would eliminate scheduler
             # overlap. Only CUDA/HIP streams expose a ``cuda_stream`` handle;

--- a/python/sglang/srt/model_executor/runner_utils/pool.py
+++ b/python/sglang/srt/model_executor/runner_utils/pool.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
+from dataclasses import dataclass, field
+from functools import cache
 from typing import Any, Iterator, Optional
 
 import torch
@@ -31,21 +33,51 @@ from sglang.srt.utils import is_cuda
 from sglang.srt.utils.cuda_vmm_utils import BumpArenaStub
 
 logger = logging.getLogger(__name__)
-_active_graph_pool_user: Optional[str] = None
-_borrow_stub: Optional[BumpArenaStub] = None
-_borrow_mem_pool: Optional[torch.cuda.MemPool] = None
-_borrow_disabled_reason: Optional[str] = None
-_borrow_static_runs: Optional[list[tuple[int, int]]] = None
-_borrow_extents_total = 0
-_largest_logged_graph_pool_borrow = 0
 
+_MIB = 1 << 20
 _CAPTURE_STREAM_NAME = "cuda_graph_capture"
+
+
+@dataclass(eq=False)
+class GraphPoolBorrowState:
+    """Mutable borrowing state and free-run cache for one runtime."""
+
+    active_user: Optional[str] = None
+    stub: Optional[BumpArenaStub] = None
+    mem_pool: Optional[torch.cuda.MemPool] = None
+    stream: Optional[torch.cuda.Stream] = None
+    disabled_reason: Optional[str] = None
+    static_runs: Optional[list[tuple[int, int]]] = None
+    check_pending: bool = False
+    extents_total: int = 0
+    largest_logged_borrow: int = 0
+    snapshot_free_runs: Any = field(
+        default_factory=lambda: cache(find_free_graph_pool_runs), init=False, repr=False
+    )
+
+
+def _get_graph_pool_borrow_state() -> GraphPoolBorrowState:
+    resources = get_resources()
+    if resources.graph_pool_borrow is None:
+        resources.graph_pool_borrow = GraphPoolBorrowState()
+    return resources.graph_pool_borrow
+
+
+def _log_graph_pool_borrow_capacity(runs: list[tuple[int, int]]) -> None:
+    total_bytes = sum(nbytes for _, nbytes in runs)
+    largest_bytes = max((nbytes for _, nbytes in runs), default=0)
+    logger.info(
+        "Graph pool borrow capacity: %.1f MiB available, largest contiguous "
+        "region %.1f MiB, %d regions",
+        total_bytes / _MIB,
+        largest_bytes / _MIB,
+        len(runs),
+    )
 
 
 def disable_graph_pool_borrow(reason: str) -> None:
     """Disable borrowing when graph storage is managed outside the shared pool."""
-    global _borrow_disabled_reason
-    _borrow_disabled_reason = reason
+    _get_graph_pool_borrow_state().disabled_reason = reason
     _teardown_borrow_pool()
     logger.info("Graph pool borrow disabled: %s", reason)
 
@@ -57,17 +89,13 @@ def set_graph_pool_borrow_runs(runs: list[tuple[int, int]]) -> None:
     remain stable for the process lifetime. Registering an empty list disables
     borrowing.
     """
-    global _borrow_static_runs
+    state = _get_graph_pool_borrow_state()
     static_runs = sorted(runs, key=lambda run: run[1], reverse=True)[
         : BumpArenaStub.MAX_EXTENTS
     ]
     _teardown_borrow_pool()
-    _borrow_static_runs = static_runs
-    logger.info(
-        "Graph pool borrow runs pinned: runs=%d free=%d",
-        len(_borrow_static_runs),
-        sum(nbytes for _, nbytes in _borrow_static_runs),
-    )
+    state.static_runs = static_runs
+    _log_graph_pool_borrow_capacity(state.static_runs)
 
 
 def get_global_graph_memory_pool() -> Optional[Any]:
@@ -134,31 +162,32 @@ class GraphPoolPrecarve:
 
 
 def graph_pool_borrow_enabled() -> bool:
+    state = _get_graph_pool_borrow_state()
     if (
-        _borrow_disabled_reason is not None
+        state.disabled_reason is not None
         or not envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.get()
         or not is_cuda()
     ):
         return False
-    if _borrow_static_runs is not None:
-        return len(_borrow_static_runs) > 0
+    if state.static_runs is not None:
+        return len(state.static_runs) > 0
     return get_global_graph_memory_pool() is not None
 
 
 @contextmanager
 def graph_pool_user_scope(user: str) -> Iterator[None]:
-    global _active_graph_pool_user
+    state = _get_graph_pool_borrow_state()
     # Graph replay silently overwrites aliases of its allocator-free blocks.
-    if _active_graph_pool_user is not None:
+    if state.active_user is not None:
         raise RuntimeError(
-            f"graph pool already has live user {_active_graph_pool_user!r}; "
+            f"graph pool already has live user {state.active_user!r}; "
             f"cannot use it for {user!r}"
         )
-    _active_graph_pool_user = user
+    state.active_user = user
     try:
         yield
     finally:
-        _active_graph_pool_user = None
+        state.active_user = None
 
 
 @contextmanager
@@ -167,6 +196,8 @@ def graph_pool_replay_scope() -> Iterator[None]:
         yield
         return
     with graph_pool_user_scope("CUDA graph"):
+        if _get_graph_pool_borrow_state().check_pending:
+            _raise_on_live_borrows("graph replay")
         yield
 
 
@@ -205,68 +236,146 @@ def find_free_graph_pool_runs(pool_id: Any) -> list[tuple[int, int]]:
     return runs
 
 
+def graph_pool_borrow_largest_run() -> int:
+    """Largest contiguous free extent a single borrow can occupy, in bytes."""
+    if not graph_pool_borrow_enabled():
+        return 0
+    state = _get_graph_pool_borrow_state()
+    if state.static_runs is not None:
+        return state.static_runs[0][1]
+    runs = state.snapshot_free_runs(get_global_graph_memory_pool())
+    return runs[0][1] if runs else 0
+
+
+def _raise_on_live_borrows(event: str) -> None:
+    """Reject borrows that graph replay or pool teardown would overwrite."""
+    state = _get_graph_pool_borrow_state()
+    state.check_pending = False
+    if state.mem_pool is None:
+        return
+    live = sum(
+        block["size"]
+        for segment in torch.cuda.memory_snapshot(
+            state.mem_pool.id, include_traces=False
+        )
+        for block in segment["blocks"]
+        if block["state"] == "active_allocated"
+    )
+    if live:
+        raise RuntimeError(
+            f"Graph-pool borrow leak at {event}: {live} bytes still referenced"
+        )
+
+
 def _teardown_borrow_pool() -> None:
     """Retire the persistent borrow pool after draining deferred frees."""
-    global _borrow_mem_pool
-    if _borrow_mem_pool is None:
+    state = _get_graph_pool_borrow_state()
+    state.snapshot_free_runs.cache_clear()
+    if state.mem_pool is None:
         return
+    if state.check_pending:
+        _raise_on_live_borrows("borrow pool teardown")
     # Borrowed blocks that saw cross-stream use can remain in event limbo.
     # Synchronize, then drive allocator event processing before dropping the pool.
     torch.cuda.synchronize()
     torch.empty(1, device="cuda")
-    _borrow_mem_pool = None
+    state.mem_pool = None
+    state.stream = None
+
+
+_PRECARVE_MIN_RUN_BYTES = 64 << 20
+# Left uncarved per run so 2 MiB small-pool segments keep a home.
+_PRECARVE_SMALL_RESERVE_BYTES = 32 << 20
+# The caching allocator rounds large segment requests up to 2 MiB.
+_PRECARVE_GRANULARITY = 2 << 20
+
+
+def graph_pool_borrow_can_fit(nbytes: int) -> bool:
+    """Whether one free run fits the payload plus allocator padding and reserve."""
+    if nbytes <= 0:
+        return False
+    required = (
+        nbytes + _PRECARVE_GRANULARITY - 1
+    ) // _PRECARVE_GRANULARITY * _PRECARVE_GRANULARITY + _PRECARVE_SMALL_RESERVE_BYTES
+    return graph_pool_borrow_largest_run() >= required
+
+
+def _precarve_run_segments(runs: list[tuple[int, int]]) -> None:
+    """Seed coalescible segments on the stream that will allocate borrows."""
+    for _, run_bytes in runs:
+        seed = (
+            (run_bytes - _PRECARVE_SMALL_RESERVE_BYTES) // _PRECARVE_GRANULARITY
+        ) * _PRECARVE_GRANULARITY
+        if seed >= _PRECARVE_MIN_RUN_BYTES:
+            torch.empty(seed, dtype=torch.uint8, device="cuda")
 
 
 @contextmanager
 def borrow_graph_pool(user: str) -> Iterator[None]:
     """Route this thread's torch allocations onto the graph pool's free runs.
 
-    Tensors allocated inside must not survive the current step: the next graph
-    replay may overwrite their bytes. An allocation no run can hold raises the
+    All borrows must use the stream that first creates the borrow pool, so
+    the caching allocator can reuse its pre-carved segments.
+    Tensors allocated inside must be released before the next graph replay,
+    which rewrites their bytes; the next replay (or pool teardown) raises if
+    any are still referenced. An allocation no run can hold raises the
     allocator's normal OOM. This is a no-op while borrowing is disabled.
     """
-    global _borrow_stub, _borrow_mem_pool, _borrow_extents_total
-    global _largest_logged_graph_pool_borrow
+    state = _get_graph_pool_borrow_state()
     if not graph_pool_borrow_enabled():
         yield
         return
     with graph_pool_user_scope(user):
-        if _borrow_mem_pool is not None:
+        stream = torch.cuda.current_stream()
+        if state.mem_pool is not None:
+            if stream != state.stream:
+                raise RuntimeError(
+                    "Graph-pool borrow must use the stream that created the borrow pool: "
+                    f"expected {state.stream}, got {stream}"
+                )
             # Return completed cross-stream frees to the cache. The allocator
             # processes their events on a later allocation.
             torch.empty(1, device="cuda")
-            if _borrow_stub.freed_bytes:
-                # Rebuild if the caching allocator released an arena segment.
-                # A high cursor alone means the cache owns reusable segments;
-                # rebuilding discards them and can turn the next large borrow
-                # into a fragmented cold-allocation OOM.
+            if state.stub.freed_bytes:
+                # The bump arena cannot reuse segments returned by empty_cache().
                 _teardown_borrow_pool()
-        if _borrow_mem_pool is None:
-            if _borrow_stub is None:
-                _borrow_stub = BumpArenaStub()
+        if state.mem_pool is None:
+            if state.stub is None:
+                state.stub = BumpArenaStub()
                 # Runs are sorted largest first, so first fit would carve every
                 # small allocation out of the run a probability matrix needs.
-                _borrow_stub.set_best_fit(True)
-            if _borrow_static_runs is not None:
-                runs = _borrow_static_runs
+                state.stub.set_best_fit(True)
+            if state.static_runs is not None:
+                runs = state.static_runs
             else:
-                runs = find_free_graph_pool_runs(get_global_graph_memory_pool())[
+                runs = state.snapshot_free_runs(get_global_graph_memory_pool())[
                     : BumpArenaStub.MAX_EXTENTS
                 ]
-            _borrow_stub.set_extents(runs)
+            state.stub.set_extents(runs)
             # Keep one caching layer across borrows so normal block reuse and
             # stream-ordered deferred frees remain allocator-managed. Capture
             # retires it because capture changes the underlying free extents.
-            _borrow_mem_pool = torch.cuda.MemPool(_borrow_stub.allocator)
-            _borrow_extents_total = sum(run_bytes for _, run_bytes in runs)
+            state.mem_pool = torch.cuda.MemPool(state.stub.allocator)
+            state.stream = stream
+            with torch.cuda.use_mem_pool(state.mem_pool):
+                _precarve_run_segments(runs)
+            # Only growth beyond the precarve is worth another log line.
+            state.largest_logged_borrow = state.stub.cursor_bytes
+            state.extents_total = sum(run_bytes for _, run_bytes in runs)
+            _log_graph_pool_borrow_capacity(runs)
             logger.info(
-                "Graph pool borrow extents: runs=%d free=%d",
-                len(runs),
-                _borrow_extents_total,
+                "Graph pool borrow pre-carved: %.1f MiB",
+                state.stub.cursor_bytes / _MIB,
             )
-        with torch.cuda.use_mem_pool(_borrow_mem_pool):
+        with torch.cuda.use_mem_pool(state.mem_pool):
             yield
-        consumed = _borrow_stub.cursor_bytes
-        if consumed > _largest_logged_graph_pool_borrow:
-            logger.info("Graph pool borrow: consumed=%d", consumed)
-            _largest_logged_graph_pool_borrow = consumed
+        state.check_pending = True
+        consumed = state.stub.cursor_bytes
+        if consumed > state.largest_logged_borrow:
+            logger.info(
+                "Graph pool borrow high-water mark: %.1f MiB used of %.1f MiB "
+                "available",
+                consumed / _MIB,
+                state.extents_total / _MIB,
+            )
+            state.largest_logged_borrow = consumed

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -58,6 +58,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 import msgspec
 
 if TYPE_CHECKING:
+    from sglang.srt.model_executor.runner_utils.pool import GraphPoolBorrowState
     from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
@@ -607,6 +608,7 @@ class Resources(_FlagGroupBase):
     # CUDA graph memory pool shared across the prefill and decode graph
     # backends (created lazily by model_executor.runner_utils.pool).
     graph_memory_pool: Any = None
+    graph_pool_borrow: GraphPoolBorrowState | None = None
     # EPLB: per-process recorder and the publish-once location metadata
     # (owning accessors live in sglang.srt.eplb).
     expert_distribution_recorder: Any = None

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -57,6 +57,8 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import msgspec
 
+from sglang.srt.arg_groups.prefill_buffer_ceiling import prefill_buffer_ceiling_of
+
 if TYPE_CHECKING:
     from sglang.srt.model_executor.runner_utils.pool import GraphPoolBorrowState
     from sglang.srt.server_args import ServerArgs
@@ -1788,13 +1790,13 @@ def max_prefill_buffer_tokens() -> int:
     """The prefill-buffer ceiling: ``chunked_prefill_size``, except PP dynamic
     chunking can grow chunks toward ``max_prefill_tokens`` and probe at 1.25x.
 
-    Every input is a published leaf (``schedule`` plus the configured PP size),
-    so this derives from the bags and follows a post-publish override;
+    The default derives from published leaves (``schedule`` plus the configured
+    PP size), so it follows post-publish overrides;
     ``overrides.max_prefill_buffer_tokens`` is the pre-publish equivalent and
-    ``TestDerivedPredicatesAgreeAcrossTiers`` pins the two equal.
+    ``TestDerivedPredicatesAgreeAcrossTiers`` pins the two equal. Records with
+    a registered ceiling provider (see ``register_prefill_buffer_ceiling``)
+    answer through it.
     """
-    import math
-
     schedule = get_schedule()
     chunked = (
         schedule.chunked_prefill_size
@@ -1806,7 +1808,7 @@ def max_prefill_buffer_tokens() -> int:
         tokens = max(
             tokens, schedule.max_prefill_tokens or 0, math.ceil(chunked * 1.25)
         )
-    return tokens
+    return prefill_buffer_ceiling_of(get_server_args(), tokens)
 
 
 def pre_capture_activation_reserve_mb(gpu_mem: float | None) -> float:

--- a/test/registered/unit/model_executor/model_runner_components/test_startup_weight_load.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_startup_weight_load.py
@@ -17,6 +17,7 @@ maybe_stub_sgl_kernel()
 from sglang.srt.configs.device_config import DeviceConfig
 from sglang.srt.configs.load_config import LoadConfig, LoadFormat
 from sglang.srt.configs.model_config import ModelImpl
+from sglang.srt.managers.scheduler import Scheduler
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.model_executor.cuda_graph_config import Backend, CudaGraphConfig
 from sglang.srt.model_executor.model_runner import ModelRunner
@@ -728,9 +729,9 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
         reset_context()
         self.addCleanup(reset_context)
 
-    def _scheduler(self, worker, trace, *, mode, draft_worker=None):
-        from sglang.srt.managers.scheduler import Scheduler
-
+    def _scheduler(
+        self, worker, trace, *, mode, draft_worker=None, enable_overlap=True, pp_size=1
+    ):
         # The schedule reads the mode from the bags, so the test states it by
         # publishing a record rather than by standing one in.
         reset_context()
@@ -739,6 +740,8 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
             role="scheduler",
         )
         scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_overlap = enable_overlap
+        scheduler.ps = SimpleNamespace(pp_size=pp_size)
         scheduler.init_tp_model_worker = lambda: setattr(scheduler, "tp_worker", worker)
         scheduler.maybe_init_draft_worker = lambda: setattr(
             scheduler, "draft_worker", draft_worker
@@ -748,7 +751,9 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
         scheduler.init_all_cuda_graphs = lambda: trace.append("capture")
         return scheduler
 
-    def _run_startup(self, mode, *, use_draft_worker=False):
+    def _run_startup(
+        self, mode, *, use_draft_worker=False, enable_overlap=True, pp_size=1
+    ):
         trace = []
         worker = _SchedulerWorker(trace, post_capture_active=True)
         draft_worker = (
@@ -764,6 +769,8 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
             trace,
             mode=mode,
             draft_worker=draft_worker,
+            enable_overlap=enable_overlap,
+            pp_size=pp_size,
         )
 
         class StreamContext:
@@ -773,8 +780,15 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
             def __exit__(self, *_args):
                 trace.append("stream_exit")
 
+        schedule_stream = object()
+
         def stream_context(stream):
-            self.assertIs(stream, worker.model_runner.forward_stream)
+            expected_stream = (
+                worker.model_runner.forward_stream
+                if enable_overlap or pp_size > 1
+                else schedule_stream
+            )
+            self.assertIs(stream, expected_stream)
             return StreamContext()
 
         def stop_after_startup():
@@ -794,7 +808,9 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
             ),
             patch(
                 "sglang.srt.managers.scheduler.torch.get_device_module",
-                return_value=SimpleNamespace(stream=stream_context),
+                return_value=SimpleNamespace(
+                    stream=stream_context, Stream=lambda priority: schedule_stream
+                ),
             ),
             self.assertRaisesRegex(RuntimeError, "stop after startup"),
         ):
@@ -804,6 +820,13 @@ class TestStartupWeightLoadSchedulerRouting(CustomTestCase):
             draft_runners=(worker.model_runner,) if use_draft_worker else ()
         )
         return trace
+
+    def test_warmup_stream_matches_batch_execution(self):
+        for enable_overlap, pp_size in ((False, 1), (True, 1), (False, 2)):
+            with self.subTest(enable_overlap=enable_overlap, pp_size=pp_size):
+                self._run_startup(
+                    "serial", enable_overlap=enable_overlap, pp_size=pp_size
+                )
 
     def test_serial_path_skips_overlap_hooks(self):
         self.assertEqual(

--- a/test/registered/unit/model_executor/runner_utils/test_graph_pool_borrow.py
+++ b/test/registered/unit/model_executor/runner_utils/test_graph_pool_borrow.py
@@ -17,32 +17,20 @@ from sglang.srt.speculative.dflash_worker_v2 import DFlashWorkerV2
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=13, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-small")
 
 
 class TestGraphPoolBorrow(CustomTestCase):
     def setUp(self):
         super().setUp()
-        self._reset_borrow_state()
+        self.state = pool.GraphPoolBorrowState()
+        self.enterContext(pool.get_resources().override(graph_pool_borrow=self.state))
 
     def tearDown(self):
-        try:
-            if torch.cuda.is_available():
-                pool._teardown_borrow_pool()
-                torch.cuda.synchronize()
-                torch.cuda.empty_cache()
-        finally:
-            self._reset_borrow_state()
-
-    @staticmethod
-    def _reset_borrow_state():
-        pool._active_graph_pool_user = None
-        pool._borrow_stub = None
-        pool._borrow_mem_pool = None
-        pool._borrow_disabled_reason = None
-        pool._borrow_static_runs = None
-        pool._borrow_extents_total = 0
-        pool._largest_logged_graph_pool_borrow = 0
+        if torch.cuda.is_available():
+            pool._teardown_borrow_pool()
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
 
     def test_mixed_segment_runs_exclude_live_blocks(self):
         """A mixed segment's free runs are borrowable, but a returned run must
@@ -63,6 +51,50 @@ class TestGraphPoolBorrow(CustomTestCase):
             runs = pool.find_free_graph_pool_runs((0, 1))
         self.assertEqual(sorted(runs), [(0x1000, 4096), (0x3000, 4096)])
 
+    def test_free_run_snapshot_lifetime_follows_borrow_state(self):
+        runs = [{"blocks": [{"state": "inactive", "address": 0x1000, "size": 8192}]}]
+        with (
+            envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
+            patch.object(pool, "is_cuda", return_value=True),
+            patch.object(pool, "get_global_graph_memory_pool", return_value=(1, 2)),
+            patch.object(
+                pool.torch.cuda, "memory_snapshot", side_effect=[runs, [], runs]
+            ) as snapshot,
+        ):
+            self.assertEqual(pool.graph_pool_borrow_largest_run(), 8192)
+            self.assertEqual(pool.graph_pool_borrow_largest_run(), 8192)
+            snapshot.assert_called_once_with((1, 2), include_traces=False)
+            pool._teardown_borrow_pool()
+            self.assertEqual(pool.graph_pool_borrow_largest_run(), 0)
+            self.assertEqual(snapshot.call_count, 2)
+            with pool.get_resources().override(graph_pool_borrow=None):
+                self.assertEqual(pool.graph_pool_borrow_largest_run(), 8192)
+            self.assertEqual(pool.graph_pool_borrow_largest_run(), 0)
+            self.assertEqual(snapshot.call_count, 3)
+
+    def test_borrow_capacity_requires_one_padded_extent(self):
+        mib = 1 << 20
+        with (
+            envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
+            patch.object(pool, "is_cuda", return_value=True),
+            patch.object(pool, "get_global_graph_memory_pool", return_value=None),
+        ):
+            pool.set_graph_pool_borrow_runs([(0x1000, 64 * mib), (0x5000, 64 * mib)])
+            for nbytes, expected in (
+                (-1, False),
+                (0, False),
+                (1, True),
+                (32 * mib, True),
+                (32 * mib + 1, False),
+                (64 * mib, False),
+            ):
+                with self.subTest(nbytes=nbytes):
+                    self.assertEqual(pool.graph_pool_borrow_can_fit(nbytes), expected)
+            with envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(False):
+                self.assertFalse(pool.graph_pool_borrow_can_fit(1))
+            pool.set_graph_pool_borrow_runs([])
+            self.assertFalse(pool.graph_pool_borrow_can_fit(1))
+
     def test_graph_replay_fails_during_active_pool_borrow(self):
         graph = Mock()
         backend = object.__new__(FullCudaGraphBackend)
@@ -78,12 +110,11 @@ class TestGraphPoolBorrow(CustomTestCase):
         with (
             envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
             patch.object(pool, "get_global_graph_memory_pool", return_value=(1, 2)),
-            patch.object(
-                pool, "_borrow_stub", MagicMock(cursor_bytes=0, freed_bytes=0)
-            ),
-            patch.object(pool, "_borrow_mem_pool", None),
+            patch.object(self.state, "stub", MagicMock(cursor_bytes=0, freed_bytes=0)),
+            patch.object(self.state, "mem_pool", None),
             patch.object(pool.torch.cuda, "MemPool"),
             patch.object(pool.torch.cuda, "use_mem_pool"),
+            patch.object(pool.torch.cuda, "current_stream"),
             patch.object(pool.torch.cuda, "memory_snapshot", return_value=snapshot),
             pool.borrow_graph_pool(user="test"),
         ):
@@ -97,15 +128,18 @@ class TestGraphPoolBorrow(CustomTestCase):
     def test_high_cursor_keeps_reusable_cached_segments(self):
         stub = MagicMock(cursor_bytes=600, freed_bytes=0)
         mem_pool = MagicMock()
+        stream = object()
 
         with (
             patch.object(pool, "graph_pool_borrow_enabled", return_value=True),
-            patch.object(pool, "_borrow_stub", stub),
-            patch.object(pool, "_borrow_mem_pool", mem_pool),
-            patch.object(pool, "_borrow_extents_total", 1000),
+            patch.object(self.state, "stub", stub),
+            patch.object(self.state, "mem_pool", mem_pool),
+            patch.object(self.state, "stream", stream),
+            patch.object(self.state, "extents_total", 1000),
             patch.object(pool, "_teardown_borrow_pool") as teardown,
             patch.object(pool.torch, "empty"),
             patch.object(pool.torch.cuda, "use_mem_pool"),
+            patch.object(pool.torch.cuda, "current_stream", return_value=stream),
         ):
             with pool.borrow_graph_pool(user="test"):
                 pass
@@ -126,7 +160,7 @@ class TestGraphPoolBorrow(CustomTestCase):
         runs = [(0x1000, 4096), (0x2000, 8192)]
 
         def reset_static_runs():
-            pool._borrow_static_runs = None
+            self.state.static_runs = None
 
         with patch.object(
             pool, "_teardown_borrow_pool", side_effect=reset_static_runs
@@ -134,7 +168,7 @@ class TestGraphPoolBorrow(CustomTestCase):
             pool.set_graph_pool_borrow_runs(runs)
 
         teardown.assert_called_once_with()
-        self.assertEqual(pool._borrow_static_runs, [(0x2000, 8192), (0x1000, 4096)])
+        self.assertEqual(self.state.static_runs, [(0x2000, 8192), (0x1000, 4096)])
 
     def test_eagle_non_greedy_probabilities_do_not_borrow_graph_pool(self):
         def fake_sampling(**kwargs):
@@ -221,7 +255,6 @@ class TestGraphPoolBorrow(CustomTestCase):
         with (
             envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
             patch.object(pool, "get_global_graph_memory_pool", return_value=handle),
-            patch.object(pool, "_borrow_mem_pool", None),
         ):
             runs = pool.find_free_graph_pool_runs(handle)
             self.assertGreaterEqual(len(runs), 2)
@@ -253,12 +286,118 @@ class TestGraphPoolBorrow(CustomTestCase):
                 self.assertEqual(c.data_ptr(), recycled_address)
                 del b, c
 
+            self.assertEqual(self.state.stream, torch.cuda.current_stream())
+            with (
+                torch.cuda.stream(stream),
+                self.assertRaisesRegex(
+                    RuntimeError, "stream that created the borrow pool"
+                ),
+            ):
+                with pool.borrow_graph_pool(user="wrong stream"):
+                    self.fail("cross-stream borrowing must fail before allocating")
+            self.assertIsNone(self.state.active_user)
+            with pool.borrow_graph_pool(user="same stream"):
+                reused = torch.empty(40 << 20, dtype=torch.uint8, device="cuda")
+                self.assertEqual(reused.data_ptr(), recycled_address)
+                del reused
+
             # Captures retire the persistent borrow pool. Its storage aliases
             # existing graph-pool runs, so the reserved footprint is unchanged.
             pool._teardown_borrow_pool()
+            self.assertIsNone(self.state.stream)
+            with torch.cuda.stream(stream), pool.borrow_graph_pool(user="new pool"):
+                self.assertEqual(self.state.stream, stream)
+                reused = torch.empty(40 << 20, dtype=torch.uint8, device="cuda")
+                self.assertTrue(on_a_run(reused))
+                del reused
+            pool._teardown_borrow_pool()
+            with pool.graph_pool_replay_scope():
+                graph.replay()
+            torch.cuda.synchronize()
+            self.assertTrue(torch.equal(y, torch.ones_like(y)))
 
         self.assertEqual(torch.cuda.memory_reserved(device_id), reserved_before)
         del graph, y
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_borrow_recovers_from_arena_fragmentation(self):
+        handle = torch.cuda.graph_pool_handle()
+        graph = torch.cuda.CUDAGraph()
+        seed = torch.zeros(8, device="cuda")
+        stream = torch.cuda.Stream()
+        with (
+            torch.cuda.stream(stream),
+            torch.cuda.graph(graph, pool=handle, stream=stream),
+        ):
+            transient = torch.empty(200 << 20, dtype=torch.uint8, device="cuda")
+            keep = seed + 1
+            del transient
+        torch.cuda.synchronize()
+
+        address, run_bytes = pool.find_free_graph_pool_runs(handle)[0]
+        self.assertEqual(run_bytes, 200 << 20)
+        with (
+            envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
+            patch.object(pool, "get_global_graph_memory_pool", return_value=handle),
+        ):
+            # Unseeded 24/32/40 MiB segments strand 192 MiB before the 42 MiB request.
+            for rows in (1500, 2000, 2500, 2600):
+                with self.subTest(rows=rows), pool.borrow_graph_pool(user="test"):
+                    first = torch.empty(
+                        (rows, 4096), dtype=torch.float32, device="cuda"
+                    )
+                    second = torch.empty(
+                        (rows, 4096), dtype=torch.float32, device="cuda"
+                    )
+                    self.assertTrue(
+                        all(
+                            address <= tensor.data_ptr()
+                            and tensor.data_ptr() + tensor.nbytes <= address + run_bytes
+                            for tensor in (first, second)
+                        )
+                    )
+                    del first, second
+            pool._teardown_borrow_pool()
+        del graph, keep
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_replay_raises_when_borrowed_tensor_is_still_referenced(self):
+        """Reject borrowed tensors that replay would silently overwrite."""
+        handle = torch.cuda.graph_pool_handle()
+        graph = torch.cuda.CUDAGraph()
+        seed = torch.zeros(8, device="cuda")
+        stream = torch.cuda.Stream()
+        with (
+            torch.cuda.stream(stream),
+            torch.cuda.graph(graph, pool=handle, stream=stream),
+        ):
+            transient = torch.empty(48 << 20, dtype=torch.uint8, device="cuda")
+            keep = seed + 1
+            del transient
+        torch.cuda.synchronize()
+
+        with (
+            envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
+            patch.object(pool, "get_global_graph_memory_pool", return_value=handle),
+        ):
+            with pool.borrow_graph_pool(user="leaky"):
+                leaked = torch.empty(1 << 20, device="cuda")
+            with self.assertRaisesRegex(
+                RuntimeError,
+                f"graph replay: {leaked.nbytes} bytes",
+            ):
+                with pool.graph_pool_replay_scope():
+                    pass
+
+            # A fresh borrow re-arms the replay check after releasing the leak.
+            del leaked
+            with pool.borrow_graph_pool(user="clean"):
+                released = torch.empty(1 << 20, device="cuda")
+            del released
+            with pool.graph_pool_replay_scope():
+                pass
+            pool._teardown_borrow_pool()
+        del graph, keep
 
     @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
     def test_static_borrow_runs_serve_without_a_pool_snapshot(self):
@@ -281,8 +420,6 @@ class TestGraphPoolBorrow(CustomTestCase):
         with (
             envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
             patch.object(pool, "get_global_graph_memory_pool", return_value=None),
-            patch.object(pool, "_borrow_static_runs", None),
-            patch.object(pool, "_borrow_mem_pool", None),
         ):
             pool.set_graph_pool_borrow_runs(runs)
             self.assertTrue(pool.graph_pool_borrow_enabled())
@@ -295,6 +432,7 @@ class TestGraphPoolBorrow(CustomTestCase):
                     )
                 )
                 del borrowed
+            pool._teardown_borrow_pool()
 
         del graph, y
 
@@ -352,18 +490,20 @@ class TestGraphPoolBorrow(CustomTestCase):
         with (
             envs.SGLANG_ENABLE_GRAPH_POOL_BORROW.override(True),
             patch.object(pool, "get_global_graph_memory_pool", return_value=handle),
-            patch.object(pool, "_borrow_mem_pool", None),
         ):
             for _ in range(3):
                 with pool.borrow_graph_pool(user="test"):
                     borrowed = torch.empty(16 << 20, dtype=torch.uint8, device="cuda")
+                    # Stream-keyed segments allow side-stream copies, not allocations.
+                    sink = torch.empty_like(borrowed)
                     with torch.cuda.stream(side):
-                        widened = borrowed.to(torch.int32)
+                        sink.copy_(borrowed)
                     borrowed.record_stream(side)
-                    del borrowed, widened
+                    del borrowed, sink
             # Regression: this used to fail with "Trying to free a pointer not
             # allocated here" after a deferred free was re-issued too early.
             torch.cuda.empty_cache()
+            pool._teardown_borrow_pool()
 
         del graph, y
 

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -19,7 +19,9 @@ import msgspec.structs
 
 import sglang as _sglang
 import sglang.srt.server_args as server_args_module
+from sglang.srt.arg_groups import prefill_buffer_ceiling
 from sglang.srt.arg_groups.arg_utils import NS, A, Arg
+from sglang.srt.arg_groups.model_override_base import resolving_view
 from sglang.srt.arg_groups.overrides import (
     attention_backends_of,
 )
@@ -45,6 +47,7 @@ from sglang.srt.runtime_context import (
     get_flags,
     get_parallel,
     get_server_args,
+    max_prefill_buffer_tokens,
     max_speculative_num_draft_tokens,
     publish,
     publish_role,
@@ -1203,6 +1206,47 @@ class TestDerivedPredicatesAgreeAcrossTiers(_IsolatedServerArgs):
                                 max_prefill_buffer_tokens_of(args),
                                 max_prefill_buffer_tokens(),
                             )
+
+    def test_prefill_buffer_ceiling_hook_honored_across_tiers(self):
+        args = _FakeResolvedArgs(
+            chunked_prefill_size=8192,
+            enable_dynamic_chunking=True,
+            pp_size=4,
+            max_prefill_tokens=16384,
+        )
+
+        def provider(record, default_ceiling):
+            self.assertIs(record, args)
+            return default_ceiling + 5
+
+        with patch.object(prefill_buffer_ceiling, "_prefill_buffer_ceiling_fn", None):
+            register = prefill_buffer_ceiling.register_prefill_buffer_ceiling
+            self.assertEqual(max_prefill_buffer_tokens_of(args), 16384)
+            self.assertIs(register(provider), provider)
+            register(provider)
+            with self.assertRaisesRegex(RuntimeError, "already registered"):
+                register(lambda record, default_ceiling: default_ceiling)
+            for record_or_view in (args, resolving_view(args), resolved_view(args)):
+                self.assertEqual(max_prefill_buffer_tokens_of(record_or_view), 16389)
+            get_context().set_server_args(args)
+            self.assertEqual(max_prefill_buffer_tokens(), 16389)
+
+    def test_prefill_buffer_ceiling_provider_can_delegate_to_default(self):
+        custom = _FakeResolvedArgs(chunked_prefill_size=8192)
+        ordinary = _FakeResolvedArgs(chunked_prefill_size=2048)
+
+        def provider(record, default_ceiling):
+            return 4096 if record is custom else default_ceiling
+
+        with patch.object(prefill_buffer_ceiling, "_prefill_buffer_ceiling_fn", None):
+            prefill_buffer_ceiling.register_prefill_buffer_ceiling(provider)
+            for record, expected in ((custom, 4096), (ordinary, 2048)):
+                with self.subTest(expected=expected):
+                    before = dataclasses.asdict(record)
+                    self.assertEqual(max_prefill_buffer_tokens_of(record), expected)
+                    get_context().set_server_args(record)
+                    self.assertEqual(max_prefill_buffer_tokens(), expected)
+                    self.assertEqual(dataclasses.asdict(record), before)
 
     def test_activation_reserve_matches_the_member(self):
         from types import SimpleNamespace


### PR DESCRIPTION
**Problem:** Serving integrations can impose a different ceiling on prefill work. Buffer sizing needs the same policy during configuration resolution and after runtime publication.

**Fix:** Add `register_prefill_buffer_ceiling(provider)` as a narrow startup API used by both readers. The provider receives the original argument record and the computed default, so it can customize supported records and retain SGLang's policy for everything else.

**Tested:** 275 runtime/configuration/buffer tests and 303 server-argument tests passed in separate invocations. The combined invocation hits an existing test-order failure, reproduced on unchanged upstream. Pre-commit passed. Model-serving benchmarks and third-party provider integrations were not run.

Stacked on #39181 because both changes touch `runtime_context.py`. The four-file API change is shown in the [incremental diff](https://github.com/cctry/sglang/compare/oss/graph-pool-borrow-owner...oss/prefill-ceiling-registration). This draft targets `main` and includes #39181 until that prerequisite lands.

<details>
<summary>Provider contract</summary>

Register once during startup, before buffer sizing. Re-registering the same callable is harmless; a different callable raises instead of silently replacing the policy. Without a provider, both readers return the existing default.

The argument is always the original record, including when the caller supplied a resolving or resolved view. Its fields are raw inputs; providers can use `resolving_view(record)` to read resolution declarations. Providers must leave the record unchanged and apply the same sizing policy before and after publication. This keeps the extension focused on sizing without coupling the runtime to a serving integration's argument type.

Tests cover registration conflicts, record identity through both view types, agreement across publication, and returning the default for unhandled records.

</details>

<details>
<summary>Commands and actual output</summary>

With CUDA 13.0, the checkout's `python/` and `sgl-model-gateway/bindings/python/src` on `PYTHONPATH`, and `libcrypto.so.3`, `libssl.so.3`, and `libnuma.so.1` preloaded:

```bash
python -m pytest -q --disable-warnings \
  test/registered/unit/test_runtime_context.py \
  test/registered/unit/test_runtime_context_config_bags.py \
  test/registered/unit/test_runtime_context_override.py \
  test/registered/unit/test_model_overrides.py \
  test/registered/unit/model_executor/test_prefill_cuda_graph_runner_helpers.py \
  test/registered/unit/model_executor/test_cuda_graph_buffer_registry.py
python -m pytest -q --disable-warnings test/registered/unit/server_args
pre-commit run
```

```text
275 passed, 21 warnings, 190 subtests passed in 12.15s
303 passed, 22 warnings, 120 subtests passed in 42.72s
```

The following combined invocation produces the same warning-assertion failure on this branch and unchanged upstream:

```bash
python -m pytest -q --disable-warnings \
  test/registered/unit/test_runtime_context.py \
  test/registered/unit/test_runtime_context_config_bags.py \
  test/registered/unit/test_runtime_context_override.py \
  test/registered/unit/test_model_overrides.py \
  test/registered/unit/server_args \
  test/registered/unit/model_executor/test_prefill_cuda_graph_runner_helpers.py \
  test/registered/unit/model_executor/test_cuda_graph_buffer_registry.py
```

```text
1 failed, 577 passed, 22 warnings, 310 subtests passed in 46.41s
1 failed, 575 passed, 22 warnings, 308 subtests passed in 46.85s
FAILED test/registered/unit/server_args/test_server_args.py::TestMultimodalFeatureTransport::test_default_transport_is_cpu_for_unsupported_multinode_model
```

That test expects the CUDA VMM opt-in warning but sees the legacy transport deprecation warning. It also passes in isolation on both versions.

</details>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34674375832](https://github.com/sgl-project/sglang/actions/runs/34674375832)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34674375787](https://github.com/sgl-project/sglang/actions/runs/34674375787)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34674375873](https://github.com/sgl-project/sglang/actions/runs/34674375873)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->