### PR TITLE
Fix Mistral3 retaining every vision-tower layer to read one

### DIFF
--- a/python/sglang/srt/models/mistral.py
+++ b/python/sglang/srt/models/mistral.py
@@ -115,16 +115,27 @@ class Mistral3ForConditionalGeneration:
         Returns:
             torch.Tensor: features from image inputs, concatenated
         """
+        # Asking the tower for hidden states makes it build and hold one tensor
+        # per layer -- 49 of them for the single layer read here, ~1.8 GiB per
+        # 1540px image against 38 MB for the layer itself -- and they stay
+        # resident for the whole loop, so the cost scales with images in the
+        # batch. When the final layer is the one selected, request it alone:
+        # the tower returns the very tensor that would have been the last entry
+        # of that list.
+        last_layer_only = self.vision_feature_layer == -1
         features = []
         for item in items:
             # in each item, we assume pixel_values is always batched
             pixel_values, image_sizes = item.feature, item.image_sizes
-            image_outputs = self.vision_tower(
-                pixel_values, image_sizes, output_hidden_states=True
-            )
-            selected_image_feature = image_outputs.hidden_states[
-                self.vision_feature_layer
-            ]
+            if last_layer_only:
+                selected_image_feature = self.vision_tower(pixel_values, image_sizes)
+            else:
+                image_outputs = self.vision_tower(
+                    pixel_values, image_sizes, output_hidden_states=True
+                )
+                selected_image_feature = image_outputs.hidden_states[
+                    self.vision_feature_layer
+                ]
 
             if self.vision_feature_select_strategy in ["default", "patch"]:
                 selected_image_feature = selected_image_feature[:, 1:]

--- a/test/registered/unit/models/test_mistral3_vision_feature.py
+++ b/test/registered/unit/models/test_mistral3_vision_feature.py
@@ -1,0 +1,93 @@
+"""Mistral3 should not ask the vision tower for every layer to read one.
+
+The tower materialises one hidden-state tensor per layer when hidden states are
+requested and holds them for the whole item loop, which is ~49x the tensor the
+model actually consumes. These tests pin that the final-layer case takes the
+cheap path and that both paths agree.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.models.mistral import Mistral3ForConditionalGeneration
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+NUM_LAYERS = 4
+TOKENS = 3
+HIDDEN = 8
+
+get_image_feature = Mistral3ForConditionalGeneration.get_image_feature
+
+
+class RecordingTower:
+    """Stands in for PixtralVisionModel, mirroring how it answers.
+
+    ``all_hidden_states`` is the input embedding followed by one tensor per
+    layer, and the value returned when hidden states are *not* requested is the
+    last entry of that list -- the property the fix relies on.
+    """
+
+    def __init__(self):
+        torch.manual_seed(0)
+        self.layers = [torch.randn(1, TOKENS, HIDDEN) for _ in range(NUM_LAYERS + 1)]
+        self.calls = []
+
+    def __call__(self, pixel_values, image_sizes, output_hidden_states=False):
+        self.calls.append(output_hidden_states)
+        if output_hidden_states:
+            return SimpleNamespace(
+                last_hidden_state=self.layers[-1], hidden_states=list(self.layers)
+            )
+        return self.layers[-1]
+
+
+def _model(vision_feature_layer):
+    return SimpleNamespace(
+        vision_tower=RecordingTower(),
+        vision_feature_layer=vision_feature_layer,
+        vision_feature_select_strategy="full",
+        multi_modal_projector=lambda feature, image_sizes: feature,
+    )
+
+
+def _items(n):
+    return [
+        SimpleNamespace(feature=torch.zeros(1, 3, 4, 4), image_sizes=[(4, 4)])
+        for _ in range(n)
+    ]
+
+
+class TestMistral3VisionFeature(unittest.TestCase):
+    def test_final_layer_never_requests_hidden_states(self):
+        model = _model(-1)
+        get_image_feature(model, _items(3))
+        self.assertEqual(model.vision_tower.calls, [False, False, False])
+
+    def test_non_final_layer_still_requests_hidden_states(self):
+        model = _model(-2)
+        get_image_feature(model, _items(2))
+        self.assertEqual(model.vision_tower.calls, [True, True])
+
+    def test_both_paths_agree_on_the_final_layer(self):
+        # -1 through the cheap path vs NUM_LAYERS (the same tensor, reached by
+        # indexing the hidden-state list) must produce identical features.
+        cheap = get_image_feature(_model(-1), _items(2))
+        listed = get_image_feature(_model(NUM_LAYERS), _items(2))
+        self.assertTrue(torch.equal(cheap, listed))
+
+    def test_non_final_layer_selects_that_layer(self):
+        model = _model(1)
+        out = get_image_feature(model, _items(1))
+        self.assertTrue(torch.equal(out, model.vision_tower.layers[1].squeeze(0)))
+
+    def test_features_are_concatenated_per_item(self):
+        out = get_image_feature(_model(-1), _items(3))
+        self.assertEqual(out.shape, (3 * TOKENS, HIDDEN))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Serving Mistral Medium 3.5 with images OOMs inside the Pixtral vision tower minutes after a clean start, on a tiny allocation, while the KV pool looks healthy.

`get_image_feature` asks the tower for `output_hidden_states=True`, so it builds and holds one hidden-state tensor per layer — 49 of them (input embedding + 48 layers) — and they stay resident for the whole item loop. The config selects `vision_feature_layer: -1`, so exactly one of those is read. For a 1540px image that is 1.84 GiB retained per image against 38 MB for the layer itself, and the cost scales with images in the batch.

Requesting the final layer alone is the same tensor: `PixtralVisionTransformer.forward` appends to `all_hidden_states` as it goes and returns `hidden_states` when the list isn't built, so the last entry and the plain return are the same value from the same ops. Non-final `vision_feature_layer` keeps the existing path.

Measured on 4 GPUs with memory held back to emulate 80 GB cards, TP4 + EAGLE, `--mem-fraction-static 0.83 --context-length 65536`, 1540x1540 images:

- retained per image: **1.84 GiB -> 0.07 GiB**
- outputs bit-identical to before the change (text and logprobs, zero delta, 1/2/3-image requests)

| workload | before | after |
|---|---|---|
| 3 images | ok, peak pinned at 139.6 GiB | ok, 128.9 GiB |
| 4 images | 500 | ok, 129.0 GiB |
| 2 concurrent x 1 image | scheduler died | ok, 128.8 GiB |
| 2 concurrent x 4 images | scheduler died | ok, 129.2 GiB |
| 8 concurrent x 4 images | — | ok, 130.8 GiB |

Peak GPU stays flat near 129 GiB instead of pinning at the 139.8 GiB ceiling, with no config change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #35379197144](https://github.com/sgl-project/sglang/actions/runs/35379197144)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35379196090](https://github.com/sgl-project/sglang/actions/runs/35379196090)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35379198207](https://github.com/sgl-project/sglang/actions/runs/35379198207)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->