### PR TITLE
[Bugfix] Fix incorrect L3 prefetch transfer rate in sglang-simulator

### DIFF
--- a/.github/workflows/_pr-test-simulator-cpu.yml
+++ b/.github/workflows/_pr-test-simulator-cpu.yml
@@ -90,6 +90,7 @@ jobs:
           PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
           TORCH_EXTENSIONS_DIR: ${{ runner.temp }}/torch-extensions
         run: |
+          python3 -m pytest -q tools/sglang-simulator/test/test_prefetch_operations.py
           python3 -m pytest -q tools/sglang-simulator/test/test_simulation_sglang_runner.py
           python3 -m pytest -q tools/sglang-simulator/test/test_simulation_sglang_serving.py
           python3 -m pytest -q tools/sglang-simulator/test/test_simulation_cache_hit_ratio.py

--- a/tools/sglang-simulator/src/sglang_simulator/simulation/sglang/cache_controller.py
+++ b/tools/sglang-simulator/src/sglang_simulator/simulation/sglang/cache_controller.py
@@ -76,23 +76,12 @@ class C_HiCacheController(BaseHook):
                 except Empty:
                     return
 
-        def handle_prefetch_operation(self):
+        def handle_prefetch_query(self):
+            """Query storage for pending prefetch requests."""
             if not self.enable_storage:
                 return
 
-            if C_HiCacheController.KV_CACHE_BYTES is None:
-                C_HiCacheController.KV_CACHE_BYTES = ConfigManager.get_kv_cache_bytes()
-            if C_HiCacheController.DISK_READ_BANDWIDTH_BYTES is None:
-                C_HiCacheController.DISK_READ_BANDWIDTH_BYTES = (
-                    ConfigManager.get_platform_config().disk_read_bandwidth
-                )
-
-            # TODO: Overlap schedule
-            remain_dur = StateManager.get_current_inference_dur()
-
-            # Process all operations in the prefetch_queue: place those meeting
-            # the prefetch criteria into the sim_prefetch_buffer, and release the
-            # remaining operations along with any excess memory they have allocated.
+            # Process pending prefetch requests and publish storage hits.
             while not self.prefetch_queue.empty():
                 try:
                     operation = self.prefetch_queue.get(block=False)
@@ -142,6 +131,21 @@ class C_HiCacheController(BaseHook):
                         self.sim_prefetch_buffer.put(operation)
                 except Empty:
                     break
