### PR TITLE
[CI] Extend DeepGEMM SM90 test timeout to four hours

### DIFF
--- a/.github/workflows/release-whl-deepgemm.yml
+++ b/.github/workflows/release-whl-deepgemm.yml
@@ -100,7 +100,7 @@ jobs:
           - arch_label: sm90
             runner: 8-gpu-h200
             wheel_arch: x86_64
-            timeout: 120
+            timeout: 240
           - arch_label: sm100
             runner: 8-gpu-b200
             wheel_arch: x86_64


### PR DESCRIPTION
## Motivation

The [SM90 DeepGEMM release test job](https://github.com/sgl-project/sglang/actions/runs/34671666208/job/103494284675) was canceled after exceeding its two-hour execution limit.

## Modifications

Increase the H200/SM90 test job timeout from 120 to 240 minutes, matching the B200 and GB300 entries.

## Accuracy Tests

- Workflow syntax/expressions checked with actionlint and the existing custom runner labels configured.
- `pre-commit run --files .github/workflows/release-whl-deepgemm.yml` and `git diff --check`.
- Full GPU suite not rerun for this timeout-only change.

## Speed Tests and Profiling

Not applicable: CI timeout configuration only.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34678337253](https://github.com/sgl-project/sglang/actions/runs/34678337253)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34678337132](https://github.com/sgl-project/sglang/actions/runs/34678337132)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->