### PR TITLE
[Cookbook] Kimi-K3: keep DCP under HiCache L1+L2 with DSPARK

### DIFF
--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
@@ -283,7 +283,8 @@ Pending update...
 
 K3's hybrid HiCache tiers the paged MLA KV **and** the KDA/mamba state across L1 (GPU) / L2 (host) / L3 (Mooncake) — enable it from the **HiCache** card in the [Playground above](#playground) for long multi-turn workloads.
 
-- On the DCP recipes (Blackwell Balanced / High-Throughput, in both the `Unified` and `Decode` roles), the host tiers are not fully DCP-aware yet: **L3 always, and L1+L2 with Spec Decode on, drop the DCP flags** (the command hints call it out — per-request KV capacity shrinks accordingly). L1+L2 with Spec Decode off keeps DCP. Only DCP goes: the MLA KV reverts to TP-replicated, but the cell's other parallelism stays, so B300/GB300/GB200 land on plain TP while B200 Unified keeps its `--pp-size 2` / `--ep-size`.
+- On the DCP recipes (Blackwell Balanced / High-Throughput, `Unified` and `Decode` roles), **L1+L2 keeps DCP**, with Spec Decode off or on DSPARK. On B200 the DSPARK pipeline collapse scales it too (PP2 × DCPEP8 → DCPEP16).
+- **L3 drops the DCP flags** on those recipes (storage keys are not dcp_rank-aware yet; the command hints call it out, and per-request KV capacity shrinks). Only DCP goes: the MLA KV reverts to TP-replicated while the cell's other parallelism stays, so B300/GB300/GB200 land on plain TP and B200 Unified keeps its `--pp-size 2` / `--ep-size`.
 - Low-Latency and the Hopper recipes take all tiers unchanged.
 
 <a id="pd-disaggregation" />

--- a/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
+++ b/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
@@ -81,7 +81,7 @@ export const config = {
       const [hw, pdMode] = k.split("|");
       return {
         when: { hw: [hw], pdMode: [pdMode], strategy: [...strategies],
-                hicache: ["l2"], spec: ["none"] },
+                hicache: ["l2"], spec: ["none", "dspark"] },
         reason: "This recipe runs DCP, and a storage backend (L3) under DCP is rejected at startup. Switch HiCache to L3 in the Deploy panel (that drops DCP), or stay on L1+L2.",
       };
     });