+
+        def handle_prefetch_operation(self):
+            """Advance ready transfers using the current inference duration."""
+            if not self.enable_storage:
+                return
+
+            if C_HiCacheController.KV_CACHE_BYTES is None:
+                C_HiCacheController.KV_CACHE_BYTES = ConfigManager.get_kv_cache_bytes()
+            if C_HiCacheController.DISK_READ_BANDWIDTH_BYTES is None:
+                C_HiCacheController.DISK_READ_BANDWIDTH_BYTES = (
+                    ConfigManager.get_platform_config().disk_read_bandwidth
+                )
+
+            # TODO: Overlap schedule
+            remain_dur = StateManager.get_current_inference_dur()
 
             # handle operation which not yet fully prefetched
             chunked_prefetch_operation = getattr(
@@ -269,6 +273,7 @@ class C_HiCacheController(BaseHook):
         target.prefetch_thread_func = override_prefetch_thread_func
         target.backup_thread_func = override_backup_thread_func
         target.handle_backup_operation = handle_backup_operation
+        target.handle_prefetch_query = handle_prefetch_query
         target.handle_prefetch_operation = handle_prefetch_operation
         target.append_host_mem_release = wrapped_append_host_mem_release
         target._generic_page_set = override_generic_page_set

--- a/tools/sglang-simulator/src/sglang_simulator/simulation/sglang/hiradix_cache.py
+++ b/tools/sglang-simulator/src/sglang_simulator/simulation/sglang/hiradix_cache.py
@@ -14,12 +14,11 @@ class C_HiRadixCacheHook(BaseHook):
             # The async thread for prefetching and backup in `HiCacheController` has been deprecated.
             # So we have to handle the backup or prefetch operation manually.
             self.cache_controller.handle_backup_operation()
-            self.cache_controller.handle_prefetch_operation()
+            self.cache_controller.handle_prefetch_query()
             result = original_check_hicache_events(self, *args, **kwargs)
             # Host pages are allocated after the storage query. Run the
             # simulated transfer only after that allocation step.
-            if hasattr(self.cache_controller, "prefetch_hit_queue"):
-                self.cache_controller.handle_prefetch_operation()
+            self.cache_controller.handle_prefetch_operation()
             return result
 
         target.check_hicache_events = wrapped_check_hicache_events

--- a/tools/sglang-simulator/src/sglang_simulator/simulation/sglang/unified_radix_cache.py
+++ b/tools/sglang-simulator/src/sglang_simulator/simulation/sglang/unified_radix_cache.py
@@ -12,11 +12,11 @@ class C_UnifiedRadixCacheHook(BaseHook):
     def hook(cls, target):
         original_check_hicache_events = target.check_hicache_events
 
-        def handle_pending_operations(controller):
+        def handle_pending_operations(controller, prefetch_handler_name):
             if controller is None:
                 return
             backup_handler = getattr(controller, "handle_backup_operation", None)
-            prefetch_handler = getattr(controller, "handle_prefetch_operation", None)
+            prefetch_handler = getattr(controller, prefetch_handler_name, None)
             if backup_handler is not None:
                 backup_handler()
             if prefetch_handler is not None:
@@ -24,11 +24,10 @@ class C_UnifiedRadixCacheHook(BaseHook):
 
         def wrapped_check_hicache_events(self, *args, **kwargs):
             controller = getattr(self, "cache_controller", None)
-            handle_pending_operations(controller)
+            handle_pending_operations(controller, "handle_prefetch_query")
             result = original_check_hicache_events(self, *args, **kwargs)
-            # Unified allocates host pages while draining its scheduler-side
-            # control queues. Process those newly admitted reads immediately.
-            handle_pending_operations(controller)
+            # Advance transfers once, after Unified allocates their host pages.
+            handle_pending_operations(controller, "handle_prefetch_operation")
             return result
 
         target.check_hicache_events = wrapped_check_hicache_events

--- a/tools/sglang-simulator/test/test_prefetch_operations.py
+++ b/tools/sglang-simulator/test/test_prefetch_operations.py
@@ -1,0 +1,95 @@
+"""Prefetch transfer accounting tests."""
+
+from dataclasses import dataclass
+from queue import Queue
+from typing import Optional
+
+import pytest
+from sglang_simulator.simulation.manager import StateManager
+from sglang_simulator.simulation.sglang.cache_controller import C_HiCacheController
+from sglang_simulator.simulation.sglang.hiradix_cache import C_HiRadixCacheHook
+from sglang_simulator.simulation.sglang.req_stats_manager import request_stats_manager
+from sglang_simulator.simulation.sglang.unified_radix_cache import (
+    C_UnifiedRadixCacheHook,
+)
+
+
+@dataclass
+class Operation:
+    request_id: str
+    host_indices: Optional[list[int]] = None
+    completed_tokens: float = 0
+    _terminated_flag: bool = False
+
+    def mark_terminate(self):
+        self._terminated_flag = True
+
+
+@pytest.fixture(autouse=True)
+def reset_state(monkeypatch):
+    StateManager.reset()
+    request_stats_manager.reset()
+    monkeypatch.setattr(C_HiCacheController, "KV_CACHE_BYTES", 1)
+    monkeypatch.setattr(C_HiCacheController, "DISK_READ_BANDWIDTH_BYTES", 1000)
+    yield
+    StateManager.reset()
+    request_stats_manager.reset()
+
+
+def make_cache(hook):
+    class Controller:
+        def __init__(self):
+            self.enable_storage = True
+            self.page_size = 1
+            self.prefetch_threshold = 1
+            self.prefetch_queue = Queue()
+            self.prefetch_hit_queue = Queue()
+            self.backup_queue = Queue()
+            self.ack_backup_queue = Queue()
+            self.backup_skip = False
+
+        def _storage_hit_query(self, operation):
+            return [f"page{i}" for i in range(1024)], 1024
+
+        def terminate_prefetch(self, operation):
+            operation.mark_terminate()
+            return operation.completed_tokens, operation.hash_value
+
+        def append_host_mem_release(self, host_indices):
+            pass
+
+        def _page_backup(self, operation):
+            pass
+
+    C_HiCacheController.hook(Controller)
+
+    class Cache:
+        def __init__(self):
+            self.cache_controller = Controller()
+
+        def check_hicache_events(self):
+            controller = self.cache_controller
+            while not controller.prefetch_hit_queue.empty():
+                operation = controller.prefetch_hit_queue.get_nowait()
+                operation.host_indices = list(range(operation.storage_hit_count))
+                controller.prefetch_buffer.put(operation)
+
+    hook.hook(Cache)
+    return Cache()
+
+
+@pytest.mark.parametrize("hook", [C_HiRadixCacheHook, C_UnifiedRadixCacheHook])
+def test_partial_transfer_advances_once_per_cache_poll(hook):
+    cache = make_cache(hook)
+    operation = Operation("request")
+    cache.cache_controller.prefetch_queue.put(operation)
+
+    StateManager.set_current_inference_dur(0.064)
+    cache.check_hicache_events()
+    assert operation.completed_tokens == 64
+
+    StateManager.step_global_clock(0.010)
+    StateManager.set_current_inference_dur(0.010)
+    cache.check_hicache_events()
+
+    assert operation.completed_tokens == pytest.approx(74)


### PR DESCRIPTION
## Motivation

The simulator model  L3 prefetches at approximately twice the configured rate in both HiRadixCache and UnifiedRadixCache. Their cache-event wrappers call handle_prefetch_operation() twice within the same simulated time interval, causing both calls to credit transfer progress using the same time budget. In an end-to-end UnifiedRadixCache test, a synthetic 1,024-token KV transfer configured at 1,000 KV tokens/s completes in 0.515 simulated seconds instead of the required 1.024 seconds. This underestimates prefetch latency and can overestimate performance for workloads that depend on L3 prefetching.

## Modifications

- Decouple storage queries from handle_prefetch_operation() into handle_prefetch_query(), giving each function a clear responsibility.
- Update the HiRadix and Unified cache hooks to query storage before cache bookkeeping and advance transfers once afterward.
- Add a unit test for both hooks to verify that partial transfers consume one time budget per cache poll.
- Include the unit test in simulator CPU CI.

## Accuracy Tests

Model accuracy testing is not applicable because this change only affects simulator timing accounting.

CPU regression tests passed for both HiRadix and Unified cache hooks:

```text
tools/sglang-simulator/test/test_prefetch_operations.py
2 passed
```

Existing simulator tests for paged decoding and cache-tier reuse also passed:

```text
test_simulation_sglang_runner.py
test_simulation_cache_hit_ratio.py::test_in_process_runner_reports_each_cache_tier
2 passed
```

## Speed Tests and Profiling

This change corrects simulated L3 transfer time.

| Configured rate | KV tokens | Required time | Before | After |
| --- | ---: | ---: | ---: | ---: |
| 1,000 KV tokens/s | 1,024 | 1.024 s | 0.515 s | 1.025 s |
| 500 KV tokens/s | 1,024 | 2.048 s | 1.025 s | 2.050 s |

Each measured request had no initial device or host cache hits and fetched 1,024 KV tokens from storage.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation is not required for this internal accounting correction.
- [x] Provide relevant validation results above; model accuracy testing is not applicable.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34676649500](https://github.com/sgl-project/sglang/actions/runs/34676649500)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34676649279](https://github.com/sgl-project/sglang/actions/runs/34676649279)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->