@@ -115,10 +115,8 @@ export const config = {
     const cell = config.cellFor(s);
     const pp = config.sizeOf(cell, "--pp-size");
     const out = [`--tp-size ${config.sizeOf(cell, "--tp-size") * pp}`];
-    // HiCache under DCP rejects speculative decoding, so when a host tier is on
-    // the DCP half is dropped instead of scaled (the HiCache options' own
-    // stripPrefixes reach cell flags only, never these overlay flags).
-    if (config.flagOf(cell, "--dcp-size") && s.hicache !== "l2" && s.hicache !== "l3") {
+    // L3 rejects DCP at startup, so under L3 the DCP half is dropped, not scaled.
+    if (config.flagOf(cell, "--dcp-size") && s.hicache !== "l3") {
       out.push(`--dcp-size ${config.sizeOf(cell, "--dcp-size") * pp}`);
     }
     if (config.flagOf(cell, "--ep-size")) {
@@ -355,26 +353,17 @@ export const config = {
           flags: [
             "--enable-hierarchical-cache",
           ],
-          // L1/L2 host tiering IS supported under DCP, so DCP stays — except with
-          // speculative decoding, which HiCache under DCP rejects at startup (the
-          // draft host pool has no DCP index translation). There the DCP operating
-          // point is dropped instead of blocking the option, same as L3 does. The
-          // ratio calculator reads --dcp-size off this command, so dropping it also
-          // re-solves --mamba-full-memory-ratio for the plain-TP shape.
-          //
-          // Which cells carry DCP is read off the cells themselves, so adding or
-          // reshaping a DCP recipe needs no edit here.
           stripPrefixes: (s) =>
-            s.spec !== "none" && config.hasDcp(s)
+            !["none", "dspark"].includes(s.spec) && config.hasDcp(s)
               ? ["--dcp-size", "--dcp-comm-backend"]
               : [],
           hints: (s) =>
-            s.spec !== "none" && config.hasDcp(s)
+            !["none", "dspark"].includes(s.spec) && config.hasDcp(s)
               ? [
-                  "HiCache under DCP rejects speculative decoding, so this recipe drops DCP",
-                  "and serves the MLA KV TP-replicated (any PP/EP in the cell stays).",
-                  "Per-request context is far shorter than the DCP",
-                  "version — DCP is what buys KV capacity. Run the cell NOSPEC to keep DCP.",
+                  "HiCache under DCP only accepts DSPARK speculative decoding, so this",
+                  "recipe drops DCP and serves the MLA KV TP-replicated (any PP/EP in the",
+                  "cell stays). Per-request context is far shorter than the DCP version —",
+                  "DCP is what buys KV capacity. Run the cell NOSPEC or DSPARK to keep DCP.",
                 ]
               : [],
         },
@@ -976,10 +965,6 @@ export const config = {
               {
                 when: { hicache: ["l3"] },
                 reason: "L3 storage keys are not dcp_rank-aware, so DCP and L3 cannot run together. Use Peak Throughput, or switch HiCache to L1+L2.",
-              },
-              {
-                when: { hicache: ["l2"], spec: ["dspark"] },
-                reason: "HiCache under DCP rejects speculative decoding, so this preset cannot add DCP here. Use Peak Throughput, or run the cell NOSPEC.",
               },
             ],
             env: ["SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=20480"],


### PR DESCRIPTION
## Motivation

HiCache under DCP accepts DSPARK speculative decoding since #35221 (`resolve_hicache_dcp_compatibility` now only rejects L3 storage backends, non-DSPARK draft paths, LMCache, HiSparse, and non-MLA models). The Kimi-K3 cookbook still described the older gate, so on the DCP cells (Blackwell Balanced / High-Throughput) selecting DSPARK + HiCache L1+L2 stripped `--dcp-size` and emitted a "HiCache under DCP rejects speculative decoding" hint. Example: https://docs.sglang.io/cookbook/autoregressive/Moonshotai/Kimi-K3#hw=b300&pdMode=unified&strategy=balanced&quant=mxfp4&mmTransport=auto&spec=dspark&hicache=l2

## Modifications

`docs/src/snippets/configs/moonshotai/kimi-k3.jsx`
- The L1+L2 Deploy option keeps `--dcp-size` / `--dcp-comm-backend` for NOSPEC and DSPARK. Only a non-DSPARK draft path still drops DCP, with the hint reworded to match the engine error (DFLASH is not selectable today, so the branch is dormant).
- `specCollapsedFlags` scales DCP with the pipeline under L1+L2 as well (B200: PP2 x DCPEP8 -> TP16 / DCP16 / EP16). L3 still drops the DCP half.
- The playground storage-backend chips (File / Mooncake / HF3FS / NiXL) gate `spec: dspark` alongside `none` under L1+L2, since DCP is standing there now and L3 through that card would otherwise be reachable.
- The Peak Capacity (+DCP8) preset drops its "L1+L2 + DSPARK cannot add DCP" disable rule. The L3 rule stays.

`docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx`
- Section 3.3 HiCache: split the DCP bullet into "L1+L2 keeps DCP, Spec Decode off or DSPARK" and "L3 drops the DCP flags".

Verified by importing the config in node and rendering with `mint dev`: the linked B300 cell now emits `--dcp-size 8` with `--speculative-algorithm DSPARK` and `--enable-hierarchical-cache`, with no rejection hint, and the Mamba ratio calculator picks up DCP 8. B200 High-Throughput DSPARK collapses to TP16 / DCP16 / EP16 under L1+L2 and TP16 / EP16 under L3.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34677040466](https://github.com/sgl-project/sglang/actions/runs/34677040466)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34677040064](https://github.com/sgl-project/sglang/actions/runs/34677040064)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->