### PR TITLE
[PD][MORI] Transfer DCP-replicated DSPARK draft KV

### DIFF
--- a/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
+++ b/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
@@ -56,11 +56,12 @@ def handle_pd_disaggregation(server_args: ServerArgs) -> None:
         if cfg.disaggregation_transfer_backend not in (
             "mooncake",
             "nixl",
+            "mori",
             "fake",
         ):
             raise ValueError(
                 "PD decode DCP requires --disaggregation-transfer-backend "
-                "mooncake, nixl, or fake for synthetic benchmarking, got "
+                "mooncake, nixl, mori, or fake for synthetic benchmarking, got "
                 f"{cfg.disaggregation_transfer_backend!r}."
             )
         if cfg.disaggregation_decode_enable_radix_cache:

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -112,6 +112,7 @@ class BaseKVManager(ABC):
     """Base class for managing transfer states"""
 
     enable_deferred_decode_kv_release: bool = False
+    requires_strict_deferred_release: bool = False
 
     @abstractmethod
     def __init__(

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -6,6 +6,7 @@ import dataclasses
 import logging
 import threading
 import time
+import uuid
 from collections import defaultdict
 from typing import Dict, List, Optional, Set, Tuple, Union
 
@@ -255,7 +256,11 @@ class CommonKVManager(BaseKVManager):
             self.transfer_infos = {}
             # Deferred KV release: aborted room -> (decode_ip, decode_port);
             # ack held until the transfer drains.
-            self._deferred_ack_targets: Dict[int, Tuple[str, int]] = {}
+            self._deferred_ack_targets: Dict[
+                int, Set[Tuple[str, int, Optional[str]]]
+            ] = {}
+            self._deferred_ack_lock = threading.Lock()
+            self._deferred_ack_retry_rooms: Set[int] = set()
             self.req_to_decode_prefix_len: Dict[int, int] = {}
             self.decode_kv_args_table = {}
             self.pp_group = get_pp_group()
@@ -278,7 +283,10 @@ class CommonKVManager(BaseKVManager):
             # Deferred KV release: room -> prefill ranks that acked their transfer
             # drained. Entry exists only while the room is held, so a stale/late
             # ack for a reused bootstrap_room is dropped.
-            self._deferred_abort_ack_tracker: Dict[int, Set[int]] = {}
+            self._deferred_abort_ack_tracker: Dict[
+                Tuple[int, Optional[str]], Set[int]
+            ] = {}
+            self._deferred_abort_lock = threading.Lock()
             # Heartbeat interval should be at least 2 seconds
             self.heartbeat_interval = max(
                 envs.SGLANG_DISAGGREGATION_HEARTBEAT_INTERVAL.get(), 2.0
@@ -451,6 +459,14 @@ class CommonKVManager(BaseKVManager):
             parts.insert(0, self.kv_status_msg_tag)
         return parts
 
+    def _snapshot_kv_status_extra_frames(
+        self,
+        bootstrap_room: int,
+        targets: List[Tuple[str, int]],
+    ) -> Dict[Tuple[str, int], List[bytes]]:
+        """Snapshot backend-specific status frames before publishing terminal state."""
+        return {}
+
     def parse_kv_status_message(
         self, msg: List[bytes]
     ) -> Optional[Tuple[int, int, int, Optional[str]]]:
@@ -485,16 +501,23 @@ class CommonKVManager(BaseKVManager):
         bootstrap_room: int,
         status: KVPoll,
         failure_reason: Optional[str] = None,
+        target_extra_frames: Optional[Dict[Tuple[str, int], List[bytes]]] = None,
     ) -> None:
         """Push of a terminal transfer status to decode endpoints."""
         if not targets:
             return
-        parts = self._encode_kv_status_message(
+        base_parts = self._encode_kv_status_message(
             bootstrap_room=bootstrap_room,
             status=status,
             failure_reason=failure_reason,
         )
         for endpoint, dst_port in targets:
+            extra_frames = (
+                target_extra_frames.get((endpoint, dst_port), [])
+                if target_extra_frames is not None
+                else []
+            )
+            parts = base_parts + extra_frames
             na = NetworkAddress(endpoint, dst_port)
             try:
                 self._send_multipart_locked(na.to_tcp(), parts, is_ipv6=na.is_ipv6)
@@ -542,12 +565,16 @@ class CommonKVManager(BaseKVManager):
 
         if targets is None:
             targets = self._room_notify_targets(bootstrap_room)
+        target_extra_frames = self._snapshot_kv_status_extra_frames(
+            bootstrap_room, targets
+        )
         self.update_status(bootstrap_room, status)
         self.send_kv_status_message(
             targets=targets,
             bootstrap_room=bootstrap_room,
             status=status,
             failure_reason=failure_reason,
+            target_extra_frames=target_extra_frames,
         )
         return status
 
@@ -620,27 +647,48 @@ class CommonKVManager(BaseKVManager):
             prefill_rank,
         )
 
-    def register_deferred_abort_room(self, bootstrap_room: int) -> None:
-        """Arm drain-ack accounting for a held room; a fresh set wipes stale acks
-        from a prior request that reused this bootstrap_room."""
-        self._deferred_abort_ack_tracker[bootstrap_room] = set()
+    def register_deferred_abort_room(
+        self, bootstrap_room: int, generation: Optional[str] = None
+    ) -> None:
+        """Arm generation-scoped drain-ack accounting for a held room."""
+        with self._deferred_abort_lock:
+            self._deferred_abort_ack_tracker[(bootstrap_room, generation)] = set()
 
-    def note_abort_ack(self, bootstrap_room: int, prefill_rank: int) -> None:
+    def note_abort_ack(
+        self,
+        bootstrap_room: int,
+        prefill_rank: int,
+        generation: Optional[str] = None,
+    ) -> None:
         """Record a prefill rank's drain ack (decode receiver thread). Only counts
         while the room is held; grabs the set by reference to avoid racing clear."""
-        acks = self._deferred_abort_ack_tracker.get(bootstrap_room)
-        if acks is not None:
-            acks.add(prefill_rank)
+        with self._deferred_abort_lock:
+            acks = self._deferred_abort_ack_tracker.get((bootstrap_room, generation))
+            if acks is not None:
+                acks.add(prefill_rank)
 
-    def is_abort_release_safe(self, bootstrap_room: int, required_acks: int) -> bool:
+    def is_abort_release_safe(
+        self,
+        bootstrap_room: int,
+        required_acks: int,
+        generation: Optional[str] = None,
+    ) -> bool:
         """True once every prefill rank that could still write these pages has acked."""
-        return (
-            len(self._deferred_abort_ack_tracker.get(bootstrap_room, ()))
-            >= required_acks
-        )
+        with self._deferred_abort_lock:
+            return (
+                len(
+                    self._deferred_abort_ack_tracker.get(
+                        (bootstrap_room, generation), ()
+                    )
+                )
+                >= required_acks
+            )
 
-    def clear_deferred_abort_state(self, bootstrap_room: int) -> None:
-        self._deferred_abort_ack_tracker.pop(bootstrap_room, None)
+    def clear_deferred_abort_state(
+        self, bootstrap_room: int, generation: Optional[str] = None
+    ) -> None:
+        with self._deferred_abort_lock:
+            self._deferred_abort_ack_tracker.pop((bootstrap_room, generation), None)
 
     def _prefill_unique_rank(self) -> int:
         """Stable per-sender id, matching what the transfer worker syncs on Success."""
@@ -650,38 +698,84 @@ class CommonKVManager(BaseKVManager):
             + self.attn_cp_rank
         )
 
-    def _send_abort_ack(self, decode_ip: str, decode_port: int, room: int) -> None:
+    def _send_abort_ack(
+        self,
+        decode_ip: str,
+        decode_port: int,
+        room: int,
+        generation: Optional[str] = None,
+    ) -> bool:
         """Best-effort ack that this rank's transfer for an aborted room drained."""
         try:
             na = NetworkAddress(decode_ip, decode_port)
-            self._send_multipart_locked(
-                na.to_tcp(),
-                [
-                    b"ABORT_ACK",
-                    str(room).encode("ascii"),
-                    str(self._prefill_unique_rank()).encode("ascii"),
-                ],
-                is_ipv6=na.is_ipv6,
-            )
+            frames = [
+                b"ABORT_ACK",
+                str(room).encode("ascii"),
+                str(self._prefill_unique_rank()).encode("ascii"),
+            ]
+            if generation is not None:
+                frames.append(generation.encode("ascii"))
+            self._send_multipart_locked(na.to_tcp(), frames, is_ipv6=na.is_ipv6)
+            return True
         except Exception as e:
             logger.debug(f"Failed to send drained ABORT_ACK for room {room}: {e}")
+            return False
 
     def _maybe_ack_drained_abort(self, room: int) -> None:
         """Send the deferred ack once an aborted room's chunks have drained
         (outstanding == 0). pop() makes it fire at most once."""
-        if self._staging_outstanding.get(room, 0) > 0:
-            return
-        target = self._deferred_ack_targets.pop(room, None)
-        if target is not None:
-            self._send_abort_ack(target[0], target[1], room)
+        with self._deferred_ack_lock:
+            if self._staging_outstanding.get(room, 0) > 0:
+                return
+            targets = set(self._deferred_ack_targets.get(room, ()))
+        failed_targets = set()
+        for target in targets:
+            sent = self._send_abort_ack(target[0], target[1], room, target[2])
+            if sent is False:
+                failed_targets.add(target)
+        if targets:
+            with self._deferred_ack_lock:
+                current_targets = self._deferred_ack_targets.get(room)
+                if current_targets is not None:
+                    current_targets.difference_update(targets - failed_targets)
+                    if not current_targets:
+                        self._deferred_ack_targets.pop(room, None)
+                    self._deferred_ack_retry_rooms.discard(room)
+        if failed_targets:
+            self._schedule_abort_ack_retry(room)
+
+    def _schedule_abort_ack_retry(self, room: int) -> None:
+        with self._deferred_ack_lock:
+            if (
+                room not in self._deferred_ack_targets
+                or room in self._deferred_ack_retry_rooms
+            ):
+                return
+            self._deferred_ack_retry_rooms.add(room)
+
+        def retry() -> None:
+            with self._deferred_ack_lock:
+                self._deferred_ack_retry_rooms.discard(room)
+            self._maybe_ack_drained_abort(room)
+
+        timer = threading.Timer(1.0, retry)
+        timer.daemon = True
+        timer.start()
 
     def register_deferred_ack_target(
-        self, room: int, decode_ip: str, decode_port: int
+        self,
+        room: int,
+        decode_ip: str,
+        decode_port: int,
+        generation: Optional[str] = None,
     ) -> None:
         """Hold this room's ack until its transfer drains. Callers must mark the
         room Failed FIRST -- registering while it still accepts chunks lets the
         worker ack, then a new chunk writes pages the decode already released."""
-        self._deferred_ack_targets[room] = (decode_ip, decode_port)
+        with self._deferred_ack_lock:
+            self._deferred_ack_targets.setdefault(room, set()).add(
+                (decode_ip, decode_port, generation)
+            )
 
     def get_kv_replica_factor(self) -> int:
         if self._kv_replica_factor is None:
@@ -1571,9 +1665,12 @@ class CommonKVSender(BaseKVSender):
         if hasattr(self.kv_mgr, "transfer_infos"):
             self.kv_mgr.transfer_infos.pop(self.bootstrap_room, None)
         if hasattr(self.kv_mgr, "_deferred_ack_targets"):
-            # Drop a held ack target if the room concluded without draining
-            # (e.g. aborted before any chunk enqueued); else it leaks on prefill.
-            self.kv_mgr._deferred_ack_targets.pop(self.bootstrap_room, None)
+            if hasattr(self.kv_mgr, "_staging_outstanding"):
+                # Send rather than discard a pending drain acknowledgement when
+                # clear races the worker's final outstanding decrement.
+                self.kv_mgr._maybe_ack_drained_abort(self.bootstrap_room)
+            else:
+                self.kv_mgr._deferred_ack_targets.pop(self.bootstrap_room, None)
 
     def abort(self):
         self.kv_mgr.record_failure(
@@ -1604,6 +1701,11 @@ class CommonKVReceiver(BaseKVReceiver):
         self.require_staging: bool = False
         self.init_time: Optional[float] = None
         self.abort_notified: bool = False
+        self.abort_generation = uuid.uuid4().hex
+        self._abort_pending_infos: Optional[Dict[Tuple, Dict]] = None
+        self._abort_retry_lock = threading.Lock()
+        self._abort_retry_scheduled = False
+        self._abort_retry_stopped = False
         self._connection_pool_entries: Dict[str, List[Dict]] = {}
         self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].add(self.bootstrap_room)
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Bootstrapping)
@@ -1842,11 +1944,13 @@ class CommonKVReceiver(BaseKVReceiver):
             and hasattr(self, "bootstrap_infos")
             and self.bootstrap_infos is not None
         ):
-            self._send_abort_notification()
-            self.abort_notified = True
+            self.ensure_abort_notified_for_drain()
         return KVPoll.Failed
 
     def clear(self) -> None:
+        with self._abort_retry_lock:
+            self._abort_retry_stopped = True
+            self._abort_pending_infos = {}
         self.kv_mgr.request_status.pop(self.bootstrap_room, None)
         self.kv_mgr.required_prefill_response_num_table.pop(self.bootstrap_room, None)
         self.kv_mgr.prefill_response_tracker.pop(self.bootstrap_room, None)
@@ -1866,31 +1970,110 @@ class CommonKVReceiver(BaseKVReceiver):
             and hasattr(self, "bootstrap_infos")
             and self.bootstrap_infos is not None
         ):
-            self._send_abort_notification()
+            self.ensure_abort_notified_for_drain()
+
+    def ensure_abort_notified_for_drain(self) -> bool:
+        if not hasattr(self, "bootstrap_infos") or self.bootstrap_infos is None:
+            return False
+        strict = getattr(self.kv_mgr, "requires_strict_deferred_release", False)
+        with self._abort_retry_lock:
+            if self._abort_retry_stopped:
+                return False
+        if not self.abort_notified:
+            if self.kv_mgr.enable_deferred_decode_kv_release:
+                self.kv_mgr.register_deferred_abort_room(
+                    self.bootstrap_room,
+                    self.abort_generation if strict else None,
+                )
             self.abort_notified = True
+        self._send_abort_notification()
+        return True
 
     def _send_abort_notification(self):
-        for bootstrap_info in self.bootstrap_infos:
+        strict = getattr(self.kv_mgr, "requires_strict_deferred_release", False)
+        if strict and self.kv_mgr.is_abort_release_safe(
+            self.bootstrap_room,
+            len(self.bootstrap_infos),
+            self.abort_generation,
+        ):
+            with self._abort_retry_lock:
+                self._abort_pending_infos = {}
+            return
+
+        pending_infos = getattr(self, "_abort_pending_infos", None)
+        infos = (
+            list(self.bootstrap_infos)
+            if strict or pending_infos is None
+            else list(pending_infos.values())
+        )
+        failed_infos = {}
+        for bootstrap_info in infos:
+            key = (
+                bootstrap_info.get("rank_ip"),
+                bootstrap_info.get("rank_port"),
+                bootstrap_info.get("pp_rank"),
+            )
             # Best-effort notification to prefill side that this request was aborted.
             try:
                 sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
+                frames = [
+                    b"ABORT",
+                    str(self.bootstrap_room).encode("ascii"),
+                    self.kv_mgr.local_ip.encode("ascii"),
+                    str(self.kv_mgr.rank_port).encode("ascii"),
+                ]
+                if strict:
+                    frames.append(self.abort_generation.encode("ascii"))
                 with lock:
-                    sock.send_multipart(
-                        [
-                            b"ABORT",
-                            str(self.bootstrap_room).encode("ascii"),
-                            self.kv_mgr.local_ip.encode("ascii"),
-                            str(self.kv_mgr.rank_port).encode("ascii"),
-                        ]
-                    )
+                    sock.send_multipart(frames)
                 logger.debug(
                     f"Sent abort notification for room {self.bootstrap_room} "
                     f"to {bootstrap_info.get('rank_ip', 'unknown')}:{bootstrap_info.get('rank_port', 'unknown')}"
                 )
             except Exception as e:
+                failed_infos[key] = bootstrap_info
                 logger.debug(
                     f"Failed to send abort notification for room {self.bootstrap_room}: {e}"
                 )
+        with self._abort_retry_lock:
+            if self._abort_retry_stopped:
+                self._abort_pending_infos = {}
+                return
+            self._abort_pending_infos = (
+                {
+                    (
+                        info.get("rank_ip"),
+                        info.get("rank_port"),
+                        info.get("pp_rank"),
+                    ): info
+                    for info in self.bootstrap_infos
+                }
+                if strict
+                else failed_infos
+            )
+        if strict or failed_infos:
+            self._schedule_abort_notification_retry()
+
+    def _schedule_abort_notification_retry(self) -> None:
+        with self._abort_retry_lock:
+            if (
+                self._abort_retry_stopped
+                or self._abort_retry_scheduled
+                or not self._abort_pending_infos
+            ):
+                return
+            self._abort_retry_scheduled = True
+
+        def retry() -> None:
+            with self._abort_retry_lock:
+                self._abort_retry_scheduled = False
+                if self._abort_retry_stopped:
+                    return
+            self._send_abort_notification()
+
+        timer = threading.Timer(1.0, retry)
+        timer.daemon = True
+        timer.start()
 
 
 class CommonKVBootstrapServer(BaseKVBootstrapServer):

--- a/python/sglang/srt/disaggregation/common/dcp_pack.py
+++ b/python/sglang/srt/disaggregation/common/dcp_pack.py
@@ -98,9 +98,11 @@ def dcp_pack_buffer_bytes_for_args(kv_args, dcp_size: int) -> int:
     max_tokens = max_prefill_buffer_tokens()
     if max_tokens <= 0:
         max_tokens = get_schedule().max_prefill_tokens
-    return dcp_pack_buffer_bytes(
-        kv_args.kv_item_lens, kv_args.page_size, max_tokens, dcp_size
-    )
+    kv_item_lens = kv_args.kv_item_lens
+    num_draft_entries = getattr(kv_args, "num_draft_entries", 0)
+    if num_draft_entries > 0:
+        kv_item_lens = kv_item_lens[: len(kv_item_lens) - num_draft_entries]
+    return dcp_pack_buffer_bytes(kv_item_lens, kv_args.page_size, max_tokens, dcp_size)
 
 
 def init_dcp_pack_buffers(

--- a/python/sglang/srt/disaggregation/common/dcp_pack.py
+++ b/python/sglang/srt/disaggregation/common/dcp_pack.py
@@ -43,6 +43,7 @@ def try_pack_dcp_src(
     src_token_indices: npt.NDArray[np.integer],
     token_item_lens: Sequence[int],
     pack_offset_bytes: int = 0,
+    pack_limit_bytes: Optional[int] = None,
 ) -> Optional[Tuple[List[int], npt.NDArray[np.int64]]]:
     if pack_offset_bytes < 0:
         raise ValueError(
@@ -54,13 +55,23 @@ def try_pack_dcp_src(
         return [], empty
     required = n * sum(int(item_len) for item_len in token_item_lens)
     required_end = pack_offset_bytes + required
-    if not pack_buffer.fits(required_end):
+    available_end = (
+        pack_buffer.get_size()
+        if pack_limit_bytes is None
+        else min(pack_limit_bytes, pack_buffer.get_size())
+    )
+    if pack_offset_bytes > available_end:
+        raise ValueError(
+            "pack_offset_bytes exceeds the selected pack region: "
+            f"offset={pack_offset_bytes}, limit={available_end}"
+        )
+    if required_end > available_end:
         logger.warning(
             "PD DCP pack buffer too small for byte range [%s, %s) (have %s); "
             "falling back to per-token RDMA",
             pack_offset_bytes,
             required_end,
-            pack_buffer.get_size(),
+            available_end,
         )
         return None
 
@@ -83,11 +94,21 @@ def try_pack_dcp_src(
     return packed_ptrs, np.arange(n, dtype=np.int64)
 
 
+def dcp_pack_buffer_bytes_for_args(kv_args, dcp_size: int) -> int:
+    max_tokens = max_prefill_buffer_tokens()
+    if max_tokens <= 0:
+        max_tokens = get_schedule().max_prefill_tokens
+    return dcp_pack_buffer_bytes(
+        kv_args.kv_item_lens, kv_args.page_size, max_tokens, dcp_size
+    )
+
+
 def init_dcp_pack_buffers(
     register_fn,
     kv_args,
     count: int,
     dcp_size: int,
+    min_size_bytes: int = 0,
 ) -> List[StagingBuffer]:
     from sglang.srt.disaggregation.common.staging_handler import (
         _get_custom_mem_pool,
@@ -102,8 +123,9 @@ def init_dcp_pack_buffers(
     # Note(kpham-sgl): size = dcp_size x ceil(max_tokens / dcp_size)
     # x sum(per-layer token bytes). At 32,768 tokens and 61 MLA layers
     # x 576 bf16 dims x 2 B: 2.14 GiB/buffer, 8.58 GiB for 4 queues.
-    size_bytes = dcp_pack_buffer_bytes(
-        kv_item_lens, kv_args.page_size, max_tokens, dcp_size
+    size_bytes = max(
+        dcp_pack_buffer_bytes(kv_item_lens, kv_args.page_size, max_tokens, dcp_size),
+        min_size_bytes,
     )
     gpu_id = kv_args.gpu_id
     device = f"cuda:{gpu_id}"

--- a/python/sglang/srt/disaggregation/common/utils.py
+++ b/python/sglang/srt/disaggregation/common/utils.py
@@ -34,6 +34,8 @@ class TransferKVChunk:
     staging_counted: bool = False
     # Mori early-send: CUDA event to synchronize before RDMA (optional).
     wait_event: Optional[object] = None
+    # Backend-local ownership token used to isolate a reused bootstrap room.
+    room_owner: Optional[str] = None
 
 
 def pack_list_of_buffers(buffers: List[bytes]) -> bytes:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -37,7 +37,11 @@ from sglang.srt.configs.mamba_utils import Mamba2CacheParams
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.disaggregation.base.conn import StateType
-from sglang.srt.disaggregation.common.conn import CommonKVManager, CommonKVReceiver
+from sglang.srt.disaggregation.common.conn import (
+    CommonKVManager,
+    CommonKVReceiver,
+    KVTransferError,
+)
 from sglang.srt.disaggregation.decode_hicache_mixin import (
     DecodeHiCachePreallocMixin,
     DecodeHiCacheTransferMixin,
@@ -415,6 +419,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 "(e.g. GQA, MHA). MLA models should not set this flag."
             )
         self.kv_manager = self._init_kv_manager()
+        self.transfer_queue.configure_deferred_release(self.kv_manager)
         if self.enable_staging:
             self.transfer_queue._init_staging_handler(self.kv_manager)
 
@@ -656,9 +661,22 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             req.retraction_mb_id = None
             self.retracted_queue.append(req)
         else:
-            decode_req = self._create_receiver_and_enqueue(
-                req, is_rebootstrap=is_rebootstrap
-            )
+            try:
+                decode_req = self._create_receiver_and_enqueue(
+                    req, is_rebootstrap=is_rebootstrap
+                )
+            except KVTransferError as exc:
+                error_message = f"Decode bootstrap rejected request: {exc}"
+                logger.error(error_message)
+                prepare_abort(
+                    req,
+                    error_message,
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                )
+                self.scheduler.output_streamer.stream_output([req], req.return_logprob)
+                if self.scheduler.metrics_reporter.enable_metrics:
+                    self.scheduler.metrics_collector.increment_bootstrap_failed_reqs()
+                return
 
             # NOTE: fake transfer does not need to resolve prefill dp rank in the pending queue
             if _is_fake_transfer(req):
@@ -722,11 +740,17 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         )
         kv_receiver_class = get_kv_class(backend, KVClassType.RECEIVER)
 
-        kv_receiver = kv_receiver_class(
+        receiver_kwargs = dict(
             mgr=self.kv_manager,
             bootstrap_addr=_bootstrap_addr(req),
             bootstrap_room=req.bootstrap_room,
         )
+        if backend == TransferBackend.MORI:
+            request_epoch = getattr(req, "disagg_request_epoch", None)
+            if is_rebootstrap and request_epoch is not None:
+                request_epoch = f"{request_epoch}:{req.retraction_count}"
+            receiver_kwargs["request_epoch"] = request_epoch
+        kv_receiver = kv_receiver_class(**receiver_kwargs)
 
         decode_req = DecodeRequest(
             req=req, kv_receiver=kv_receiver, is_rebootstrap=is_rebootstrap
@@ -2091,15 +2115,24 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         self.enable_deferred_kv_release = (
             envs.SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE.get()
         )
+        self.strict_deferred_kv_release = False
         self.deferred_kv_release_timeout = (
             envs.SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE_TIMEOUT.get()
         )
         # Aborted-mid-transfer requests whose KV pages/slot are held until drained
-        # or timed out. Entries: (decode_req, deadline, metadata_idx, required_acks).
-        self._deferred_releases: List[Tuple[DecodeRequest, float, int, int]] = []
+        # or timed out. Entries contain the request generation so room reuse
+        # cannot merge acknowledgements from distinct request incarnations.
+        self._deferred_releases: List[
+            Tuple[DecodeRequest, float, int, int, Optional[str]]
+        ] = []
 
     def add(self, decode_req: DecodeRequest) -> None:
         self.queue.append(decode_req)
+
+    def configure_deferred_release(self, kv_manager: CommonKVManager) -> None:
+        if kv_manager.requires_strict_deferred_release:
+            self.enable_deferred_kv_release = True
+            self.strict_deferred_kv_release = True
 
     def extend(self, decode_reqs: List[DecodeRequest]) -> None:
         self.queue.extend(decode_reqs)
@@ -2340,6 +2373,14 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 poll == KVPoll.Failed
                 or hicache_restore_status == HiCacheRestoreResult.FAILED
             ):
+                ensure_abort = getattr(
+                    decode_req.kv_receiver, "ensure_abort_notified_for_drain", None
+                )
+                if (
+                    getattr(self, "strict_deferred_kv_release", False)
+                    and ensure_abort is not None
+                ):
+                    ensure_abort()
                 error_message = (
                     f"Decode transfer failed for request rank={self.tp_rank} "
                     f"{decode_req.req.rid=} {decode_req.req.bootstrap_room=}"
@@ -2446,15 +2487,35 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         return transferred_reqs
 
     def _defer_release(self, decode_req: DecodeRequest) -> None:
-        deadline = time.monotonic() + self.deferred_kv_release_timeout
+        deadline = (
+            float("inf")
+            if self.strict_deferred_kv_release
+            else time.monotonic() + self.deferred_kv_release_timeout
+        )
         # Require an ack from every notified prefill rank (dummy-proof). Snapshot
         # now -- the receiver may be cleared by resolve time.
         required_acks = len(decode_req.kv_receiver.bootstrap_infos)
+        generation = (
+            decode_req.kv_receiver.abort_generation
+            if self.strict_deferred_kv_release
+            else None
+        )
         self._deferred_releases.append(
-            (decode_req, deadline, decode_req.metadata_buffer_index, required_acks)
+            (
+                decode_req,
+                deadline,
+                decode_req.metadata_buffer_index,
+                required_acks,
+                generation,
+            )
         )
 
-    def _do_release(self, decode_req: DecodeRequest, idx: int) -> None:
+    def _do_release(
+        self,
+        decode_req: DecodeRequest,
+        idx: int,
+        generation: Optional[str],
+    ) -> None:
         room = decode_req.req.bootstrap_room
         if self.enable_staging and self.staging_handler.is_staging_room(room):
             self.staging_handler.unregister_decode_req(room)
@@ -2462,7 +2523,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         release_kv_cache(decode_req.req, self.tree_cache, is_insert=False)
         self.metadata_buffers.bootstrap_room[idx] = 0
         self.req_to_metadata_buffer_idx_allocator.free(idx)
-        decode_req.kv_receiver.kv_mgr.clear_deferred_abort_state(room)
+        decode_req.kv_receiver.kv_mgr.clear_deferred_abort_state(room, generation)
         decode_req.kv_receiver.clear()
         decode_req.kv_receiver = None
 
@@ -2477,18 +2538,26 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         now = time.monotonic()
         still_held = []
         to_release = []
-        for decode_req, deadline, idx, required_acks in self._deferred_releases:
+        for (
+            decode_req,
+            deadline,
+            idx,
+            required_acks,
+            generation,
+        ) in self._deferred_releases:
             room = decode_req.req.bootstrap_room
             kv_mgr = decode_req.kv_receiver.kv_mgr
-            drained = kv_mgr.is_abort_release_safe(room, required_acks)
+            drained = kv_mgr.is_abort_release_safe(room, required_acks, generation)
             if not drained and now < deadline:
-                still_held.append((decode_req, deadline, idx, required_acks))
+                still_held.append(
+                    (decode_req, deadline, idx, required_acks, generation)
+                )
             else:
-                to_release.append((decode_req, idx, room, drained))
+                to_release.append((decode_req, idx, room, generation, drained))
         # Commit the survivors before releasing so a _do_release exception can't
         # leave a released entry in the list (double-free / None receiver on retry).
         self._deferred_releases = still_held
-        for decode_req, idx, room, drained in to_release:
+        for decode_req, idx, room, generation, drained in to_release:
             if not drained:
                 logger.warning(
                     f"Deferred KV release for room {room} timed out after "
@@ -2496,16 +2565,19 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                     f"ack from prefill; releasing anyway."
                 )
             try:
-                self._do_release(decode_req, idx)
+                self._do_release(decode_req, idx, generation)
             except Exception:
                 # Isolate a failed release so the rest still run; entry already dropped.
                 logger.exception(f"Deferred KV release failed for room {room}")
 
     def release_memory_occupation(self):
         """Clean up in-flight transfers before releasing GPU memory."""
+        if self._deferred_releases:
+            raise RuntimeError(
+                "Cannot release decode KV memory while deferred transfer "
+                "drain acknowledgements are pending"
+            )
         self.queue.clear()
-        # Pool is being torn down; drop held entries without per-request release.
-        self._deferred_releases.clear()
 
     def resume_memory_occupation(self):
         """Queues are already cleared on release; new transfers can be accepted."""

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -1813,9 +1813,7 @@ class MoriKVManager(CommonKVManager):
         status_sink: Optional[List[TransferStatus]] = None,
     ) -> List[TransferStatus]:
         statuses = status_sink if status_sink is not None else []
-        if getattr(self.kv_args, "num_draft_entries", 0):
-            raise RuntimeError("MORI DCP1-to-DCP-N draft KV transfer is not supported")
-        if plan.target_src_token_indices.size == 0:
+        if plan.empty():
             return statuses
         if (
             peer_info.dcp_dst_region_indices is None
@@ -1838,15 +1836,32 @@ class MoriKVManager(CommonKVManager):
                 f"item_lens={len(peer_info.dcp_token_item_lens)}"
             )
 
+        num_draft = getattr(self.kv_args, "num_draft_entries", 0)
+        num_target = len(self.kv_mem_descs) - num_draft
+        if num_target < 0:
+            raise RuntimeError(
+                f"MORI DCP has num_draft_entries={num_draft} but only "
+                f"{len(self.kv_mem_descs)} KV regions"
+            )
+
         self._submit_dcp_part(
-            self.kv_mem_descs,
-            dst_descs,
-            peer_info.dcp_token_item_lens,
+            self.kv_mem_descs[:num_target],
+            dst_descs[:num_target],
+            peer_info.dcp_token_item_lens[:num_target],
             plan.target_src_token_indices,
             plan.target_dst_token_indices,
             statuses,
             packed_src=packed_src,
         )
+        if num_draft:
+            self._submit_dcp_part(
+                self.kv_mem_descs[num_target:],
+                dst_descs[num_target:],
+                peer_info.dcp_token_item_lens[num_target:],
+                plan.draft_src_token_indices,
+                plan.draft_dst_token_indices,
+                statuses,
+            )
         return statuses
 
     def _pack_dcp_rank_once(
@@ -1859,6 +1874,9 @@ class MoriKVManager(CommonKVManager):
         rank = peer_info.dst_dcp_rank
         token_item_lens = peer_info.dcp_token_item_lens
         assert token_item_lens is not None
+        num_draft = getattr(self.kv_args, "num_draft_entries", 0)
+        num_target = len(self.kv_args.kv_data_ptrs) - num_draft
+        token_item_lens = token_item_lens[:num_target]
         signature = (
             peer_info.dst_dcp_size,
             tuple(token_item_lens),
@@ -1884,7 +1902,7 @@ class MoriKVManager(CommonKVManager):
         rank_stride = pack_buffer.get_size() // peer_info.dst_dcp_size
         packed = try_pack_dcp_src(
             pack_buffer=pack_buffer,
-            kv_data_ptrs=self.kv_args.kv_data_ptrs,
+            kv_data_ptrs=self.kv_args.kv_data_ptrs[:num_target],
             src_token_indices=src_token_indices,
             token_item_lens=token_item_lens,
             pack_offset_bytes=rank * rank_stride,

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -7,7 +7,8 @@ import struct
 import threading
 import time
 import uuid
-from typing import List, Optional
+from collections import defaultdict
+from typing import Dict, List, Optional, Tuple
 
 import msgspec
 import numpy as np
@@ -34,6 +35,7 @@ from sglang.srt.disaggregation.common.conn import (
     CommonKVSender,
     KVTransferError,
 )
+from sglang.srt.disaggregation.common.staging_buffer import StagingBuffer
 from sglang.srt.disaggregation.common.utils import (
     AuxDataCodec,
     DCPTokenTransferPlan,
@@ -56,6 +58,11 @@ from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
 logger = logging.getLogger(__name__)
 MORI_GUARD = b"MoriMsgGuard"
 MORI_DCP_GUARD = b"MoriDCPMsgGuard"
+MORI_DCP_DRAIN_GUARD = b"MoriDCPDrainV1"
+MORI_DCP_REGISTER_ACK = b"MoriDCPRegisterAck"
+MORI_DCP_MIN_PACK_BUFFER_BYTES = 32 * 1024 * 1024
+MORI_DCP_REGISTRATION_TIMEOUT_SECONDS = 30.0
+MORI_ABORT_TOMBSTONE_LIMIT = 65536
 _TAG_ABORT = b"ABORT"
 
 
@@ -133,6 +140,7 @@ class TransferInfo:
     # populate this field (older receiver or radix-cache feature off) -> treat
     # as 0 (no prefix hit, full send) for backward compatibility.
     decode_prefix_len: Optional[int] = None
+    abort_generation: Optional[str] = None
 
     @classmethod
     def from_zmq(cls, payload: List[bytes]) -> TransferInfo:
@@ -164,6 +172,9 @@ class TransferInfo:
             decode_prefix_len: Optional[int] = int(payload[8].decode("ascii"))
         else:
             decode_prefix_len = None
+        abort_generation = (
+            payload[9].decode("ascii") if len(payload) > 9 and payload[9] else None
+        )
 
         # A transfer is "dummy" only when the receiver does not need any
         # kv/aux/state delivered. When decode_prefix_len > 0 and the delta is
@@ -183,6 +194,7 @@ class TransferInfo:
             required_dst_info_num=required_dst_info_num,
             is_dummy=is_dummy,
             decode_prefix_len=decode_prefix_len,
+            abort_generation=abort_generation,
         )
 
 
@@ -204,6 +216,8 @@ class KVArgsRegisterInfo:
     dst_kv_layer_ids: List[int] = dataclasses.field(default_factory=list)
     dst_dcp_size: int = 1
     dst_dcp_rank: int = 0
+    dcp_registration_id: Optional[str] = None
+    supports_dcp_drain: bool = False
     requires_dcp_relayout: bool = False
     dcp_token_item_lens: Optional[List[int]] = None
     dcp_dst_region_indices: Optional[List[int]] = None
@@ -274,6 +288,11 @@ class KVArgsRegisterInfo:
                 if len(payload) > 16 and payload[16]
                 else 0
             ),
+            dcp_registration_id=(
+                payload[17].decode("ascii")
+                if len(payload) > 17 and payload[17]
+                else None
+            ),
         )
 
 
@@ -326,6 +345,25 @@ class BatchTransferPlan:
 
 
 @dataclasses.dataclass(frozen=True)
+class MoriPackedDCPSource:
+    mem_desc: MemoryDesc
+    layer_offsets: List[int]
+    token_indices: npt.NDArray[np.int64]
+
+
+@dataclasses.dataclass(frozen=True)
+class MoriPackedDCPRank:
+    signature: Tuple[int, Tuple[int, ...], str, bytes]
+    source: Optional[MoriPackedDCPSource]
+
+
+class MoriKVSubmissionError(RuntimeError):
+    def __init__(self, statuses: List[TransferStatus], cause: Exception):
+        super().__init__(f"MORI KV transfer submission failed: {cause}")
+        self.statuses = statuses
+
+
+@dataclasses.dataclass(frozen=True)
 class TransferTarget:
     info: TransferInfo
     peer_info: KVArgsRegisterInfo
@@ -347,11 +385,21 @@ class MoriKVManager(CommonKVManager):
         is_mla_backend: Optional[bool] = False,
     ):
         super().__init__(args, disaggregation_mode, server_args, is_mla_backend)
+        self.requires_strict_deferred_release = (
+            disaggregation_mode == DisaggregationMode.DECODE and self.dcp_size > 1
+        )
+        if self.requires_strict_deferred_release:
+            self.enable_deferred_decode_kv_release = True
         self.engine = self._init_engine()
         self.engine_desc = self.engine.get_engine_desc()
         self.kv_mem_descs: List[MemoryDesc] = []
         self.aux_mem_descs: List[MemoryDesc] = []
         self.state_mem_descs: List[List[MemoryDesc]] = []
+        self._dcp_pack_mem_descs: Dict[int, MemoryDesc] = {}
+        self._dcp_pack_init_lock = threading.Lock()
+        self._dcp_pack_dcp_size: Optional[int] = None
+        self._dcp_pack_worker_count = 0
+        self._dcp_pack_disabled_workers: set[int] = set()
         self.transfer_lock = threading.Lock()
         self._zmq_ctx = zmq.Context()
         self._socket_local = threading.local()
@@ -364,10 +412,18 @@ class MoriKVManager(CommonKVManager):
             ]
             self._wait_poll_ms = envs.SGLANG_MORI_WAIT_POLL_MS.get()
             self._transfer_timeout_ms = envs.SGLANG_MORI_TRANSFER_TIMEOUT_MS.get()
+            self._staging_outstanding = defaultdict(int)
+            self._rooms_pending_clear: Dict[int, str] = {}
+            self._room_generations: Dict[int, str] = {}
+            self._room_owners: Dict[int, str] = {}
+            self._retired_room_status: Dict[Tuple[int, str], KVPoll] = {}
+            self._retired_room_failures: Dict[Tuple[int, str], str] = {}
+            self._aborted_generations: Dict[Tuple[int, str], None] = {}
+            self._room_lifecycle_lock = threading.Lock()
             for shard, queue in enumerate(self._transfer_queues):
                 threading.Thread(
                     target=self._transfer_worker,
-                    args=(queue,),
+                    args=(queue, shard),
                     daemon=True,
                     name=(
                         f"mori-xfer-dp{self.system_dp_rank}-"
@@ -376,6 +432,9 @@ class MoriKVManager(CommonKVManager):
                 ).start()
             self._start_bootstrap_thread()
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
+            self._decode_room_generations: Dict[int, str] = {}
+            self._dcp_registration_lock = threading.Lock()
+            self._dcp_registration_events: Dict[str, threading.Event] = {}
             self._start_decode_thread()
             self._start_heartbeat_checker_thread()
 
@@ -457,11 +516,281 @@ class MoriKVManager(CommonKVManager):
                 component_descs.append(desc)
             self.state_mem_descs.append(component_descs)
 
-    def _transfer_worker(self, queue: FastQueue) -> None:
+    def _register_staging_memory(self, ptr: int, size: int) -> None:
+        self._dcp_pack_mem_descs[ptr] = self.engine.register_memory(
+            ptr,
+            size,
+            self.kv_args.gpu_id,
+            MemoryLocationType.GPU,
+        )
+
+    def _init_dcp_pack_buffers_once(self, dcp_size: int) -> None:
+        with self._dcp_pack_init_lock:
+            if self._dcp_pack_dcp_size is not None:
+                if self._dcp_pack_dcp_size != dcp_size:
+                    raise RuntimeError(
+                        "MORI DCP peers must use one dcp_size per manager, got "
+                        f"{self._dcp_pack_dcp_size} and {dcp_size}"
+                    )
+                return
+            if not self.kv_args.kv_item_lens:
+                return
+
+            from sglang.srt.disaggregation.common.dcp_pack import (
+                dcp_pack_buffer_bytes_for_args,
+            )
+
+            buffer_bytes = max(
+                dcp_pack_buffer_bytes_for_args(self.kv_args, dcp_size),
+                MORI_DCP_MIN_PACK_BUFFER_BYTES,
+            )
+            budget_bytes = int(
+                envs.SGLANG_MORI_DCP_PACK_BUFFER_BUDGET_GB.get() * 1024 * 1024 * 1024
+            )
+            self._dcp_pack_dcp_size = dcp_size
+            self._dcp_pack_worker_count = max(
+                0,
+                min(
+                    self._num_shards,
+                    budget_bytes // buffer_bytes,
+                ),
+            )
+            self._dcp_pack_buffers = [None] * self._num_shards
+            if self._dcp_pack_worker_count == 0:
+                logger.warning(
+                    "MORI DCP pack buffer needs %.1f MB but budget is %.1f MB; "
+                    "using per-token RDMA",
+                    buffer_bytes / (1024 * 1024),
+                    budget_bytes / (1024 * 1024),
+                )
+            else:
+                logger.info(
+                    "MORI DCP packing configured for %d/%d workers: %.1f MB "
+                    "per buffer, %.1f MB budget",
+                    self._dcp_pack_worker_count,
+                    self._num_shards,
+                    buffer_bytes / (1024 * 1024),
+                    budget_bytes / (1024 * 1024),
+                )
+
+    def _get_or_init_dcp_pack_buffer(
+        self, worker_index: int
+    ) -> Optional[StagingBuffer]:
+        if (
+            self._dcp_pack_buffers is None
+            or worker_index >= self._dcp_pack_worker_count
+            or worker_index in self._dcp_pack_disabled_workers
+        ):
+            return None
+        pack_buffer = self._dcp_pack_buffers[worker_index]
+        if pack_buffer is not None:
+            return pack_buffer
+
+        with self._dcp_pack_init_lock:
+            pack_buffer = self._dcp_pack_buffers[worker_index]
+            if pack_buffer is not None:
+                return pack_buffer
+            try:
+                from sglang.srt.disaggregation.common.dcp_pack import (
+                    init_dcp_pack_buffers,
+                )
+
+                dcp_size = self._dcp_pack_dcp_size
+                if dcp_size is None:
+                    return None
+                pack_buffer = init_dcp_pack_buffers(
+                    self._register_staging_memory,
+                    self.kv_args,
+                    1,
+                    dcp_size,
+                    min_size_bytes=MORI_DCP_MIN_PACK_BUFFER_BYTES,
+                )[0]
+                self._dcp_pack_buffers[worker_index] = pack_buffer
+                return pack_buffer
+            except Exception:
+                self._dcp_pack_disabled_workers.add(worker_index)
+                logger.exception(
+                    "MORI DCP pack allocation failed for worker %d; using "
+                    "per-token RDMA",
+                    worker_index,
+                )
+                return None
+
+    def _retire_room_locked(self, room: int, owner: str) -> None:
+        if self._room_owners.get(room) != owner:
+            return
+        status = self.request_status.pop(room, KVPoll.Failed)
+        if status not in (KVPoll.Success, KVPoll.Failed):
+            status = KVPoll.Failed
+        self._retired_room_status[(room, owner)] = status
+        failure_reason = self.failure_records.pop(room, None)
+        if failure_reason is not None:
+            self._retired_room_failures[(room, owner)] = failure_reason
+        self.req_to_decode_prefix_len.pop(room, None)
+        self.transfer_infos.pop(room, None)
+        self._room_generations.pop(room, None)
+        self._room_owners.pop(room, None)
+
+    def activate_room_owner(self, room: int, owner: str) -> None:
+        with self._room_lifecycle_lock:
+            with self.failure_lock:
+                with self.transfer_lock:
+                    with self._deferred_ack_lock:
+                        old_owner = self._room_owners.get(room)
+                        if old_owner is not None and old_owner != owner:
+                            old_status = self.request_status.get(room)
+                            if self._staging_outstanding.get(
+                                room, 0
+                            ) > 0 or old_status not in (KVPoll.Success, KVPoll.Failed):
+                                raise KVTransferError(
+                                    room,
+                                    f"Cannot reuse active MORI bootstrap room {room}",
+                                )
+                            self._retire_room_locked(room, old_owner)
+
+                        self._room_owners[room] = owner
+                        self._room_generations.pop(room, None)
+                        self.req_to_decode_prefix_len.pop(room, None)
+                        self.failure_records.pop(room, None)
+
+                        infos = self.transfer_infos.get(room, {})
+                        generations = {
+                            info.abort_generation
+                            for info in infos.values()
+                            if info.abort_generation is not None
+                        }
+                        if len(generations) > 1:
+                            self.transfer_infos.pop(room, None)
+                            self.request_status[room] = KVPoll.Failed
+                            self.failure_records[room] = (
+                                "MORI decode ranks supplied inconsistent request epochs"
+                            )
+                            return
+
+                        generation = next(iter(generations), None)
+                        if generation is not None:
+                            self._room_generations[room] = generation
+                        if (
+                            generation is not None
+                            and (
+                                room,
+                                generation,
+                            )
+                            in self._aborted_generations
+                        ):
+                            self.transfer_infos.pop(room, None)
+                            self.request_status[room] = KVPoll.Failed
+                            self.failure_records[room] = (
+                                "MORI request was aborted before the prefill sender activated"
+                            )
+                        elif infos:
+                            ready = (
+                                len(infos)
+                                >= next(iter(infos.values())).required_dst_info_num
+                            )
+                            self.request_status[room] = (
+                                KVPoll.WaitingForInput
+                                if ready
+                                else KVPoll.Bootstrapping
+                            )
+                        else:
+                            self.request_status[room] = KVPoll.Bootstrapping
+                        if generation is not None:
+                            self._aborted_generations = {
+                                entry: None
+                                for entry in self._aborted_generations
+                                if entry[0] != room
+                            }
+
+    def check_room_owner_status(self, room: int, owner: str) -> KVPoll:
+        with self.transfer_lock:
+            if self._room_owners.get(room) == owner:
+                return self.request_status.get(room, KVPoll.Failed)
+            return self._retired_room_status.get((room, owner), KVPoll.Failed)
+
+    def pop_room_owner_failure(self, room: int, owner: str) -> Optional[str]:
+        with self.failure_lock:
+            with self.transfer_lock:
+                if self._room_owners.get(room) == owner:
+                    return self.failure_records.pop(room, None)
+                return self._retired_room_failures.pop((room, owner), None)
+
+    def clear_room_owner(self, room: int, owner: str) -> None:
+        with self._room_lifecycle_lock:
+            with self.failure_lock:
+                with self.transfer_lock:
+                    if self._room_owners.get(room) == owner:
+                        self._retire_room_locked(room, owner)
+                    self._retired_room_status.pop((room, owner), None)
+                    self._retired_room_failures.pop((room, owner), None)
+
+    def _snapshot_kv_status_extra_frames(
+        self,
+        bootstrap_room: int,
+        targets: List[Tuple[str, int]],
+    ) -> Dict[Tuple[str, int], List[bytes]]:
+        with self.transfer_lock:
+            generation = self._room_generations.get(bootstrap_room)
+        if generation is None:
+            return {}
+        generation_frame = generation.encode("ascii")
+        return {target: [generation_frame] for target in targets}
+
+    @staticmethod
+    def _status_targets(infos: List[TransferInfo]) -> List[Tuple[str, int]]:
+        targets: List[Tuple[str, int]] = []
+        for info in infos:
+            if info.is_dummy:
+                continue
+            target = (info.endpoint, info.dst_port)
+            if target not in targets:
+                targets.append(target)
+        return targets
+
+    def _conclude_owned_transfer(
+        self,
+        room: int,
+        status: KVPoll,
+        room_owner: Optional[str],
+        failure_reason: Optional[str] = None,
+        target_infos: Optional[List[TransferInfo]] = None,
+    ) -> Optional[KVPoll]:
+        with self._room_lifecycle_lock:
+            with self.transfer_lock:
+                if room_owner is not None and self._room_owners.get(room) != room_owner:
+                    return None
+                infos = (
+                    list(self.transfer_infos.get(room, {}).values())
+                    if target_infos is None
+                    else target_infos
+                )
+            return super().conclude_transfer(
+                bootstrap_room=room,
+                status=status,
+                targets=self._status_targets(infos),
+                failure_reason=failure_reason,
+            )
+
+    def _conclude_owned_failure(
+        self,
+        room: int,
+        failure_reason: str,
+        room_owner: Optional[str],
+    ) -> Optional[KVPoll]:
+        return self._conclude_owned_transfer(
+            room,
+            KVPoll.Failed,
+            room_owner,
+            failure_reason=failure_reason,
+        )
+
+    def _transfer_worker(self, queue: FastQueue, worker_index: int) -> None:
         while True:
             kv_chunk = queue.get()
+            room = kv_chunk.room
+            success_infos: Optional[List[TransferInfo]] = None
             try:
-                self._process_transfer_chunk(kv_chunk)
+                success_infos = self._process_transfer_chunk(kv_chunk, worker_index)
             except Exception as exc:
                 failure_reason = f"transfer worker raised: {exc!r}"
                 try:
@@ -472,8 +801,8 @@ class MoriKVManager(CommonKVManager):
                 except Exception:
                     pass
                 try:
-                    self.conclude_failure(
-                        bootstrap_room=kv_chunk.room, failure_reason=failure_reason
+                    self._conclude_owned_failure(
+                        kv_chunk.room, failure_reason, kv_chunk.room_owner
                     )
                 except Exception:
                     try:
@@ -483,46 +812,122 @@ class MoriKVManager(CommonKVManager):
                         )
                     except Exception:
                         pass
+            finally:
+                with self._deferred_ack_lock:
+                    self._staging_outstanding[room] -= 1
+                    drained = self._staging_outstanding[room] <= 0
+                if success_infos is not None:
+                    self._conclude_owned_transfer(
+                        room,
+                        KVPoll.Success,
+                        kv_chunk.room_owner,
+                        target_infos=success_infos,
+                    )
+                if self.enable_deferred_decode_kv_release:
+                    self._maybe_ack_drained_abort(room)
+                if drained:
+                    with self._deferred_ack_lock:
+                        if self._staging_outstanding.get(room, 0) <= 0:
+                            self._staging_outstanding.pop(room, None)
+                    self._clear_room_after_drain(room)
 
-    def _process_transfer_chunk(self, kv_chunk: TransferKVChunk) -> None:
+    def _maybe_ack_drained_abort(self, room: int) -> None:
+        with self._room_lifecycle_lock:
+            with self.failure_lock:
+                with self.transfer_lock:
+                    with self._deferred_ack_lock:
+                        if self._staging_outstanding.get(room, 0) <= 0:
+                            owner = self._room_owners.get(room)
+                            expected_generation = self._room_generations.get(room)
+                            targets = self._deferred_ack_targets.get(room, ())
+                            has_matching_target = any(
+                                target[2] == expected_generation for target in targets
+                            )
+                            if (
+                                owner is not None
+                                and self.request_status.get(room) == KVPoll.Failed
+                                and has_matching_target
+                            ):
+                                self._retire_room_locked(room, owner)
+        super()._maybe_ack_drained_abort(room)
+
+    def _defer_room_clear_if_outstanding(
+        self, room: int, owner: Optional[str] = None
+    ) -> bool:
+        with self.transfer_lock:
+            if owner is not None and self._room_owners.get(room) != owner:
+                return False
+            with self._deferred_ack_lock:
+                if self._staging_outstanding.get(room, 0) <= 0:
+                    return False
+                if owner is not None:
+                    self._rooms_pending_clear[room] = owner
+            self.update_status(room, KVPoll.Failed)
+            return True
+
+    def _clear_room_after_drain(self, room: int) -> None:
+        with self._room_lifecycle_lock:
+            with self.failure_lock:
+                with self.transfer_lock:
+                    with self._deferred_ack_lock:
+                        owner = self._rooms_pending_clear.get(room)
+                        if self._staging_outstanding.get(room, 0) > 0 or owner is None:
+                            return
+                        self._rooms_pending_clear.pop(room, None)
+                        if self._room_owners.get(room) == owner:
+                            self._retire_room_locked(room, owner)
+                        self._retired_room_status.pop((room, owner), None)
+                        self._retired_room_failures.pop((room, owner), None)
+
+    def _process_transfer_chunk(
+        self, kv_chunk: TransferKVChunk, worker_index: int = 0
+    ) -> Optional[List[TransferInfo]]:
         room = kv_chunk.room
-        if self._should_skip_transfer(room):
+        room_owner = kv_chunk.room_owner
+        if self._should_skip_transfer(room, room_owner):
             return
 
         if kv_chunk.wait_event is not None:
             kv_chunk.wait_event.synchronize()
 
-        if self._should_skip_transfer(room):
+        if self._should_skip_transfer(room, room_owner):
             return
 
-        statuses = self._submit_kv_transfer(
-            room,
-            kv_chunk.prefill_kv_indices,
-            kv_chunk.index_slice,
-            kv_chunk.is_last_chunk,
-            aux_index=kv_chunk.prefill_aux_index,
-            state_indices=kv_chunk.state_indices,
-            num_kv_tokens=kv_chunk.num_kv_tokens,
-        )
-
-        if self._should_skip_transfer(room):
-            return
+        try:
+            statuses, target_infos = self._submit_kv_transfer(
+                room,
+                kv_chunk.prefill_kv_indices,
+                kv_chunk.index_slice,
+                kv_chunk.is_last_chunk,
+                aux_index=kv_chunk.prefill_aux_index,
+                state_indices=kv_chunk.state_indices,
+                num_kv_tokens=kv_chunk.num_kv_tokens,
+                worker_index=worker_index,
+                room_owner=room_owner,
+            )
+        except MoriKVSubmissionError as exc:
+            self._wait_transfer_completion(exc.statuses)
+            raise
 
         failure_reason = self._wait_transfer_completion(statuses)
-        if self._should_skip_transfer(room):
+        if self._should_skip_transfer(room, room_owner):
             return
         if failure_reason is not None:
-            self.conclude_failure(bootstrap_room=room, failure_reason=failure_reason)
-            return
+            self._conclude_owned_failure(room, failure_reason, room_owner)
+            return None
 
         if kv_chunk.is_last_chunk:
-            # conclude_transfer downgrades to Failed when a failure was recorded
-            # while this chunk was in flight, and applies the same status locally
-            # and on the wire.
-            self.conclude_transfer(bootstrap_room=room, status=KVPoll.Success)
+            return target_infos if target_infos is not None else []
+        return None
 
-    def _should_skip_transfer(self, room: int) -> bool:
-        if room not in self.request_status or self.check_status(room) == KVPoll.Failed:
+    def _should_skip_transfer(
+        self, room: int, room_owner: Optional[str] = None
+    ) -> bool:
+        if (
+            (room_owner is not None and self._room_owners.get(room) != room_owner)
+            or room not in self.request_status
+            or self.check_status(room) == KVPoll.Failed
+        ):
             logger.debug(
                 "Skipping chunk for room %s because it has already failed or been aborted",
                 room,
@@ -541,12 +946,20 @@ class MoriKVManager(CommonKVManager):
 
         while True:
             rc = self.engine.wait_all(statuses, timeout_ms=self._wait_poll_ms)
+            if rc == StatusCode.SUCCESS:
+                return None
             if rc != StatusCode.IN_PROGRESS:
-                if rc == StatusCode.SUCCESS:
-                    return None
-                return self._collect_transfer_failure_reason(statuses)
+                failure_reason = self._collect_transfer_failure_reason(statuses)
+                self.engine.wait_all(statuses, timeout_ms=-1)
+                return failure_reason
             if sla_ms > 0 and (time.perf_counter() - start) * 1000 >= sla_ms:
-                return f"KV transfer exceeded SLA {sla_ms}ms"
+                timeout_reason = f"KV transfer exceeded SLA {sla_ms}ms"
+                logger.error(
+                    "%s; waiting for all in-flight MORI writes to drain",
+                    timeout_reason,
+                )
+                self.engine.wait_all(statuses, timeout_ms=-1)
+                return timeout_reason
 
     @staticmethod
     def _collect_transfer_failure_reason(statuses: List[TransferStatus]) -> str:
@@ -565,35 +978,59 @@ class MoriKVManager(CommonKVManager):
         state_indices: Optional[List] = None,
         num_kv_tokens: Optional[int] = None,
         wait_event: Optional[object] = None,
+        room_owner: Optional[str] = None,
     ) -> None:
         assert self.disaggregation_mode == DisaggregationMode.PREFILL
         assert not is_last_chunk or (is_last_chunk and aux_index is not None)
 
-        if (
-            bootstrap_room not in self.request_status
-            or self.check_status(bootstrap_room) == KVPoll.Failed
-        ):
-            logger.debug(
-                "Request with bootstrap_room=%s already failed", bootstrap_room
-            )
-            return
+        with self.transfer_lock:
+            if (
+                bootstrap_room not in self.request_status
+                or self.check_status(bootstrap_room) == KVPoll.Failed
+                or (
+                    room_owner is not None
+                    and self._room_owners.get(bootstrap_room) != room_owner
+                )
+            ):
+                logger.debug(
+                    "Request with bootstrap_room=%s already failed", bootstrap_room
+                )
+                return
 
-        if bootstrap_room not in self.transfer_infos:
-            return
+            if bootstrap_room not in self.transfer_infos:
+                return
 
-        shard_idx = bootstrap_room % self._num_shards
-        self._transfer_queues[shard_idx].put(
-            TransferKVChunk(
-                room=bootstrap_room,
-                prefill_kv_indices=kv_indices,
-                index_slice=index_slice,
-                is_last_chunk=is_last_chunk,
-                prefill_aux_index=aux_index,
-                state_indices=state_indices,
-                num_kv_tokens=num_kv_tokens,
-                wait_event=wait_event,
+            infos = self.transfer_infos[bootstrap_room].values()
+            requires_pack = self._dcp_pack_worker_count > 0 and any(
+                (peer := self.decode_kv_args_table.get(info.engine_key)) is not None
+                and peer.requires_dcp_relayout
+                for info in infos
             )
-        )
+            shard_idx = bootstrap_room % (
+                self._dcp_pack_worker_count if requires_pack else self._num_shards
+            )
+            with self._deferred_ack_lock:
+                self._staging_outstanding[bootstrap_room] += 1
+        try:
+            self._transfer_queues[shard_idx].put(
+                TransferKVChunk(
+                    room=bootstrap_room,
+                    prefill_kv_indices=kv_indices,
+                    index_slice=index_slice,
+                    is_last_chunk=is_last_chunk,
+                    prefill_aux_index=aux_index,
+                    state_indices=state_indices,
+                    num_kv_tokens=num_kv_tokens,
+                    wait_event=wait_event,
+                    room_owner=room_owner,
+                )
+            )
+        except Exception:
+            with self._deferred_ack_lock:
+                self._staging_outstanding[bootstrap_room] -= 1
+            if self.enable_deferred_decode_kv_release:
+                self._maybe_ack_drained_abort(bootstrap_room)
+            raise
 
     def _connect_threadsafe(self, endpoint: str, is_ipv6: bool = False):
         """Thread-local ZMQ socket cache with shared Context.
@@ -617,22 +1054,78 @@ class MoriKVManager(CommonKVManager):
             cache[endpoint] = sock
         return cache[endpoint]
 
-    def _handle_register_message(self, payload: List[bytes]) -> None:
+    def _handle_register_message(
+        self, payload: List[bytes], supports_dcp_drain: bool = False
+    ) -> None:
         try:
             register_info = KVArgsRegisterInfo.from_zmq(payload)
+            register_info.supports_dcp_drain = supports_dcp_drain
+            if register_info.dst_dcp_size > 1 and not register_info.dcp_registration_id:
+                raise RuntimeError(
+                    "MORI DCP peer does not request a registration capability ACK"
+                )
             self._add_remote_peer(register_info)
+            if register_info.dcp_registration_id is not None:
+                na = NetworkAddress(register_info.endpoint, register_info.dst_port)
+                socket = self._connect_threadsafe(na.to_tcp(), is_ipv6=na.is_ipv6)
+                socket.send_multipart(
+                    [
+                        MORI_DCP_REGISTER_ACK,
+                        register_info.dcp_registration_id.encode("ascii"),
+                    ]
+                )
         except Exception:
             logger.exception("Failed to register remote peer")
 
     def _handle_transfer_message(self, payload: List[bytes]) -> None:
         try:
             transfer_info = TransferInfo.from_zmq(payload)
+            peer_info = self.decode_kv_args_table.get(transfer_info.engine_key)
+            requires_generation = peer_info is not None and peer_info.dst_dcp_size > 1
+            if requires_generation and transfer_info.abort_generation is None:
+                with self.transfer_lock:
+                    has_owner = transfer_info.room in self._room_owners
+                    if has_owner:
+                        self.update_status(transfer_info.room, KVPoll.Failed)
+                if has_owner:
+                    self.record_failure(
+                        transfer_info.room,
+                        "MORI DCP metadata is missing its request epoch",
+                    )
+                logger.warning(
+                    "Rejecting MORI DCP metadata without a request epoch for room %s",
+                    transfer_info.room,
+                )
+                return
+
             with self.transfer_lock:
-                # Accept metadata when room is not yet created (None) or
-                # in Bootstrapping. Reject for active/terminal states where
-                # the worker may already be using transfer_infos.
-                # None is allowed because metadata can arrive from decode
-                # before the prefill scheduler creates the MoriKVSender.
+                if (
+                    transfer_info.abort_generation is not None
+                    and (
+                        transfer_info.room,
+                        transfer_info.abort_generation,
+                    )
+                    in self._aborted_generations
+                ):
+                    logger.debug(
+                        "Ignoring aborted MORI metadata for room %s generation %s",
+                        transfer_info.room,
+                        transfer_info.abort_generation,
+                    )
+                    return
+
+                expected_generation = self._room_generations.get(transfer_info.room)
+                if (
+                    expected_generation is not None
+                    and transfer_info.abort_generation != expected_generation
+                ):
+                    logger.debug(
+                        "Ignoring stale MORI metadata for room %s generation %s",
+                        transfer_info.room,
+                        transfer_info.abort_generation,
+                    )
+                    return
+
                 current = self.request_status.get(transfer_info.room)
                 if current is not None and current != KVPoll.Bootstrapping:
                     logger.debug(
@@ -641,10 +1134,29 @@ class MoriKVManager(CommonKVManager):
                         current,
                     )
                     return
+                if (
+                    transfer_info.room in self._room_owners
+                    and expected_generation is None
+                    and transfer_info.abort_generation is not None
+                ):
+                    self._room_generations[transfer_info.room] = (
+                        transfer_info.abort_generation
+                    )
+                    self._aborted_generations = {
+                        entry: None
+                        for entry in self._aborted_generations
+                        if entry[0] != transfer_info.room
+                    }
+
+                # Metadata may arrive before the prefill scheduler creates
+                # the sender, so an owner-less room is intentionally valid.
                 infos = self.transfer_infos.setdefault(transfer_info.room, {})
                 infos[transfer_info.engine_key] = transfer_info
 
-                if len(infos) >= transfer_info.required_dst_info_num:
+                if (
+                    infos is not None
+                    and len(infos) >= transfer_info.required_dst_info_num
+                ):
                     self.resolve_kv_replica_factor(infos)
                     # All decode peers reported their dst metadata; pick a
                     # non-None decode_prefix_len if any peer set it (they
@@ -682,7 +1194,11 @@ class MoriKVManager(CommonKVManager):
             logger.exception("Failed to parse transfer info message")
 
     def _validate_message(self, msg: List[bytes]) -> Optional[List[bytes]]:
-        if not msg or msg[0] not in (MORI_GUARD, MORI_DCP_GUARD):
+        if not msg or msg[0] not in (
+            MORI_GUARD,
+            MORI_DCP_GUARD,
+            MORI_DCP_DRAIN_GUARD,
+        ):
             logger.warning("Received malformed bootstrap message")
             return None
         payload = msg[1:]
@@ -698,30 +1214,78 @@ class MoriKVManager(CommonKVManager):
 
         try:
             bootstrap_room = int(msg[1].decode("ascii"))
+            decode_ip = msg[2].decode("ascii") if len(msg) > 2 else None
+            decode_port = int(msg[3].decode("ascii")) if len(msg) > 3 else None
+            generation = msg[4].decode("ascii") if len(msg) > 4 and msg[4] else None
         except (ValueError, UnicodeDecodeError):
             logger.warning("Malformed ABORT message: invalid room field %r", msg[1])
             return
 
         with self.transfer_lock:
             current = self.request_status.get(bootstrap_room)
-            if current is None:
-                logger.debug(
-                    "ABORT for room %s is not tracked; ignoring",
-                    bootstrap_room,
-                )
-                return
-            if current == KVPoll.Success:
-                logger.debug(
-                    "ABORT for room %s already succeeded; ignoring",
-                    bootstrap_room,
-                )
-                return
-            if current == KVPoll.Failed:
-                return
+            room_owner = self._room_owners.get(bootstrap_room)
+            expected_generation = self._room_generations.get(bootstrap_room)
+            if expected_generation is None:
+                info_generations = {
+                    info.abort_generation
+                    for info in self.transfer_infos.get(bootstrap_room, {}).values()
+                    if info.abort_generation is not None
+                }
+                if len(info_generations) == 1:
+                    expected_generation = next(iter(info_generations))
+                    if room_owner is not None:
+                        self._room_generations[bootstrap_room] = expected_generation
 
-            self.update_status(bootstrap_room, KVPoll.Failed)
+            stale_generation = (
+                expected_generation is not None and generation != expected_generation
+            )
+            if not stale_generation and generation is not None:
+                key = (bootstrap_room, generation)
+                self._aborted_generations.pop(key, None)
+                self._aborted_generations[key] = None
+                if len(self._aborted_generations) > MORI_ABORT_TOMBSTONE_LIMIT:
+                    oldest = next(iter(self._aborted_generations))
+                    self._aborted_generations.pop(oldest)
+            generation_matches = (
+                expected_generation is not None and generation == expected_generation
+            ) or (expected_generation is None and generation is None)
+            room_active = room_owner is not None and current not in (
+                None,
+                KVPoll.Success,
+                KVPoll.Failed,
+            )
+            if room_owner is None and generation_matches:
+                self.transfer_infos.pop(bootstrap_room, None)
+                self.request_status.pop(bootstrap_room, None)
+                self.req_to_decode_prefix_len.pop(bootstrap_room, None)
+            if room_active and generation_matches:
+                self.update_status(bootstrap_room, KVPoll.Failed)
 
-        logger.debug("Room %s marked Failed via ABORT from decode", bootstrap_room)
+        if stale_generation:
+            if decode_ip is not None and decode_port is not None:
+                self.register_deferred_ack_target(
+                    bootstrap_room, decode_ip, decode_port, generation
+                )
+                self._maybe_ack_drained_abort(bootstrap_room)
+            return
+
+        if room_active:
+            logger.debug("Room %s marked Failed via ABORT from decode", bootstrap_room)
+        else:
+            logger.debug(
+                "ABORT for inactive room %s; checking outstanding writes",
+                bootstrap_room,
+            )
+
+        if (
+            self.enable_deferred_decode_kv_release
+            and decode_ip is not None
+            and decode_port is not None
+        ):
+            self.register_deferred_ack_target(
+                bootstrap_room, decode_ip, decode_port, generation
+            )
+            self._maybe_ack_drained_abort(bootstrap_room)
 
     def _start_bootstrap_thread(self) -> None:
         def bootstrap_worker():
@@ -742,7 +1306,10 @@ class MoriKVManager(CommonKVManager):
                     room = payload[0].decode("ascii")
 
                     if room == "None":
-                        self._handle_register_message(payload)
+                        self._handle_register_message(
+                            payload,
+                            supports_dcp_drain=tag == MORI_DCP_DRAIN_GUARD,
+                        )
                     else:
                         self._handle_transfer_message(payload)
                 except Exception:
@@ -750,11 +1317,39 @@ class MoriKVManager(CommonKVManager):
 
         threading.Thread(target=bootstrap_worker, daemon=True).start()
 
+    def activate_decode_room_generation(self, room: int, generation: str) -> None:
+        with self.transfer_lock:
+            current = self._decode_room_generations.get(room)
+            if current is not None and current != generation:
+                raise KVTransferError(
+                    room,
+                    f"Cannot reuse active MORI decode bootstrap room {room}",
+                )
+            self._decode_room_generations[room] = generation
+
+    def clear_decode_room_generation(self, room: int, generation: str) -> None:
+        with self.transfer_lock:
+            if self._decode_room_generations.get(room) == generation:
+                self._decode_room_generations.pop(room, None)
+
+    def _is_current_decode_generation(
+        self, room: int, generation: Optional[str]
+    ) -> bool:
+        if not self.requires_strict_deferred_release:
+            return True
+        with self.transfer_lock:
+            expected_generation = self._decode_room_generations.get(room)
+        return expected_generation is not None and generation == expected_generation
+
     def _start_decode_thread(self) -> None:
         def decode_worker():
             while True:
                 try:
                     msg = self.server_socket.recv_multipart()
+                    if self._handle_dcp_registration_ack(msg):
+                        continue
+                    if self._handle_abort_ack(msg):
+                        continue
                     if msg and msg[0] == MoriKVManager.AUX_DATA_HEADER:
                         self._handle_aux_data(msg)
                         continue
@@ -766,6 +1361,16 @@ class MoriKVManager(CommonKVManager):
                         )
                         continue
                     room, status, prefill_rank, reason = parsed
+                    generation = (
+                        msg[5].decode("ascii") if len(msg) > 5 and msg[5] else None
+                    )
+                    if not self._is_current_decode_generation(room, generation):
+                        logger.debug(
+                            "Dropping stale MORI status for room %s generation %s",
+                            room,
+                            generation,
+                        )
+                        continue
                     self.apply_prefill_status(
                         bootstrap_room=room,
                         status=status,
@@ -777,11 +1382,48 @@ class MoriKVManager(CommonKVManager):
 
         threading.Thread(target=decode_worker, daemon=True).start()
 
+    def _handle_dcp_registration_ack(self, msg: List[bytes]) -> bool:
+        if not msg or msg[0] != MORI_DCP_REGISTER_ACK:
+            return False
+        if len(msg) != 2 or not msg[1]:
+            logger.warning("Malformed MORI DCP registration acknowledgement")
+            return True
+        try:
+            registration_id = msg[1].decode("ascii")
+        except UnicodeDecodeError:
+            logger.warning("Malformed MORI DCP registration acknowledgement token")
+            return True
+        with self._dcp_registration_lock:
+            event = self._dcp_registration_events.get(registration_id)
+        if event is not None:
+            event.set()
+        else:
+            logger.debug(
+                "Dropping late MORI DCP registration acknowledgement %s",
+                registration_id,
+            )
+        return True
+
+    def _handle_abort_ack(self, msg: List[bytes]) -> bool:
+        if not msg or msg[0] != b"ABORT_ACK":
+            return False
+        if self.enable_deferred_decode_kv_release and len(msg) >= 3:
+            self.note_abort_ack(
+                int(msg[1].decode("ascii")),
+                int(msg[2].decode("ascii")),
+                msg[3].decode("ascii") if len(msg) > 3 and msg[3] else None,
+            )
+        return True
+
     def _add_remote_peer(self, register_info: KVArgsRegisterInfo) -> None:
         engine_key = register_info.engine_key
         if engine_key in self.decode_kv_args_table:
             logger.debug("Remote peer %s already registered. Skipping.", engine_key)
             return
+        if register_info.dst_dcp_size > 1:
+            if not register_info.supports_dcp_drain:
+                raise RuntimeError("MORI DCP peer does not advertise drain-ACK support")
+            self.enable_deferred_decode_kv_release = True
         register_info.requires_dcp_relayout = self.requires_dcp_relayout(
             register_info.dst_dcp_size, register_info.dst_dcp_rank
         )
@@ -803,6 +1445,7 @@ class MoriKVManager(CommonKVManager):
                 [register_info.dst_kv_item_lens[index] for index in dst_indices],
                 register_info.dst_dcp_size,
             )
+            self._init_dcp_pack_buffers_once(register_info.dst_dcp_size)
         self.engine.register_remote_engine(register_info.engine_desc)
         self.decode_kv_args_table[engine_key] = register_info
         logger.debug(
@@ -885,20 +1528,27 @@ class MoriKVManager(CommonKVManager):
         src_desc: MemoryDesc,
         dst_desc: MemoryDesc,
         plan: BatchTransferPlan,
+        status_sink: Optional[List[TransferStatus]] = None,
     ) -> List[TransferStatus]:
         if plan.empty():
-            return []
+            return status_sink if status_sink is not None else []
 
         transfer_uid = self.engine.allocate_transfer_uid()
 
-        statuses = self.engine.batch_write(
-            [src_desc],
-            [plan.local_offsets],
-            [dst_desc],
-            [plan.remote_offsets],
-            [plan.sizes],
-            [transfer_uid],
+        statuses = list(
+            self.engine.batch_write(
+                [src_desc],
+                [plan.local_offsets],
+                [dst_desc],
+                [plan.remote_offsets],
+                [plan.sizes],
+                [transfer_uid],
+            )
         )
+        if status_sink is not None:
+            # Retain each status before a later submission can fail so the
+            # worker drains every operation before reusing transfer memory.
+            status_sink.extend(statuses)
         return statuses
 
     def _build_contiguous_transfer_plan(
@@ -1024,6 +1674,7 @@ class MoriKVManager(CommonKVManager):
         peer_info: KVArgsRegisterInfo,
         prefill_kv_indices: npt.NDArray[np.int32],
         dst_kv_indices: npt.NDArray[np.int32],
+        status_sink: Optional[List[TransferStatus]] = None,
     ) -> List[TransferStatus]:
         grouped_plan = GroupedIndexPlan.from_groups(
             *group_concurrent_contiguous(
@@ -1031,7 +1682,7 @@ class MoriKVManager(CommonKVManager):
                 dst_kv_indices,
             )
         )
-        statuses: List[TransferStatus] = []
+        statuses = status_sink if status_sink is not None else []
         kv_item_len = self.kv_args.kv_item_lens[0]
 
         if self.is_mla_backend or self.is_hybrid_mla_backend:
@@ -1042,12 +1693,11 @@ class MoriKVManager(CommonKVManager):
                 layer_plan = self._build_contiguous_transfer_plan(
                     grouped_plan, self.kv_args.kv_item_lens[layer_id]
                 )
-                statuses.extend(
-                    self._submit_batch_transfer_plan(
-                        src_descs[layer_id],
-                        dst_descs[layer_id],
-                        layer_plan,
-                    )
+                self._submit_batch_transfer_plan(
+                    src_descs[layer_id],
+                    dst_descs[layer_id],
+                    layer_plan,
+                    status_sink=statuses,
                 )
             return statuses
 
@@ -1065,47 +1715,108 @@ class MoriKVManager(CommonKVManager):
                 prefill_kv_indices, dst_kv_indices, tp_cfg
             )
             for layer_id in range(layers_current_pp_stage):
-                statuses.extend(
-                    self._submit_batch_transfer_plan(
-                        src_k_descs[layer_id],
-                        dst_k_descs[layer_id],
-                        slice_plan,
-                    )
+                self._submit_batch_transfer_plan(
+                    src_k_descs[layer_id],
+                    dst_k_descs[layer_id],
+                    slice_plan,
+                    status_sink=statuses,
                 )
-                statuses.extend(
-                    self._submit_batch_transfer_plan(
-                        src_v_descs[layer_id],
-                        dst_v_descs[layer_id],
-                        slice_plan,
-                    )
+                self._submit_batch_transfer_plan(
+                    src_v_descs[layer_id],
+                    dst_v_descs[layer_id],
+                    slice_plan,
+                    status_sink=statuses,
                 )
             return statuses
 
         layer_plan = self._build_contiguous_transfer_plan(grouped_plan, kv_item_len)
         for layer_id in range(layers_current_pp_stage):
-            statuses.extend(
-                self._submit_batch_transfer_plan(
-                    src_k_descs[layer_id],
-                    dst_k_descs[layer_id],
-                    layer_plan,
-                )
+            self._submit_batch_transfer_plan(
+                src_k_descs[layer_id],
+                dst_k_descs[layer_id],
+                layer_plan,
+                status_sink=statuses,
             )
-            statuses.extend(
-                self._submit_batch_transfer_plan(
-                    src_v_descs[layer_id],
-                    dst_v_descs[layer_id],
-                    layer_plan,
-                )
+            self._submit_batch_transfer_plan(
+                src_v_descs[layer_id],
+                dst_v_descs[layer_id],
+                layer_plan,
+                status_sink=statuses,
             )
         return statuses
+
+    def _submit_dcp_part(
+        self,
+        src_descs: List[MemoryDesc],
+        dst_descs: List[MemoryDesc],
+        token_item_lens: List[int],
+        src_token_indices: npt.NDArray[np.int64],
+        dst_token_indices: npt.NDArray[np.int64],
+        statuses: List[TransferStatus],
+        packed_src: Optional[MoriPackedDCPSource] = None,
+    ) -> None:
+        if src_token_indices.size == 0:
+            return
+        if not (len(src_descs) == len(dst_descs) == len(token_item_lens)):
+            raise RuntimeError(
+                "MORI DCP transfer-part region count differs: "
+                f"src={len(src_descs)}, dst={len(dst_descs)}, "
+                f"item_lens={len(token_item_lens)}"
+            )
+
+        src_layer_offsets = [0] * len(src_descs)
+        if packed_src is not None:
+            if len(packed_src.layer_offsets) != len(src_descs):
+                raise RuntimeError(
+                    "MORI packed DCP source region count differs: "
+                    f"packed={len(packed_src.layer_offsets)}, src={len(src_descs)}"
+                )
+            src_descs = [packed_src.mem_desc] * len(packed_src.layer_offsets)
+            src_layer_offsets = packed_src.layer_offsets
+            src_token_indices = packed_src.token_indices
+
+        grouped_plan = GroupedIndexPlan.from_groups(
+            *group_concurrent_contiguous(
+                src_token_indices,
+                dst_token_indices,
+            )
+        )
+        for src_desc, dst_desc, token_item_len, src_layer_offset in zip(
+            src_descs,
+            dst_descs,
+            token_item_lens,
+            src_layer_offsets,
+        ):
+            transfer_plan = self._build_contiguous_transfer_plan(
+                grouped_plan, token_item_len
+            )
+            if src_layer_offset:
+                transfer_plan = dataclasses.replace(
+                    transfer_plan,
+                    local_offsets=[
+                        src_layer_offset + offset
+                        for offset in transfer_plan.local_offsets
+                    ],
+                )
+            self._submit_batch_transfer_plan(
+                src_desc,
+                dst_desc,
+                transfer_plan,
+                status_sink=statuses,
+            )
 
     def send_kvcache_dcp(
         self,
         peer_info: KVArgsRegisterInfo,
         plan: DCPTokenTransferPlan,
+        packed_src: Optional[MoriPackedDCPSource] = None,
+        status_sink: Optional[List[TransferStatus]] = None,
     ) -> List[TransferStatus]:
+        statuses = status_sink if status_sink is not None else []
+        if getattr(self.kv_args, "num_draft_entries", 0):
+            raise RuntimeError("MORI DCP1-to-DCP-N draft KV transfer is not supported")
         if plan.target_src_token_indices.size == 0:
-            return []
+            return statuses
         if (
             peer_info.dcp_dst_region_indices is None
             or peer_info.dcp_token_item_lens is None
@@ -1127,26 +1838,74 @@ class MoriKVManager(CommonKVManager):
                 f"item_lens={len(peer_info.dcp_token_item_lens)}"
             )
 
-        grouped_plan = GroupedIndexPlan.from_groups(
-            *group_concurrent_contiguous(
-                plan.target_src_token_indices,
-                plan.target_dst_token_indices,
-            )
-        )
-        statuses: List[TransferStatus] = []
-        for src_desc, dst_desc, token_item_len in zip(
+        self._submit_dcp_part(
             self.kv_mem_descs,
             dst_descs,
             peer_info.dcp_token_item_lens,
-        ):
-            statuses.extend(
-                self._submit_batch_transfer_plan(
-                    src_desc,
-                    dst_desc,
-                    self._build_contiguous_transfer_plan(grouped_plan, token_item_len),
-                )
-            )
+            plan.target_src_token_indices,
+            plan.target_dst_token_indices,
+            statuses,
+            packed_src=packed_src,
+        )
         return statuses
+
+    def _pack_dcp_rank_once(
+        self,
+        pack_buffer: Optional[StagingBuffer],
+        peer_info: KVArgsRegisterInfo,
+        src_token_indices: npt.NDArray[np.int64],
+        packed_source_by_dcp_rank: Dict[int, MoriPackedDCPRank],
+    ) -> Optional[MoriPackedDCPSource]:
+        rank = peer_info.dst_dcp_rank
+        token_item_lens = peer_info.dcp_token_item_lens
+        assert token_item_lens is not None
+        signature = (
+            peer_info.dst_dcp_size,
+            tuple(token_item_lens),
+            src_token_indices.dtype.str,
+            src_token_indices.tobytes(),
+        )
+        if rank in packed_source_by_dcp_rank:
+            cached = packed_source_by_dcp_rank[rank]
+            if cached.signature == signature:
+                return cached.source
+            logger.warning(
+                "MORI DCP rank %d has inconsistent source geometry within one "
+                "chunk; using per-token RDMA for this target",
+                rank,
+            )
+            return None
+        if pack_buffer is None or src_token_indices.size == 0:
+            packed_source_by_dcp_rank[rank] = MoriPackedDCPRank(signature, None)
+            return None
+
+        from sglang.srt.disaggregation.common.dcp_pack import try_pack_dcp_src
+
+        rank_stride = pack_buffer.get_size() // peer_info.dst_dcp_size
+        packed = try_pack_dcp_src(
+            pack_buffer=pack_buffer,
+            kv_data_ptrs=self.kv_args.kv_data_ptrs,
+            src_token_indices=src_token_indices,
+            token_item_lens=token_item_lens,
+            pack_offset_bytes=rank * rank_stride,
+            pack_limit_bytes=(rank + 1) * rank_stride,
+        )
+        if packed is None:
+            packed_source_by_dcp_rank[rank] = MoriPackedDCPRank(signature, None)
+            return None
+
+        pack_base = pack_buffer.get_ptr()
+        pack_desc = self._dcp_pack_mem_descs.get(pack_base)
+        if pack_desc is None:
+            raise RuntimeError("MORI DCP pack buffer is not registered")
+        packed_ptrs, packed_indices = packed
+        packed_source = MoriPackedDCPSource(
+            mem_desc=pack_desc,
+            layer_offsets=[ptr - pack_base for ptr in packed_ptrs],
+            token_indices=packed_indices,
+        )
+        packed_source_by_dcp_rank[rank] = MoriPackedDCPRank(signature, packed_source)
+        return packed_source
 
     def send_aux(
         self,
@@ -1154,10 +1913,26 @@ class MoriKVManager(CommonKVManager):
         prefill_aux_index: int,
         dst_aux_index: int,
         room: int,
+        generation: Optional[str] = None,
+        status_sink: Optional[List[TransferStatus]] = None,
     ) -> List[TransferStatus]:
         if self._send_aux_rdma:
-            return self.send_aux_rdma(peer_info, prefill_aux_index, dst_aux_index, room)
-        return self.send_aux_tcp(peer_info, prefill_aux_index, dst_aux_index, room)
+            return self.send_aux_rdma(
+                peer_info,
+                prefill_aux_index,
+                dst_aux_index,
+                room,
+                generation,
+                status_sink,
+            )
+        self.send_aux_tcp(
+            peer_info,
+            prefill_aux_index,
+            dst_aux_index,
+            room,
+            generation,
+        )
+        return status_sink if status_sink is not None else []
 
     def send_aux_rdma(
         self,
@@ -1165,31 +1940,35 @@ class MoriKVManager(CommonKVManager):
         prefill_aux_index: int,
         dst_aux_index: int,
         room: int,
+        generation: Optional[str] = None,
+        status_sink: Optional[List[TransferStatus]] = None,
     ) -> List[TransferStatus]:
         if not self.aux_mem_descs or len(self.aux_mem_descs) != len(
             peer_info.dst_aux_mem_descs
         ):
-            return self.send_aux_tcp(peer_info, prefill_aux_index, dst_aux_index, room)
+            self.send_aux_tcp(
+                peer_info,
+                prefill_aux_index,
+                dst_aux_index,
+                room,
+                generation,
+            )
+            return status_sink if status_sink is not None else []
 
-        src_descs: List[MemoryDesc] = []
-        dst_descs: List[MemoryDesc] = []
-        local_offsets: List[List[int]] = []
-        remote_offsets: List[List[int]] = []
-        sizes: List[List[int]] = []
-        uids = []
+        statuses = status_sink if status_sink is not None else []
         for i in range(len(self.aux_mem_descs)):
             item_len = self.kv_args.aux_item_lens[i]
-            src_descs.append(self.aux_mem_descs[i])
-            dst_descs.append(peer_info.dst_aux_mem_descs[i])
-            local_offsets.append([prefill_aux_index * item_len])
-            remote_offsets.append([dst_aux_index * item_len])
-            sizes.append([item_len])
-            uids.append(self.engine.allocate_transfer_uid())
-        return list(
-            self.engine.batch_write(
-                src_descs, local_offsets, dst_descs, remote_offsets, sizes, uids
+            self._submit_batch_transfer_plan(
+                self.aux_mem_descs[i],
+                peer_info.dst_aux_mem_descs[i],
+                BatchTransferPlan(
+                    local_offsets=[prefill_aux_index * item_len],
+                    remote_offsets=[dst_aux_index * item_len],
+                    sizes=[item_len],
+                ),
+                status_sink=statuses,
             )
-        )
+        return statuses
 
     def send_aux_tcp(
         self,
@@ -1197,6 +1976,7 @@ class MoriKVManager(CommonKVManager):
         prefill_aux_index: int,
         dst_aux_index: int,
         room: int,
+        generation: Optional[str] = None,
     ) -> List[TransferStatus]:
         for i in range(len(self.kv_args.aux_data_ptrs)):
             length = self.kv_args.aux_item_lens[i]
@@ -1209,11 +1989,12 @@ class MoriKVManager(CommonKVManager):
                 buffer_index=i,
                 aux_index=dst_aux_index,
                 data=data,
+                generation=generation,
             )
         return []  # TCP path has no TransferStatus to poll
 
     def _send_aux_data_to_endpoint(
-        self, remote, dst_port, room, buffer_index, aux_index, data
+        self, remote, dst_port, room, buffer_index, aux_index, data, generation=None
     ):
         na = NetworkAddress(remote, dst_port)
         socket = self._connect_threadsafe(na.to_tcp(), is_ipv6=na.is_ipv6)
@@ -1225,6 +2006,7 @@ class MoriKVManager(CommonKVManager):
                 str(aux_index).encode("ascii"),
                 struct.pack(">I", len(data)),
                 data,
+                generation.encode("ascii") if generation is not None else b"",
             ]
         )
 
@@ -1233,10 +2015,11 @@ class MoriKVManager(CommonKVManager):
         peer_info: KVArgsRegisterInfo,
         src_state_indices: List[npt.NDArray[np.int32]],
         dst_state_indices: List[npt.NDArray[np.int32]],
+        status_sink: Optional[List[TransferStatus]] = None,
     ) -> List[TransferStatus]:
         # Guard: no local state tensors -> no-op (e.g. SWA layers=0 on this PP rank)
         if not self.state_mem_descs:
-            return []
+            return status_sink if status_sink is not None else []
 
         state_types = self.kv_args.state_types
         if not state_types:
@@ -1255,7 +2038,7 @@ class MoriKVManager(CommonKVManager):
         src_state_item_lens = self.kv_args.state_item_lens
         src_state_dim_per_tensor = self.kv_args.state_dim_per_tensor
 
-        statuses: List[TransferStatus] = []
+        statuses = status_sink if status_sink is not None else []
         for i, st in enumerate(state_types):
             src_indices = src_state_indices[i] if i < len(src_state_indices) else None
             dst_indices = dst_state_indices[i] if i < len(dst_state_indices) else None
@@ -1287,18 +2070,17 @@ class MoriKVManager(CommonKVManager):
                         "Replicated Mamba PD state transfer currently requires "
                         "matching prefill/decode attention TP sizes"
                     )
-                statuses.extend(
-                    self._send_mamba_state(
-                        peer_info,
-                        src_indices,
-                        dst_indices,
-                        src_descs,
-                        dst_descs,
-                        src_lens,
-                        dst_lens,
-                        src_dims,
-                        dst_dims,
-                    )
+                self._send_mamba_state(
+                    peer_info,
+                    src_indices,
+                    dst_indices,
+                    src_descs,
+                    dst_descs,
+                    src_lens,
+                    dst_lens,
+                    src_dims,
+                    dst_dims,
+                    status_sink=statuses,
                 )
             elif st in (
                 "swa",
@@ -1309,16 +2091,15 @@ class MoriKVManager(CommonKVManager):
                 "c128_state",
                 "minimax_index_k",
             ):
-                statuses.extend(
-                    self._send_swa_dsa_state(
-                        peer_info,
-                        src_indices,
-                        dst_indices,
-                        src_descs,
-                        src_lens,
-                        dst_descs,
-                        st,
-                    )
+                self._send_swa_dsa_state(
+                    peer_info,
+                    src_indices,
+                    dst_indices,
+                    src_descs,
+                    src_lens,
+                    dst_descs,
+                    st,
+                    status_sink=statuses,
                 )
             else:
                 raise RuntimeError(f"PD state transfer failed: unknown state_type={st}")
@@ -1336,6 +2117,7 @@ class MoriKVManager(CommonKVManager):
         dst_state_item_lens: List[int],
         src_state_dim_per_tensor: List[int],
         dst_state_dim_per_tensor: List[int],
+        status_sink: Optional[List[TransferStatus]] = None,
     ) -> List[TransferStatus]:
         if src_state_indices.size != 1 or dst_state_indices.size != 1:
             raise RuntimeError(
@@ -1360,7 +2142,7 @@ class MoriKVManager(CommonKVManager):
 
         src_idx = int(src_state_indices[0])
         dst_idx = int(dst_state_indices[0])
-        statuses: List[TransferStatus] = []
+        statuses = status_sink if status_sink is not None else []
 
         local_tp_rank = self.kv_args.engine_rank % self.attn_tp_size
         dst_tp_rank = peer_info.decode_tp_rank % peer_info.decode_tp_size
@@ -1402,16 +2184,16 @@ class MoriKVManager(CommonKVManager):
                 dst_offset = dst_idx * dst_item_len + dst_dim_offset
                 size = bytes_to_send
 
-            transfer_uid = self.engine.allocate_transfer_uid()
-            batch_statuses = self.engine.batch_write(
-                [src_desc],
-                [[src_offset]],
-                [dst_desc],
-                [[dst_offset]],
-                [[size]],
-                [transfer_uid],
+            self._submit_batch_transfer_plan(
+                src_desc,
+                dst_desc,
+                BatchTransferPlan(
+                    local_offsets=[src_offset],
+                    remote_offsets=[dst_offset],
+                    sizes=[size],
+                ),
+                status_sink=statuses,
             )
-            statuses.extend(batch_statuses)
 
         return statuses
 
@@ -1424,6 +2206,7 @@ class MoriKVManager(CommonKVManager):
         src_state_item_lens: List[int],
         dst_state_mem_descs: List[MemoryDesc],
         state_type: str,
+        status_sink: Optional[List[TransferStatus]] = None,
     ) -> List[TransferStatus]:
         # TP mismatch check for non-MLA SWA
         if (
@@ -1491,17 +2274,16 @@ class MoriKVManager(CommonKVManager):
             *group_concurrent_contiguous(src_state_indices, dst_state_indices)
         )
 
-        statuses: List[TransferStatus] = []
+        statuses = status_sink if status_sink is not None else []
         for i, src_desc in enumerate(src_state_mem_descs):
             dst_desc = dst_state_mem_descs[i]
             state_item_len = src_state_item_lens[i]
 
-            statuses.extend(
-                self._submit_batch_transfer_plan(
-                    src_desc,
-                    dst_desc,
-                    self._build_contiguous_transfer_plan(grouped_plan, state_item_len),
-                )
+            self._submit_batch_transfer_plan(
+                src_desc,
+                dst_desc,
+                self._build_contiguous_transfer_plan(grouped_plan, state_item_len),
+                status_sink=statuses,
             )
 
         return statuses
@@ -1513,6 +2295,15 @@ class MoriKVManager(CommonKVManager):
         aux_index = int(msg[3].decode("ascii"))
         data_length = struct.unpack(">I", msg[4])[0]
         data = msg[5]
+        generation = msg[6].decode("ascii") if len(msg) > 6 and msg[6] else None
+
+        if not self._is_current_decode_generation(room, generation):
+            logger.debug(
+                "Dropping stale MORI AUX data for room %s generation %s",
+                room,
+                generation,
+            )
+            return
 
         if len(data) != data_length:
             logger.error(f"AUX_DATA length mismatch for bootstrap_room {room}")
@@ -1531,20 +2322,30 @@ class MoriKVManager(CommonKVManager):
         aux_index: Optional[int] = None,
         state_indices: Optional[List[npt.NDArray[np.int32]]] = None,
         num_kv_tokens: Optional[int] = None,
-    ) -> List[TransferStatus]:
+        worker_index: Optional[int] = None,
+        room_owner: Optional[str] = None,
+    ) -> Tuple[List[TransferStatus], Optional[List[TransferInfo]]]:
         assert self.disaggregation_mode == DisaggregationMode.PREFILL
 
         if (
             bootstrap_room not in self.request_status
             or self.request_status.get(bootstrap_room) == KVPoll.Failed
         ):
-            return []
+            return [], None
 
         targets: List[TransferTarget] = []
+        target_infos_snapshot: Optional[List[TransferInfo]] = None
         with self.transfer_lock:
             current = self.request_status.get(bootstrap_room)
-            if current is None or current == KVPoll.Failed:
-                return []
+            if (
+                current is None
+                or current == KVPoll.Failed
+                or (
+                    room_owner is not None
+                    and self._room_owners.get(bootstrap_room) != room_owner
+                )
+            ):
+                return [], None
 
             transfer_infos = self.transfer_infos.get(bootstrap_room)
             if not transfer_infos:
@@ -1560,8 +2361,19 @@ class MoriKVManager(CommonKVManager):
                         f"Peer info missing for engine {info.engine_key}"
                     )
                 targets.append(TransferTarget(info=info, peer_info=peer_info))
+            if is_last_chunk:
+                target_infos_snapshot = [
+                    info for info in transfer_infos.values() if not info.is_dummy
+                ]
 
+        pack_buffer = (
+            self._get_or_init_dcp_pack_buffer(worker_index)
+            if worker_index is not None
+            and any(target.peer_info.requires_dcp_relayout for target in targets)
+            else None
+        )
         result_statuses: List[TransferStatus] = []
+        packed_source_by_dcp_rank: Dict[int, MoriPackedDCPRank] = {}
         try:
             for target in targets:
                 info = target.info
@@ -1581,11 +2393,29 @@ class MoriKVManager(CommonKVManager):
                             decode_prefix_len=info.decode_prefix_len or 0,
                             num_kv_tokens=num_kv_tokens,
                         )
-                        result_statuses.extend(self.send_kvcache_dcp(peer_info, plan))
+                        packed_src = (
+                            self._pack_dcp_rank_once(
+                                pack_buffer,
+                                peer_info,
+                                plan.target_src_token_indices,
+                                packed_source_by_dcp_rank,
+                            )
+                            if pack_buffer is not None
+                            else None
+                        )
+                        self.send_kvcache_dcp(
+                            peer_info,
+                            plan,
+                            packed_src,
+                            status_sink=result_statuses,
+                        )
                     else:
                         dst_indices_chunk = info.dst_kv_indices[index_slice]
-                        result_statuses.extend(
-                            self.send_kvcache(peer_info, kv_indices, dst_indices_chunk)
+                        self.send_kvcache(
+                            peer_info,
+                            kv_indices,
+                            dst_indices_chunk,
+                            status_sink=result_statuses,
                         )
 
                 if (
@@ -1594,10 +2424,11 @@ class MoriKVManager(CommonKVManager):
                     and not info.is_dummy
                     and self.state_mem_descs
                 ):
-                    result_statuses.extend(
-                        self.send_state(
-                            peer_info, state_indices, info.dst_state_indices
-                        )
+                    self.send_state(
+                        peer_info,
+                        state_indices,
+                        info.dst_state_indices,
+                        status_sink=result_statuses,
                     )
 
                 if (
@@ -1606,19 +2437,22 @@ class MoriKVManager(CommonKVManager):
                     and info.dst_aux_index >= 0
                     and self.pp_group.is_last_rank
                 ):
-                    result_statuses.extend(
-                        self.send_aux(
-                            peer_info, aux_index, info.dst_aux_index, bootstrap_room
-                        )
+                    self.send_aux(
+                        peer_info,
+                        aux_index,
+                        info.dst_aux_index,
+                        bootstrap_room,
+                        info.abort_generation,
+                        status_sink=result_statuses,
                     )
         except Exception as e:
             logger.exception(
                 "Mori KV transfer submission failed for bootstrap_room=%s",
                 bootstrap_room,
             )
-            raise RuntimeError(f"Transfer submission failed: {e}") from e
+            raise MoriKVSubmissionError(result_statuses, e) from e
 
-        return result_statuses
+        return result_statuses, target_infos_snapshot
 
 
 class MoriKVSender(CommonKVSender):
@@ -1631,6 +2465,8 @@ class MoriKVSender(CommonKVSender):
         pp_rank: int,
         req_has_disagg_prefill_dp_rank: bool = False,
     ):
+        self.room_owner = uuid.uuid4().hex
+        mgr.activate_room_owner(bootstrap_room, self.room_owner)
         super().__init__(
             mgr,
             bootstrap_addr,
@@ -1676,6 +2512,7 @@ class MoriKVSender(CommonKVSender):
                 False,
                 num_kv_tokens=num_kv_tokens,
                 wait_event=wait_event,
+                room_owner=self.room_owner,
             )
         else:
             self.kv_mgr.add_transfer_request(
@@ -1687,17 +2524,16 @@ class MoriKVSender(CommonKVSender):
                 state_indices=normalized_state,
                 num_kv_tokens=num_kv_tokens,
                 wait_event=wait_event,
+                room_owner=self.room_owner,
             )
 
     def poll(self) -> KVPoll:
         if self.conclude_state is not None:
             return self.conclude_state
 
-        if self.bootstrap_room not in self.kv_mgr.request_status:
-            self.conclude_state = KVPoll.Failed
-            return self.conclude_state
-
-        status = self.kv_mgr.check_status(self.bootstrap_room)
+        status = self.kv_mgr.check_room_owner_status(
+            self.bootstrap_room, self.room_owner
+        )
         if status == KVPoll.Bootstrapping:
             timeout_result = self._check_bootstrap_timeout()
             if timeout_result is not None:
@@ -1707,14 +2543,21 @@ class MoriKVSender(CommonKVSender):
             self.conclude_state = status
         return status
 
+    def clear(self) -> None:
+        if self.kv_mgr._defer_room_clear_if_outstanding(
+            self.bootstrap_room, self.room_owner
+        ):
+            return
+        self.kv_mgr.clear_room_owner(self.bootstrap_room, self.room_owner)
+
     def failure_exception(self):
         if self.conclude_state is None:
             self.conclude_state = KVPoll.Failed
 
+        failure_reason = self.kv_mgr.pop_room_owner_failure(
+            self.bootstrap_room, self.room_owner
+        )
         self.clear()
-
-        with self.kv_mgr.failure_lock:
-            failure_reason = self.kv_mgr.failure_records.pop(self.bootstrap_room, None)
         is_propagated = failure_reason is None
         if is_propagated:
             failure_reason = "KV transfer failed"
@@ -1729,9 +2572,26 @@ class MoriKVReceiver(CommonKVReceiver):
         mgr: MoriKVManager,
         bootstrap_addr: str,
         bootstrap_room: Optional[int] = None,
+        request_epoch: Optional[str] = None,
     ):
-        super().__init__(mgr, bootstrap_addr, bootstrap_room)
+        generation_activated = False
+        if mgr.requires_strict_deferred_release:
+            if bootstrap_room is None or not isinstance(request_epoch, str):
+                raise KVTransferError(
+                    bootstrap_room, "MORI DCP receiver requires a request epoch"
+                )
+            mgr.activate_decode_room_generation(bootstrap_room, request_epoch)
+            generation_activated = True
+        try:
+            super().__init__(mgr, bootstrap_addr, bootstrap_room)
+        except Exception:
+            if generation_activated:
+                mgr.clear_decode_room_generation(bootstrap_room, request_epoch)
+            raise
+        if request_epoch is not None:
+            self.abort_generation = request_epoch
         self.init_time: Optional[float] = None
+        self.metadata_published = False
 
     def init(
         self,
@@ -1766,42 +2626,81 @@ class MoriKVReceiver(CommonKVReceiver):
         )
         dst_dcp_size = str(self.kv_mgr.dcp_size).encode("ascii")
         dst_dcp_rank = str(self.kv_mgr.dcp_rank).encode("ascii")
-        registration_guard = MORI_DCP_GUARD if self.kv_mgr.dcp_size > 1 else MORI_GUARD
+        registration_guard = (
+            MORI_DCP_DRAIN_GUARD if self.kv_mgr.dcp_size > 1 else MORI_GUARD
+        )
+        registration_waiters: Dict[str, threading.Event] = {}
+        if self.kv_mgr.dcp_size > 1:
+            registration_waiters = {
+                uuid.uuid4().hex: threading.Event() for _ in self.bootstrap_infos
+            }
+            with self.kv_mgr._dcp_registration_lock:
+                self.kv_mgr._dcp_registration_events.update(registration_waiters)
+        registration_ids: List[Optional[str]] = (
+            list(registration_waiters)
+            if registration_waiters
+            else [None] * len(self.bootstrap_infos)
+        )
 
-        for bootstrap_info in self.bootstrap_infos:
-            try:
+        try:
+            for bootstrap_info, registration_id in zip(
+                self.bootstrap_infos, registration_ids
+            ):
                 sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
+                frames = [
+                    registration_guard,
+                    "None".encode("ascii"),
+                    self.kv_mgr.local_ip.encode("ascii"),
+                    str(self.kv_mgr.rank_port).encode("ascii"),
+                    engine_desc_blob,
+                    packed_kv_descs,
+                    packed_aux_descs,
+                    packed_state_descs,
+                    gpu_id,
+                    decode_tp_size,
+                    decode_tp_rank,
+                    kv_item_len,
+                    packed_state_item_lens,
+                    packed_state_dim_per_tensor,
+                    packed_kv_item_lens,
+                    packed_kv_layer_ids,
+                    dst_dcp_size,
+                    dst_dcp_rank,
+                ]
+                if registration_id is not None:
+                    frames.append(registration_id.encode("ascii"))
                 with lock:
-                    sock.send_multipart(
-                        [
-                            registration_guard,
-                            "None".encode("ascii"),
-                            self.kv_mgr.local_ip.encode("ascii"),
-                            str(self.kv_mgr.rank_port).encode("ascii"),
-                            engine_desc_blob,
-                            packed_kv_descs,
-                            packed_aux_descs,
-                            packed_state_descs,
-                            gpu_id,
-                            decode_tp_size,
-                            decode_tp_rank,
-                            kv_item_len,
-                            packed_state_item_lens,
-                            packed_state_dim_per_tensor,
-                            packed_kv_item_lens,
-                            packed_kv_layer_ids,
-                            dst_dcp_size,
-                            dst_dcp_rank,
-                        ]
+                    sock.send_multipart(frames)
+
+            deadline = time.monotonic() + min(
+                float(self.kv_mgr.waiting_timeout),
+                MORI_DCP_REGISTRATION_TIMEOUT_SECONDS,
+            )
+            for registration_id, event in registration_waiters.items():
+                if not event.wait(max(0.0, deadline - time.monotonic())):
+                    missing_count = sum(
+                        not waiter.is_set() for waiter in registration_waiters.values()
                     )
-            except zmq.ZMQError:
-                self.kv_mgr.record_failure(
-                    self.bootstrap_room,
-                    f"_register_kv_args to prefill {bootstrap_info.get('rank_ip')}:{bootstrap_info.get('rank_port')} failed",
-                )
-                self.conclude_state = KVPoll.Failed
-                self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
-                return False
+                    raise TimeoutError(
+                        "MORI DCP registration capability acknowledgement timed out "
+                        f"for {missing_count} prefill rank(s)"
+                    )
+        except (zmq.ZMQError, TimeoutError) as exc:
+            failure_reason = (
+                "_register_kv_args to prefill "
+                f"{bootstrap_info.get('rank_ip')}:{bootstrap_info.get('rank_port')} failed"
+                if isinstance(exc, zmq.ZMQError)
+                else str(exc)
+            )
+            self.kv_mgr.record_failure(self.bootstrap_room, failure_reason)
+            self.conclude_state = KVPoll.Failed
+            self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
+            return False
+        finally:
+            if registration_waiters:
+                with self.kv_mgr._dcp_registration_lock:
+                    for registration_id in registration_waiters:
+                        self.kv_mgr._dcp_registration_events.pop(registration_id, None)
         return True
 
     def send_metadata(
@@ -1825,6 +2724,11 @@ class MoriKVReceiver(CommonKVReceiver):
             if decode_prefix_len is not None and decode_prefix_len > 0
             else b""
         )
+        abort_generation_bytes = (
+            self.abort_generation.encode("ascii")
+            if self.kv_mgr.requires_strict_deferred_release
+            else b""
+        )
 
         for bootstrap_info in self.bootstrap_infos:
             is_dummy = bootstrap_info.get("is_dummy", False)
@@ -1835,6 +2739,7 @@ class MoriKVReceiver(CommonKVReceiver):
             try:
                 sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
                 with lock:
+                    self.metadata_published = True
                     sock.send_multipart(
                         [
                             MORI_GUARD,
@@ -1847,6 +2752,7 @@ class MoriKVReceiver(CommonKVReceiver):
                             state_bytes,
                             str(self.required_dst_info_num).encode("ascii"),
                             decode_prefix_bytes,
+                            abort_generation_bytes,
                         ]
                     )
             except zmq.ZMQError:
@@ -1859,6 +2765,11 @@ class MoriKVReceiver(CommonKVReceiver):
                 self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
                 return
         self.init_time = time.time()
+
+    def ensure_abort_notified_for_drain(self) -> bool:
+        if not self.metadata_published:
+            return False
+        return super().ensure_abort_notified_for_drain()
 
     def poll(self) -> KVPoll:
         if self.conclude_state is not None:
@@ -1880,14 +2791,19 @@ class MoriKVReceiver(CommonKVReceiver):
         if self.bootstrap_room is None:
             return
         super().clear()
+        if self.kv_mgr.requires_strict_deferred_release:
+            self.kv_mgr.clear_decode_room_generation(
+                self.bootstrap_room, self.abort_generation
+            )
 
     def failure_exception(self):
         if self.conclude_state is None:
             self.conclude_state = KVPoll.Failed
 
-        self.clear()
         with self.kv_mgr.failure_lock:
             failure_reason = self.kv_mgr.failure_records.pop(self.bootstrap_room, None)
+        if not (self.kv_mgr.requires_strict_deferred_release and self.abort_notified):
+            self.clear()
         is_propagated = failure_reason is None
         if is_propagated:
             failure_reason = "KV transfer failed"
@@ -1900,7 +2816,8 @@ class MoriKVReceiver(CommonKVReceiver):
             return
         bootstrap_room = self.bootstrap_room
         super().abort()
-        self.clear()
+        if not (self.kv_mgr.requires_strict_deferred_release and self.abort_notified):
+            self.clear()
         with self.kv_mgr.failure_lock:
             self.kv_mgr.failure_records.pop(bootstrap_room, None)
 

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -36,13 +36,18 @@ from sglang.srt.disaggregation.common.conn import (
 )
 from sglang.srt.disaggregation.common.utils import (
     AuxDataCodec,
+    DCPTokenTransferPlan,
     FastQueue,
     TransferKVChunk,
+    build_dcp_token_transfer_plan,
     group_concurrent_contiguous,
     pack_int_lists,
     unpack_int_lists,
 )
-from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.disaggregation.utils import (
+    DisaggregationMode,
+    resolve_dcp_dst_entry_indices,
+)
 from sglang.srt.environ import envs
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.common import run_with_deadline
@@ -50,6 +55,7 @@ from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
 
 logger = logging.getLogger(__name__)
 MORI_GUARD = b"MoriMsgGuard"
+MORI_DCP_GUARD = b"MoriDCPMsgGuard"
 _TAG_ABORT = b"ABORT"
 
 
@@ -194,6 +200,13 @@ class KVArgsRegisterInfo:
     dst_kv_item_len: int
     dst_state_item_lens: List[List[int]]
     dst_state_dim_per_tensor: List[List[int]]
+    dst_kv_item_lens: List[int] = dataclasses.field(default_factory=list)
+    dst_kv_layer_ids: List[int] = dataclasses.field(default_factory=list)
+    dst_dcp_size: int = 1
+    dst_dcp_rank: int = 0
+    requires_dcp_relayout: bool = False
+    dcp_token_item_lens: Optional[List[int]] = None
+    dcp_dst_region_indices: Optional[List[int]] = None
 
     @property
     def engine_key(self) -> str:
@@ -221,6 +234,21 @@ class KVArgsRegisterInfo:
             if len(payload) > 12 and payload[12]
             else []
         )
+        dst_kv_item_lens = (
+            list(struct.unpack(f"{len(payload[13]) // 8}Q", payload[13]))
+            if len(payload) > 13 and payload[13]
+            else [dst_kv_item_len] * len(dst_kv_mem_descs)
+        )
+        if len(dst_kv_item_lens) != len(dst_kv_mem_descs):
+            raise ValueError(
+                "dst_kv_item_lens length mismatch: "
+                f"got {len(dst_kv_item_lens)}, expected {len(dst_kv_mem_descs)}"
+            )
+        dst_kv_layer_ids = (
+            list(struct.unpack(f"{len(payload[14]) // 4}I", payload[14]))
+            if len(payload) > 14 and payload[14]
+            else []
+        )
         return cls(
             endpoint=endpoint,
             dst_port=dst_port,
@@ -234,6 +262,18 @@ class KVArgsRegisterInfo:
             dst_kv_item_len=dst_kv_item_len,
             dst_state_item_lens=dst_state_item_lens,
             dst_state_dim_per_tensor=dst_state_dim_per_tensor,
+            dst_kv_item_lens=dst_kv_item_lens,
+            dst_kv_layer_ids=dst_kv_layer_ids,
+            dst_dcp_size=(
+                int(payload[15].decode("ascii"))
+                if len(payload) > 15 and payload[15]
+                else 1
+            ),
+            dst_dcp_rank=(
+                int(payload[16].decode("ascii"))
+                if len(payload) > 16 and payload[16]
+                else 0
+            ),
         )
 
 
@@ -462,6 +502,7 @@ class MoriKVManager(CommonKVManager):
             kv_chunk.is_last_chunk,
             aux_index=kv_chunk.prefill_aux_index,
             state_indices=kv_chunk.state_indices,
+            num_kv_tokens=kv_chunk.num_kv_tokens,
         )
 
         if self._should_skip_transfer(room):
@@ -641,7 +682,7 @@ class MoriKVManager(CommonKVManager):
             logger.exception("Failed to parse transfer info message")
 
     def _validate_message(self, msg: List[bytes]) -> Optional[List[bytes]]:
-        if not msg or msg[0] != MORI_GUARD:
+        if not msg or msg[0] not in (MORI_GUARD, MORI_DCP_GUARD):
             logger.warning("Received malformed bootstrap message")
             return None
         payload = msg[1:]
@@ -741,6 +782,27 @@ class MoriKVManager(CommonKVManager):
         if engine_key in self.decode_kv_args_table:
             logger.debug("Remote peer %s already registered. Skipping.", engine_key)
             return
+        register_info.requires_dcp_relayout = self.requires_dcp_relayout(
+            register_info.dst_dcp_size, register_info.dst_dcp_rank
+        )
+        if register_info.requires_dcp_relayout:
+            if self.kv_args.kv_layer_ids or register_info.dst_kv_layer_ids:
+                dst_indices = resolve_dcp_dst_entry_indices(
+                    self.kv_args.kv_layer_ids,
+                    register_info.dst_kv_layer_ids,
+                    len(self.kv_mem_descs),
+                    len(register_info.dst_kv_mem_descs),
+                )
+            else:
+                _, dst_indices, _ = self.get_mla_kv_ptrs_with_pp(
+                    list(range(len(self.kv_mem_descs))),
+                    list(range(len(register_info.dst_kv_mem_descs))),
+                )
+            register_info.dcp_dst_region_indices = dst_indices
+            register_info.dcp_token_item_lens = self.prepare_dcp_token_item_lens(
+                [register_info.dst_kv_item_lens[index] for index in dst_indices],
+                register_info.dst_dcp_size,
+            )
         self.engine.register_remote_engine(register_info.engine_desc)
         self.decode_kv_args_table[engine_key] = register_info
         logger.debug(
@@ -1033,6 +1095,55 @@ class MoriKVManager(CommonKVManager):
                     src_v_descs[layer_id],
                     dst_v_descs[layer_id],
                     layer_plan,
+                )
+            )
+        return statuses
+
+    def send_kvcache_dcp(
+        self,
+        peer_info: KVArgsRegisterInfo,
+        plan: DCPTokenTransferPlan,
+    ) -> List[TransferStatus]:
+        if plan.target_src_token_indices.size == 0:
+            return []
+        if (
+            peer_info.dcp_dst_region_indices is None
+            or peer_info.dcp_token_item_lens is None
+        ):
+            raise RuntimeError("MORI DCP peer transfer metadata is not initialized")
+
+        dst_descs = [
+            peer_info.dst_kv_mem_descs[index]
+            for index in peer_info.dcp_dst_region_indices
+        ]
+        if not (
+            len(self.kv_mem_descs)
+            == len(dst_descs)
+            == len(peer_info.dcp_token_item_lens)
+        ):
+            raise RuntimeError(
+                "MORI DCP source/destination KV region count differs: "
+                f"src={len(self.kv_mem_descs)}, dst={len(dst_descs)}, "
+                f"item_lens={len(peer_info.dcp_token_item_lens)}"
+            )
+
+        grouped_plan = GroupedIndexPlan.from_groups(
+            *group_concurrent_contiguous(
+                plan.target_src_token_indices,
+                plan.target_dst_token_indices,
+            )
+        )
+        statuses: List[TransferStatus] = []
+        for src_desc, dst_desc, token_item_len in zip(
+            self.kv_mem_descs,
+            dst_descs,
+            peer_info.dcp_token_item_lens,
+        ):
+            statuses.extend(
+                self._submit_batch_transfer_plan(
+                    src_desc,
+                    dst_desc,
+                    self._build_contiguous_transfer_plan(grouped_plan, token_item_len),
                 )
             )
         return statuses
@@ -1419,6 +1530,7 @@ class MoriKVManager(CommonKVManager):
         is_last_chunk: bool,
         aux_index: Optional[int] = None,
         state_indices: Optional[List[npt.NDArray[np.int32]]] = None,
+        num_kv_tokens: Optional[int] = None,
     ) -> List[TransferStatus]:
         assert self.disaggregation_mode == DisaggregationMode.PREFILL
 
@@ -1456,10 +1568,25 @@ class MoriKVManager(CommonKVManager):
                 peer_info = target.peer_info
 
                 if not info.is_dummy:
-                    dst_indices_chunk = info.dst_kv_indices[index_slice]
-                    result_statuses.extend(
-                        self.send_kvcache(peer_info, kv_indices, dst_indices_chunk)
-                    )
+                    if peer_info.requires_dcp_relayout:
+                        if num_kv_tokens is None:
+                            raise ValueError("PD DCP transfer requires num_kv_tokens")
+                        plan = build_dcp_token_transfer_plan(
+                            kv_indices,
+                            info.dst_kv_indices,
+                            physical_page_size=self.kv_args.page_size,
+                            dcp_size=peer_info.dst_dcp_size,
+                            dcp_rank=peer_info.dst_dcp_rank,
+                            src_page_offset=index_slice.start or 0,
+                            decode_prefix_len=info.decode_prefix_len or 0,
+                            num_kv_tokens=num_kv_tokens,
+                        )
+                        result_statuses.extend(self.send_kvcache_dcp(peer_info, plan))
+                    else:
+                        dst_indices_chunk = info.dst_kv_indices[index_slice]
+                        result_statuses.extend(
+                            self.send_kvcache(peer_info, kv_indices, dst_indices_chunk)
+                        )
 
                 if (
                     is_last_chunk
@@ -1629,6 +1756,17 @@ class MoriKVReceiver(CommonKVReceiver):
         packed_state_dim_per_tensor = pack_int_lists(
             self.kv_mgr.kv_args.state_dim_per_tensor, "I"
         )
+        packed_kv_item_lens = struct.pack(
+            f"{len(self.kv_mgr.kv_args.kv_item_lens)}Q",
+            *self.kv_mgr.kv_args.kv_item_lens,
+        )
+        packed_kv_layer_ids = struct.pack(
+            f"{len(self.kv_mgr.kv_args.kv_layer_ids)}I",
+            *self.kv_mgr.kv_args.kv_layer_ids,
+        )
+        dst_dcp_size = str(self.kv_mgr.dcp_size).encode("ascii")
+        dst_dcp_rank = str(self.kv_mgr.dcp_rank).encode("ascii")
+        registration_guard = MORI_DCP_GUARD if self.kv_mgr.dcp_size > 1 else MORI_GUARD
 
         for bootstrap_info in self.bootstrap_infos:
             try:
@@ -1636,7 +1774,7 @@ class MoriKVReceiver(CommonKVReceiver):
                 with lock:
                     sock.send_multipart(
                         [
-                            MORI_GUARD,
+                            registration_guard,
                             "None".encode("ascii"),
                             self.kv_mgr.local_ip.encode("ascii"),
                             str(self.kv_mgr.rank_port).encode("ascii"),
@@ -1650,6 +1788,10 @@ class MoriKVReceiver(CommonKVReceiver):
                             kv_item_len,
                             packed_state_item_lens,
                             packed_state_dim_per_tensor,
+                            packed_kv_item_lens,
+                            packed_kv_layer_ids,
+                            dst_dcp_size,
+                            dst_dcp_rank,
                         ]
                     )
             except zmq.ZMQError:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -31,7 +31,7 @@ import torch
 
 from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.disaggregation.base.conn import StateType
-from sglang.srt.disaggregation.common.conn import CommonKVManager
+from sglang.srt.disaggregation.common.conn import CommonKVManager, KVTransferError
 from sglang.srt.disaggregation.common.staging_buffer import (
     compute_grid_segments,
     staging_grid_tokens,
@@ -351,7 +351,7 @@ class PrefillBootstrapQueue:
 
         dest_tp_ranks = [self.tp_rank]
 
-        req.disagg_kv_sender = kv_sender_class(
+        sender_kwargs = dict(
             mgr=self.kv_manager,
             bootstrap_addr=f"{req.bootstrap_host}:{self.bootstrap_port}",
             bootstrap_room=req.bootstrap_room,
@@ -359,6 +359,21 @@ class PrefillBootstrapQueue:
             pp_rank=self.pp_rank,
             req_has_disagg_prefill_dp_rank=req.disagg_prefill_dp_rank is not None,
         )
+        try:
+            req.disagg_kv_sender = kv_sender_class(**sender_kwargs)
+        except KVTransferError as exc:
+            error_message = f"Prefill bootstrap rejected request: {exc}"
+            logger.warning(error_message)
+            req.time_stats.trace_ctx.abort(abort_info={"reason": error_message})
+            prepare_abort(
+                req,
+                error_message,
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            )
+            self.scheduler.output_streamer.stream_output([req], req.return_logprob)
+            if self.scheduler.metrics_reporter.enable_metrics:
+                self.scheduler.metrics_collector.increment_bootstrap_failed_reqs()
+            return False
         self._process_req(req)
         req.pending_bootstrap = True
         return True

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -827,6 +827,9 @@ class Envs:
     # Per-transfer SLA (ms) before a KV transfer is failed; 0 disables the SLA
     # and relies on the RDMA retry-exceeded timeout only.
     SGLANG_MORI_TRANSFER_TIMEOUT_MS = EnvInt(0)
+    # Total VRAM budget for lazily allocated MORI DCP pack buffers. A worker
+    # without a buffer falls back to the raw per-token transfer path.
+    SGLANG_MORI_DCP_PACK_BUFFER_BUDGET_GB = EnvFloat(8.0)
     SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(4096)
 
     # ===================================================================

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1031,6 +1031,7 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
     routed_dp_rank: Optional[int] = None
     # For PD disagg — hint telling decode which prefill DP worker has the KV cache
     disagg_prefill_dp_rank: Optional[int] = None
+    disagg_request_epoch: Optional[str] = None
 
     # Routing key for routing-key schedule policy
     routing_key: Optional[str] = None

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -955,6 +955,7 @@ class Req(ReqDllmMixin):
         bootstrap_host: Optional[str] = None,
         bootstrap_port: Optional[int] = None,
         bootstrap_room: Optional[int] = None,
+        disagg_request_epoch: Optional[str] = None,
         disagg_mode: Optional[DisaggregationMode] = None,
         routed_dp_rank: Optional[int] = None,
         disagg_prefill_dp_rank: Optional[int] = None,
@@ -1277,6 +1278,7 @@ class Req(ReqDllmMixin):
         self.bootstrap_host: str = bootstrap_host
         self.bootstrap_port: Optional[int] = bootstrap_port
         self.bootstrap_room: Optional[int] = bootstrap_room
+        self.disagg_request_epoch: Optional[str] = disagg_request_epoch
         # Decode-local: the already-emitted boundary token to replay when a
         # retracted request is rebootstrapped. Set in pause_generation(retract)
         # and consumed in the decode transfer commit; never plumbed to prefill.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2766,6 +2766,7 @@ class Scheduler(
                 bootstrap_host=recv_req.bootstrap_host,
                 bootstrap_port=recv_req.bootstrap_port,
                 bootstrap_room=recv_req.bootstrap_room,
+                disagg_request_epoch=recv_req.disagg_request_epoch,
                 disagg_mode=self.disaggregation_mode,
                 routed_dp_rank=recv_req.routed_dp_rank,
                 disagg_prefill_dp_rank=recv_req.disagg_prefill_dp_rank,
@@ -4764,6 +4765,11 @@ class Scheduler(
         self.metrics_reporter.record_scheduler_idle()
 
     def _record_scheduler_state_for_paused_engine(self) -> None:
+        if (
+            self.disaggregation_mode == DisaggregationMode.DECODE
+            and self.disagg_decode_transfer_queue is not None
+        ):
+            self.disagg_decode_transfer_queue.resolve_deferred_releases()
         if self.is_fully_idle():
             self.metrics_reporter.record_scheduler_idle()
         else:
@@ -4808,6 +4814,7 @@ class Scheduler(
                 idle &= len(self.disagg_decode_prealloc_queue.queue) == 0
                 idle &= len(self.disagg_decode_prealloc_queue.retracted_queue) == 0
                 idle &= len(self.disagg_decode_transfer_queue.queue) == 0
+                idle &= not self.disagg_decode_transfer_queue.has_pending_deferred_releases()
                 if self.decode_offload_manager is not None:
                     idle &= len(self.decode_offload_manager.ongoing_offload) == 0
 
@@ -4944,6 +4951,11 @@ class Scheduler(
 
     def flush_cache(self, empty_cache: bool = True):
         """Flush memory pools (e.g., KV cache, Mamba cache) and optionally empty device allocator cache."""
+        if (
+            self.disaggregation_mode == DisaggregationMode.DECODE
+            and self.disagg_decode_transfer_queue is not None
+        ):
+            self.disagg_decode_transfer_queue.resolve_deferred_releases()
         if self.is_fully_idle():
             self.cur_batch_for_debug = None
             self.last_batch = None
@@ -5285,19 +5297,6 @@ class Scheduler(
                     logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
                     receiver = decode_req.kv_receiver
                     receiver.abort()
-                    # Arm drain-ack accounting once the ABORT is sent, so acks
-                    # arriving before this req is deferred (e.g. during the next
-                    # forward step) are captured. A fresh set also drops stale acks
-                    # from a prior request that reused this bootstrap_room. A
-                    # redundant abort only re-wipes -- holds longer, never releases
-                    # early -- so no transition guard is needed.
-                    if (
-                        receiver.kv_mgr.enable_deferred_decode_kv_release
-                        and receiver.abort_notified
-                    ):
-                        receiver.kv_mgr.register_deferred_abort_room(
-                            decode_req.req.bootstrap_room
-                        )
 
             # Abort requests whose KV is already backed up for retraction.
             if self.disagg_decode_prealloc_queue.retracted_queue:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -27,6 +27,7 @@ import socket
 import sys
 import threading
 import time
+import uuid
 from array import array
 from collections import deque
 from contextlib import nullcontext
@@ -1413,6 +1414,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 bootstrap_host=obj.bootstrap_host,
                 bootstrap_port=obj.bootstrap_port,
                 bootstrap_room=bootstrap_room,
+                disagg_request_epoch=(
+                    uuid.uuid4().hex
+                    if self.disaggregation_mode == DisaggregationMode.DECODE
+                    else None
+                ),
                 lora_id=obj.lora_id,
                 input_embeds=input_embeds,
                 positional_embed_overrides=obj.positional_embed_overrides,

--- a/rust/sglang-server/src/message/io_struct.rs
+++ b/rust/sglang-server/src/message/io_struct.rs
@@ -53,6 +53,7 @@ wire_struct! {
         decode_tp_size: Option<i64>,
         routed_dp_rank: Option<i64>,
         disagg_prefill_dp_rank: Option<i64>,
+        disagg_request_epoch: Option<String>,
     }
 }
 
@@ -114,6 +115,7 @@ impl<'a> From<&'a GenerateRequest> for TokenizedGenerateReqInput<'a> {
             decode_tp_size: req.decode_tp_size,
             routed_dp_rank: req.routed_dp_rank,
             disagg_prefill_dp_rank: req.disagg_prefill_dp_rank,
+            disagg_request_epoch: Some(uuid::Uuid::new_v4().simple().to_string()),
         }
     }
 }
@@ -180,9 +182,9 @@ mod tests {
         let bytes = TokenizedGenerateReqInput::from(&req).encode().unwrap();
         let val = rmpv::decode::read_value(&mut &bytes[..]).unwrap();
         let arr = val.as_array().expect("array");
-        // msgspec requires >= 14 (through `stream`); we emit 32 (through
+        // msgspec requires >= 14 (through `stream`); we emit 33 (through
         // `disagg_prefill_dp_rank`). Trailing defaulted fields are omitted.
-        assert_eq!(arr.len(), 32, "header ends at disagg_prefill_dp_rank");
+        assert_eq!(arr.len(), 33, "header ends at disagg_prefill_dp_rank");
         assert_eq!(arr[0].as_str(), Some("TokenizedGenerateReqInput"));
         assert_eq!(arr[1].as_str(), Some("r1"));
         assert!(arr[5].is_nil(), "idx 5 must be input_embeds (nil)");
@@ -212,7 +214,7 @@ mod tests {
         );
     }
 
-    /// The PD block must land on Python's wire indices 25–31, with the filler
+    /// The PD block must land on Python's wire indices 25–32, with the filler
     /// block (17–24) holding its defaults — a shift here silently routes KV
     /// transfers to the wrong host/room.
     #[test]
@@ -245,5 +247,10 @@ mod tests {
         assert_eq!(arr[29].as_i64(), Some(2), "decode_tp_size at 29");
         assert_eq!(arr[30].as_i64(), Some(3), "routed_dp_rank at 30");
         assert_eq!(arr[31].as_i64(), Some(4), "disagg_prefill_dp_rank at 31");
+        assert_eq!(
+            arr[32].as_str().map(str::len),
+            Some(32),
+            "disagg_request_epoch at 32"
+        );
     }
 }

--- a/test/registered/amd/disaggregation/test_mori_transfer_engine_e2e.py
+++ b/test/registered/amd/disaggregation/test_mori_transfer_engine_e2e.py
@@ -1,8 +1,21 @@
 import os
+import struct
+import threading
 import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
+import numpy as np
 import requests
 
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.common.utils import build_dcp_token_transfer_plan
+from sglang.srt.disaggregation.mori.conn import (
+    MORI_DCP_GUARD,
+    KVArgsRegisterInfo,
+    MoriKVManager,
+)
+from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.test.ci.ci_register import register_amd_ci
 from sglang.test.server_fixtures.disaggregation_fixture import (
     PDDisaggregationServerBase,
@@ -15,6 +28,251 @@ from sglang.test.test_utils import (
 )
 
 register_amd_ci(est_time=900, suite="stage-b-test-large-8-gpu-mi35x-disaggregation-amd")
+
+
+class TestMoriDCPTransfer(unittest.TestCase):
+    def test_register_info_parses_dcp_geometry(self):
+        kv_descs = [object(), object()]
+        payload = [
+            b"None",
+            b"10.0.0.2",
+            b"23456",
+            b"engine",
+            b"kv",
+            b"aux",
+            b"state",
+            b"3",
+            b"4",
+            b"1",
+            b"1024",
+            b"",
+            b"",
+            struct.pack("2Q", 1024, 2048),
+            struct.pack("2I", 2, 7),
+            b"4",
+            b"3",
+        ]
+        fake_engine_desc = SimpleNamespace(key="engine")
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.mori.conn.EngineDesc.unpack",
+                return_value=fake_engine_desc,
+            ),
+            patch(
+                "sglang.srt.disaggregation.mori.conn._unpack_mem_desc_list",
+                side_effect=[kv_descs, []],
+            ),
+            patch(
+                "sglang.srt.disaggregation.mori.conn._unpack_mem_desc_lists",
+                return_value=[],
+            ),
+        ):
+            info = KVArgsRegisterInfo.from_zmq(payload)
+
+        self.assertEqual(info.dst_kv_item_lens, [1024, 2048])
+        self.assertEqual(info.dst_kv_layer_ids, [2, 7])
+        self.assertEqual(info.dst_dcp_size, 4)
+        self.assertEqual(info.dst_dcp_rank, 3)
+
+    def test_register_info_defaults_for_legacy_peer(self):
+        kv_descs = [object(), object()]
+        payload = [
+            b"None",
+            b"10.0.0.2",
+            b"23456",
+            b"engine",
+            b"kv",
+            b"aux",
+            b"state",
+            b"0",
+            b"1",
+            b"0",
+            b"256",
+        ]
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.mori.conn.EngineDesc.unpack",
+                return_value=SimpleNamespace(key="engine"),
+            ),
+            patch(
+                "sglang.srt.disaggregation.mori.conn._unpack_mem_desc_list",
+                side_effect=[kv_descs, []],
+            ),
+            patch(
+                "sglang.srt.disaggregation.mori.conn._unpack_mem_desc_lists",
+                return_value=[],
+            ),
+        ):
+            info = KVArgsRegisterInfo.from_zmq(payload)
+
+        self.assertEqual(info.dst_kv_item_lens, [256, 256])
+        self.assertEqual(info.dst_kv_layer_ids, [])
+        self.assertEqual(info.dst_dcp_size, 1)
+        self.assertEqual(info.dst_dcp_rank, 0)
+
+    def test_send_kvcache_dcp_uses_token_byte_offsets(self):
+        manager = MoriKVManager.__new__(MoriKVManager)
+        manager.kv_mem_descs = ["src0", "src1"]
+        manager._submit_batch_transfer_plan = MagicMock(
+            side_effect=[["status0"], ["status1"]]
+        )
+        peer_info = SimpleNamespace(
+            dst_kv_mem_descs=["dst0", "dst1"],
+            dcp_dst_region_indices=[1, 0],
+            dcp_token_item_lens=[8, 16],
+        )
+        plan = build_dcp_token_transfer_plan(
+            np.array([2], dtype=np.int32),
+            np.array([7], dtype=np.int32),
+            physical_page_size=4,
+            dcp_size=2,
+            dcp_rank=0,
+            num_kv_tokens=4,
+        )
+
+        statuses = manager.send_kvcache_dcp(peer_info, plan)
+
+        self.assertEqual(statuses, ["status0", "status1"])
+        first_plan = manager._submit_batch_transfer_plan.call_args_list[0].args[2]
+        self.assertEqual(first_plan.local_offsets, [64, 80])
+        self.assertEqual(first_plan.remote_offsets, [224, 232])
+        self.assertEqual(first_plan.sizes, [8, 8])
+        second_plan = manager._submit_batch_transfer_plan.call_args_list[1].args[2]
+        self.assertEqual(second_plan.local_offsets, [128, 160])
+        self.assertEqual(second_plan.remote_offsets, [448, 464])
+        self.assertEqual(second_plan.sizes, [16, 16])
+
+    def test_add_remote_peer_resolves_dcp_destination_layers(self):
+        manager = MoriKVManager.__new__(MoriKVManager)
+        manager.decode_kv_args_table = {}
+        manager.engine = SimpleNamespace(register_remote_engine=MagicMock())
+        manager.dcp_size = 1
+        manager.dcp_rank = 0
+        manager.is_mla_backend = True
+        manager.is_hybrid_mla_backend = False
+        manager.kv_mem_descs = ["src2", "src7"]
+        manager.kv_args = SimpleNamespace(
+            kv_layer_ids=[2, 7],
+            kv_item_lens=[512, 1024],
+            page_size=64,
+            num_draft_entries=0,
+        )
+        peer_info = KVArgsRegisterInfo(
+            endpoint="10.0.0.2",
+            dst_port=23456,
+            engine_desc=SimpleNamespace(key="peer"),
+            dst_kv_mem_descs=["dst7", "dst2"],
+            dst_aux_mem_descs=[],
+            dst_state_mem_descs=[],
+            gpu_id=3,
+            decode_tp_size=4,
+            decode_tp_rank=3,
+            dst_kv_item_len=1024,
+            dst_state_item_lens=[],
+            dst_state_dim_per_tensor=[],
+            dst_kv_item_lens=[1024, 512],
+            dst_kv_layer_ids=[7, 2],
+            dst_dcp_size=4,
+            dst_dcp_rank=3,
+        )
+
+        manager._add_remote_peer(peer_info)
+
+        self.assertTrue(peer_info.requires_dcp_relayout)
+        self.assertEqual(peer_info.dcp_dst_region_indices, [1, 0])
+        self.assertEqual(peer_info.dcp_token_item_lens, [8, 16])
+        self.assertIs(manager.decode_kv_args_table["peer"], peer_info)
+        manager.engine.register_remote_engine.assert_called_once_with(
+            peer_info.engine_desc
+        )
+
+    def test_add_remote_peer_slices_regular_mla_destination_for_pp(self):
+        manager = MoriKVManager.__new__(MoriKVManager)
+        manager.decode_kv_args_table = {}
+        manager.engine = SimpleNamespace(register_remote_engine=MagicMock())
+        manager.dcp_size = 1
+        manager.dcp_rank = 0
+        manager.is_mla_backend = True
+        manager.is_hybrid_mla_backend = False
+        manager.kv_mem_descs = ["src2", "src3"]
+        manager.kv_args = SimpleNamespace(
+            kv_layer_ids=[],
+            kv_item_lens=[512, 512],
+            page_size=64,
+            prefill_start_layer=2,
+            mla_compression_ratios=None,
+            num_draft_entries=0,
+        )
+        peer_info = KVArgsRegisterInfo(
+            endpoint="10.0.0.2",
+            dst_port=23456,
+            engine_desc=SimpleNamespace(key="peer"),
+            dst_kv_mem_descs=["dst0", "dst1", "dst2", "dst3"],
+            dst_aux_mem_descs=[],
+            dst_state_mem_descs=[],
+            gpu_id=3,
+            decode_tp_size=4,
+            decode_tp_rank=3,
+            dst_kv_item_len=512,
+            dst_state_item_lens=[],
+            dst_state_dim_per_tensor=[],
+            dst_kv_item_lens=[512, 512, 512, 512],
+            dst_dcp_size=4,
+            dst_dcp_rank=3,
+        )
+
+        manager._add_remote_peer(peer_info)
+
+        self.assertEqual(peer_info.dcp_dst_region_indices, [2, 3])
+        self.assertEqual(peer_info.dcp_token_item_lens, [8, 8])
+
+    def test_dcp_registration_guard_is_accepted(self):
+        manager = MoriKVManager.__new__(MoriKVManager)
+
+        self.assertEqual(
+            manager._validate_message([MORI_DCP_GUARD, b"None"]),
+            [b"None"],
+        )
+
+    def test_submit_routes_nonzero_dcp_chunk_with_full_destination_pages(self):
+        manager = MoriKVManager.__new__(MoriKVManager)
+        manager.disaggregation_mode = DisaggregationMode.PREFILL
+        manager.request_status = {23: KVPoll.WaitingForInput}
+        manager.transfer_lock = threading.Lock()
+        info = SimpleNamespace(
+            engine_key="peer",
+            is_dummy=False,
+            dst_kv_indices=np.array([7], dtype=np.int32),
+            decode_prefix_len=0,
+            dst_state_indices=[],
+            dst_aux_index=-1,
+        )
+        peer_info = SimpleNamespace(
+            requires_dcp_relayout=True,
+            dst_dcp_size=2,
+            dst_dcp_rank=0,
+        )
+        manager.transfer_infos = {23: {"peer": info}}
+        manager.decode_kv_args_table = {"peer": peer_info}
+        manager.kv_args = SimpleNamespace(page_size=4)
+        manager.state_mem_descs = []
+        manager.update_status = MagicMock()
+        manager.send_kvcache_dcp = MagicMock(return_value=["status"])
+
+        statuses = manager._submit_kv_transfer(
+            23,
+            np.array([3], dtype=np.int32),
+            slice(1, 2),
+            False,
+            num_kv_tokens=4,
+        )
+
+        self.assertEqual(statuses, ["status"])
+        plan = manager.send_kvcache_dcp.call_args.args[1]
+        np.testing.assert_array_equal(plan.target_src_token_indices, [12, 14])
+        np.testing.assert_array_equal(plan.target_dst_token_indices, [30, 31])
 
 
 class MoriTransferEngineBase(PDDisaggregationServerBase):

--- a/test/registered/amd/disaggregation/test_mori_transfer_engine_e2e.py
+++ b/test/registered/amd/disaggregation/test_mori_transfer_engine_e2e.py
@@ -351,14 +351,22 @@ class TestMoriDCPTransfer(unittest.TestCase):
         self.assertEqual(second_plan.remote_offsets, [448, 464])
         self.assertEqual(second_plan.sizes, [16, 16])
 
-    def test_send_kvcache_dcp_rejects_draft_rows(self):
+    def test_send_kvcache_dcp_keeps_draft_rows_replicated_and_unpacked(self):
         manager = MoriKVManager.__new__(MoriKVManager)
         manager.kv_mem_descs = ["target-src", "draft-src"]
         manager.kv_args = SimpleNamespace(num_draft_entries=1)
-        manager._submit_batch_transfer_plan = MagicMock()
+        submitted_statuses = iter(("target-status", "draft-status"))
+
+        def submit_plan(*args, status_sink=None):
+            result = [next(submitted_statuses)]
+            if status_sink is not None:
+                status_sink.extend(result)
+            return result
+
+        manager._submit_batch_transfer_plan = MagicMock(side_effect=submit_plan)
         peer_info = SimpleNamespace(
-            dst_kv_mem_descs=["target-dst", "draft-dst"],
-            dcp_dst_region_indices=[0, 1],
+            dst_kv_mem_descs=["draft-dst", "target-dst"],
+            dcp_dst_region_indices=[1, 0],
             dcp_token_item_lens=[8, 16],
         )
         plan = build_dcp_token_transfer_plan(
@@ -369,10 +377,117 @@ class TestMoriDCPTransfer(unittest.TestCase):
             dcp_rank=0,
             num_kv_tokens=4,
         )
+        packed_src = MoriPackedDCPSource(
+            mem_desc="target-pack",
+            layer_offsets=[128],
+            token_indices=np.arange(2, dtype=np.int64),
+        )
 
-        with self.assertRaisesRegex(RuntimeError, "draft KV transfer is not supported"):
-            manager.send_kvcache_dcp(peer_info, plan)
+        statuses = manager.send_kvcache_dcp(peer_info, plan, packed_src)
+
+        self.assertEqual(statuses, ["target-status", "draft-status"])
+        target_call, draft_call = manager._submit_batch_transfer_plan.call_args_list
+        self.assertEqual(target_call.args[:2], ("target-pack", "target-dst"))
+        self.assertEqual(target_call.args[2].local_offsets, [128])
+        self.assertEqual(target_call.args[2].remote_offsets, [112])
+        self.assertEqual(target_call.args[2].sizes, [16])
+        self.assertEqual(draft_call.args[:2], ("draft-src", "draft-dst"))
+        self.assertEqual(draft_call.args[2].local_offsets, [96])
+        self.assertEqual(draft_call.args[2].remote_offsets, [448])
+        self.assertEqual(draft_call.args[2].sizes, [64])
+
+    def test_send_kvcache_dcp_submits_draft_when_target_plan_is_empty(self):
+        manager = MoriKVManager.__new__(MoriKVManager)
+        manager.kv_mem_descs = ["target-src", "draft-src"]
+        manager.kv_args = SimpleNamespace(num_draft_entries=1)
+
+        def submit_plan(*args, status_sink=None):
+            result = ["draft-status"]
+            if status_sink is not None:
+                status_sink.extend(result)
+            return result
+
+        manager._submit_batch_transfer_plan = MagicMock(side_effect=submit_plan)
+        peer_info = SimpleNamespace(
+            dst_kv_mem_descs=["target-dst", "draft-dst"],
+            dcp_dst_region_indices=[0, 1],
+            dcp_token_item_lens=[8, 16],
+        )
+        plan = build_dcp_token_transfer_plan(
+            np.array([3], dtype=np.int32),
+            np.array([7], dtype=np.int32),
+            physical_page_size=2,
+            dcp_size=4,
+            dcp_rank=3,
+            num_kv_tokens=2,
+        )
+        self.assertEqual(plan.target_src_token_indices.size, 0)
+
+        statuses = manager.send_kvcache_dcp(peer_info, plan)
+
+        self.assertEqual(statuses, ["draft-status"])
+        draft_call = manager._submit_batch_transfer_plan.call_args
+        self.assertEqual(draft_call.args[:2], ("draft-src", "draft-dst"))
+        self.assertEqual(draft_call.args[2].local_offsets, [96])
+        self.assertEqual(draft_call.args[2].remote_offsets, [896])
+        self.assertEqual(draft_call.args[2].sizes, [32])
+
+    def test_send_kvcache_dcp_empty_plan_preserves_status_sink(self):
+        manager = MoriKVManager.__new__(MoriKVManager)
+        manager.kv_args = SimpleNamespace(num_draft_entries=1)
+        manager._submit_batch_transfer_plan = MagicMock()
+        plan = build_dcp_token_transfer_plan(
+            np.empty((0,), dtype=np.int32),
+            np.empty((0,), dtype=np.int32),
+            physical_page_size=2,
+            dcp_size=2,
+            dcp_rank=0,
+            num_kv_tokens=0,
+        )
+        statuses = ["existing-status"]
+
+        result = manager.send_kvcache_dcp(SimpleNamespace(), plan, status_sink=statuses)
+
+        self.assertIs(result, statuses)
+        self.assertEqual(result, ["existing-status"])
         manager._submit_batch_transfer_plan.assert_not_called()
+
+    def test_send_kvcache_dcp_retains_submitted_parts_on_later_failure(self):
+        manager = MoriKVManager.__new__(MoriKVManager)
+        manager.kv_mem_descs = ["target-src", "draft0-src", "draft1-src"]
+        manager.kv_args = SimpleNamespace(num_draft_entries=2)
+        submitted_statuses = iter(("target-status", "draft0-status"))
+
+        def submit_plan(*args, status_sink=None):
+            try:
+                result = [next(submitted_statuses)]
+            except StopIteration:
+                raise RuntimeError("draft submit failed")
+            if status_sink is not None:
+                status_sink.extend(result)
+            return result
+
+        manager._submit_batch_transfer_plan = MagicMock(side_effect=submit_plan)
+        peer_info = SimpleNamespace(
+            dst_kv_mem_descs=["target-dst", "draft0-dst", "draft1-dst"],
+            dcp_dst_region_indices=[0, 1, 2],
+            dcp_token_item_lens=[8, 16, 16],
+        )
+        plan = build_dcp_token_transfer_plan(
+            np.array([3, 4], dtype=np.int32),
+            np.array([7], dtype=np.int32),
+            physical_page_size=2,
+            dcp_size=2,
+            dcp_rank=0,
+            num_kv_tokens=4,
+        )
+        statuses = []
+
+        with self.assertRaisesRegex(RuntimeError, "draft submit failed"):
+            manager.send_kvcache_dcp(peer_info, plan, status_sink=statuses)
+
+        self.assertEqual(statuses, ["target-status", "draft0-status"])
+        self.assertEqual(manager._submit_batch_transfer_plan.call_count, 3)
 
     def test_add_remote_peer_resolves_dcp_destination_layers(self):
         manager = MoriKVManager.__new__(MoriKVManager)
@@ -577,6 +692,43 @@ class TestMoriDCPPackedTransfer(unittest.TestCase):
         self.assertIsNone(pack_buffer)
         self.assertEqual(manager._dcp_pack_disabled_workers, {1})
         self.assertIsNone(manager._get_or_init_dcp_pack_buffer(1))
+
+    def test_pack_dcp_rank_excludes_draft_tail(self):
+        manager = MoriKVManager.__new__(MoriKVManager)
+        manager.kv_args = SimpleNamespace(
+            kv_data_ptrs=[0x2000, 0x3000],
+            num_draft_entries=1,
+        )
+        manager._dcp_pack_mem_descs = {0x1000: "pack-desc"}
+        pack_buffer = SimpleNamespace(
+            get_size=lambda: 1024,
+            get_ptr=lambda: 0x1000,
+        )
+        peer_info = SimpleNamespace(
+            dst_dcp_rank=0,
+            dst_dcp_size=2,
+            dcp_token_item_lens=[8, 16],
+        )
+        src_indices = np.array([1, 3], dtype=np.int64)
+        packed_by_rank = {}
+
+        with patch(
+            "sglang.srt.disaggregation.common.dcp_pack.try_pack_dcp_src",
+            return_value=([0x1080], np.arange(2, dtype=np.int64)),
+        ) as pack_mock:
+            packed = manager._pack_dcp_rank_once(
+                pack_buffer,
+                peer_info,
+                src_indices,
+                packed_by_rank,
+            )
+
+        self.assertIsNotNone(packed)
+        self.assertEqual(packed.mem_desc, "pack-desc")
+        self.assertEqual(packed.layer_offsets, [128])
+        pack_mock.assert_called_once()
+        self.assertEqual(pack_mock.call_args.kwargs["kv_data_ptrs"], [0x2000])
+        self.assertEqual(pack_mock.call_args.kwargs["token_item_lens"], [8])
 
     def test_packed_source_collapses_to_one_block_per_layer(self):
         manager = MoriKVManager.__new__(MoriKVManager)

--- a/test/registered/amd/disaggregation/test_mori_transfer_engine_e2e.py
+++ b/test/registered/amd/disaggregation/test_mori_transfer_engine_e2e.py
@@ -11,11 +11,16 @@ import requests
 from sglang.srt.disaggregation.base.conn import KVPoll
 from sglang.srt.disaggregation.common.utils import build_dcp_token_transfer_plan
 from sglang.srt.disaggregation.mori.conn import (
-    MORI_DCP_GUARD,
     KVArgsRegisterInfo,
     MoriKVManager,
+    MoriKVReceiver,
+    MoriKVSubmissionError,
+    MoriPackedDCPSource,
 )
 from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.environ import envs
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
 from sglang.test.ci.ci_register import register_amd_ci
 from sglang.test.server_fixtures.disaggregation_fixture import (
     PDDisaggregationServerBase,
@@ -31,6 +36,199 @@ register_amd_ci(est_time=900, suite="stage-b-test-large-8-gpu-mi35x-disaggregati
 
 
 class TestMoriDCPTransfer(unittest.TestCase):
+    @staticmethod
+    def _make_generation_manager():
+        manager = MoriKVManager.__new__(MoriKVManager)
+        manager._deferred_ack_lock = threading.Lock()
+        manager._deferred_ack_retry_rooms = set()
+        manager._staging_outstanding = {}
+        manager._room_lifecycle_lock = threading.Lock()
+        manager.transfer_lock = threading.Lock()
+        manager._room_generations = {}
+        manager._room_owners = {}
+        manager._retired_room_status = {}
+        manager._retired_room_failures = {}
+        manager._aborted_generations = {}
+        manager._rooms_pending_clear = {}
+        manager._deferred_ack_targets = {}
+        manager.transfer_infos = {}
+        manager.decode_kv_args_table = {}
+        manager.request_status = {}
+        manager.req_to_decode_prefix_len = {}
+        manager.failure_lock = threading.Lock()
+        manager.failure_records = {}
+        manager.requires_strict_deferred_release = True
+        manager.enable_deferred_decode_kv_release = True
+        return manager
+
+    def test_shared_status_notification_keeps_request_epoch(self):
+        manager = self._make_generation_manager()
+        manager.attn_tp_rank = 0
+        manager.pp_size = 1
+        manager.attn_cp_size = 1
+        manager.pp_rank = 0
+        manager.attn_cp_rank = 0
+        manager._send_multipart_locked = MagicMock()
+        manager._room_owners[23] = "owner-a"
+        manager._room_generations[23] = "request-a"
+        manager.request_status[23] = KVPoll.Transferring
+        manager.transfer_infos[23] = {
+            "decode": SimpleNamespace(
+                endpoint="10.0.0.2",
+                dst_port=9000,
+                is_dummy=False,
+            )
+        }
+
+        status = manager._conclude_owned_transfer(
+            23,
+            KVPoll.Success,
+            "owner-a",
+        )
+
+        self.assertEqual(status, KVPoll.Success)
+        sent_frames = manager._send_multipart_locked.call_args.args[1]
+        self.assertEqual(sent_frames[-1], b"request-a")
+
+    def test_decode_tokenizer_epochs_are_unique_for_reused_request_id(self):
+        class FakeSamplingParams:
+            def __init__(self, **_kwargs):
+                pass
+
+            def normalize(self, _tokenizer):
+                pass
+
+            def verify(self, _vocab_size):
+                pass
+
+        manager = TokenizerManager.__new__(TokenizerManager)
+        manager.preferred_sampling_params = {}
+        manager.sampling_params_class = FakeSamplingParams
+        manager.tokenizer = None
+        manager.model_config = SimpleNamespace(vocab_size=32)
+        manager.disaggregation_mode = DisaggregationMode.DECODE
+        manager.rid_to_state = {
+            "reused-request-id": SimpleNamespace(
+                time_stats=SimpleNamespace(set_tokenize_finish_time=lambda: None)
+            )
+        }
+        request = GenerateReqInput(
+            rid="reused-request-id",
+            text="hello",
+            sampling_params={},
+            bootstrap_room=23,
+        )
+
+        first = manager._create_tokenized_object(request, "hello", [1])
+        second = manager._create_tokenized_object(request, "hello", [1])
+
+        self.assertIsNotNone(first.disagg_request_epoch)
+        self.assertNotEqual(first.disagg_request_epoch, second.disagg_request_epoch)
+        manager.disaggregation_mode = DisaggregationMode.PREFILL
+        prefill = manager._create_tokenized_object(request, "hello", [1])
+        self.assertIsNone(prefill.disagg_request_epoch)
+
+    def test_aborted_generation_does_not_poison_reused_room(self):
+        manager = self._make_generation_manager()
+        manager.decode_kv_args_table = {"decode": SimpleNamespace(dst_dcp_size=4)}
+        manager.resolve_kv_replica_factor = MagicMock()
+        manager._send_abort_ack = MagicMock(return_value=True)
+        payload = lambda generation: [
+            b"23",
+            b"10.0.0.2",
+            b"9000",
+            b"decode",
+            np.array([7], dtype=np.int32).tobytes(),
+            b"1",
+            b"",
+            b"1",
+            b"",
+            generation.encode("ascii"),
+        ]
+
+        manager.activate_room_owner(23, "owner-a")
+        manager._handle_transfer_message(payload("request-a"))
+        manager._handle_abort_message(
+            [b"ABORT", b"23", b"10.0.0.2", b"9000", b"request-a"]
+        )
+        self.assertNotIn(23, manager._room_owners)
+
+        manager._handle_transfer_message(payload("request-a"))
+        manager._handle_transfer_message(payload("request-b"))
+        manager.activate_room_owner(23, "owner-b")
+
+        self.assertEqual(manager.request_status[23], KVPoll.WaitingForInput)
+        self.assertEqual(manager._room_generations[23], "request-b")
+        manager._handle_abort_message(
+            [b"ABORT", b"23", b"10.0.0.2", b"9000", b"request-a"]
+        )
+        manager._handle_abort_message([b"ABORT", b"23", b"10.0.0.2", b"9000"])
+        self.assertEqual(manager.request_status[23], KVPoll.WaitingForInput)
+        self.assertEqual(manager._room_owners[23], "owner-b")
+
+        with patch("sglang.srt.disaggregation.mori.conn.MORI_ABORT_TOMBSTONE_LIMIT", 2):
+            for room in (30, 31, 32):
+                manager._handle_abort_message(
+                    [
+                        b"ABORT",
+                        str(room).encode("ascii"),
+                        b"10.0.0.2",
+                        b"9000",
+                        f"request-{room}".encode("ascii"),
+                    ]
+                )
+        self.assertEqual(len(manager._aborted_generations), 2)
+
+    def test_dcp1_abort_waits_for_counted_chunk_and_cleans_owner(self):
+        manager = self._make_generation_manager()
+        manager.decode_kv_args_table = {"decode": SimpleNamespace(dst_dcp_size=1)}
+        manager.resolve_kv_replica_factor = MagicMock()
+        manager.activate_room_owner(23, "owner-a")
+        manager._handle_transfer_message(
+            [
+                b"23",
+                b"10.0.0.2",
+                b"9000",
+                b"decode",
+                np.array([7], dtype=np.int32).tobytes(),
+                b"1",
+                b"",
+                b"1",
+                b"",
+            ]
+        )
+        manager.disaggregation_mode = DisaggregationMode.PREFILL
+        manager._num_shards = 1
+        manager._dcp_pack_worker_count = 0
+        manager._staging_outstanding[23] = 0
+        manager._transfer_queues = [MagicMock()]
+        manager._send_abort_ack = MagicMock(return_value=True)
+
+        def abort_during_admission(_chunk):
+            self.assertEqual(manager._staging_outstanding[23], 1)
+            manager._handle_abort_message([b"ABORT", b"23", b"10.0.0.2", b"9000"])
+            manager._send_abort_ack.assert_not_called()
+
+        manager._transfer_queues[0].put.side_effect = abort_during_admission
+        manager.add_transfer_request(
+            23,
+            np.array([2], dtype=np.int32),
+            slice(0, 1),
+            False,
+            num_kv_tokens=4,
+            room_owner="owner-a",
+        )
+        self.assertTrue(manager._defer_room_clear_if_outstanding(23, "owner-a"))
+        manager._staging_outstanding[23] = 0
+        manager._maybe_ack_drained_abort(23)
+        manager._clear_room_after_drain(23)
+
+        manager._send_abort_ack.assert_called_once_with("10.0.0.2", 9000, 23, None)
+        self.assertNotIn(23, manager._room_owners)
+        self.assertNotIn(23, manager.request_status)
+        self.assertNotIn((23, "owner-a"), manager._retired_room_status)
+        self.assertNotIn((23, "owner-a"), manager._retired_room_failures)
+
     def test_register_info_parses_dcp_geometry(self):
         kv_descs = [object(), object()]
         payload = [
@@ -51,6 +249,7 @@ class TestMoriDCPTransfer(unittest.TestCase):
             struct.pack("2I", 2, 7),
             b"4",
             b"3",
+            b"registration-a",
         ]
         fake_engine_desc = SimpleNamespace(key="engine")
 
@@ -74,6 +273,7 @@ class TestMoriDCPTransfer(unittest.TestCase):
         self.assertEqual(info.dst_kv_layer_ids, [2, 7])
         self.assertEqual(info.dst_dcp_size, 4)
         self.assertEqual(info.dst_dcp_rank, 3)
+        self.assertEqual(info.dcp_registration_id, "registration-a")
 
     def test_register_info_defaults_for_legacy_peer(self):
         kv_descs = [object(), object()]
@@ -115,9 +315,16 @@ class TestMoriDCPTransfer(unittest.TestCase):
     def test_send_kvcache_dcp_uses_token_byte_offsets(self):
         manager = MoriKVManager.__new__(MoriKVManager)
         manager.kv_mem_descs = ["src0", "src1"]
-        manager._submit_batch_transfer_plan = MagicMock(
-            side_effect=[["status0"], ["status1"]]
-        )
+        manager.kv_args = SimpleNamespace(num_draft_entries=0)
+        submitted_statuses = iter(("status0", "status1"))
+
+        def submit_plan(*args, status_sink=None):
+            result = [next(submitted_statuses)]
+            if status_sink is not None:
+                status_sink.extend(result)
+            return result
+
+        manager._submit_batch_transfer_plan = MagicMock(side_effect=submit_plan)
         peer_info = SimpleNamespace(
             dst_kv_mem_descs=["dst0", "dst1"],
             dcp_dst_region_indices=[1, 0],
@@ -144,6 +351,29 @@ class TestMoriDCPTransfer(unittest.TestCase):
         self.assertEqual(second_plan.remote_offsets, [448, 464])
         self.assertEqual(second_plan.sizes, [16, 16])
 
+    def test_send_kvcache_dcp_rejects_draft_rows(self):
+        manager = MoriKVManager.__new__(MoriKVManager)
+        manager.kv_mem_descs = ["target-src", "draft-src"]
+        manager.kv_args = SimpleNamespace(num_draft_entries=1)
+        manager._submit_batch_transfer_plan = MagicMock()
+        peer_info = SimpleNamespace(
+            dst_kv_mem_descs=["target-dst", "draft-dst"],
+            dcp_dst_region_indices=[0, 1],
+            dcp_token_item_lens=[8, 16],
+        )
+        plan = build_dcp_token_transfer_plan(
+            np.array([3, 4], dtype=np.int32),
+            np.array([7], dtype=np.int32),
+            physical_page_size=2,
+            dcp_size=2,
+            dcp_rank=0,
+            num_kv_tokens=4,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "draft KV transfer is not supported"):
+            manager.send_kvcache_dcp(peer_info, plan)
+        manager._submit_batch_transfer_plan.assert_not_called()
+
     def test_add_remote_peer_resolves_dcp_destination_layers(self):
         manager = MoriKVManager.__new__(MoriKVManager)
         manager.decode_kv_args_table = {}
@@ -153,6 +383,7 @@ class TestMoriDCPTransfer(unittest.TestCase):
         manager.is_mla_backend = True
         manager.is_hybrid_mla_backend = False
         manager.kv_mem_descs = ["src2", "src7"]
+        manager._init_dcp_pack_buffers_once = MagicMock()
         manager.kv_args = SimpleNamespace(
             kv_layer_ids=[2, 7],
             kv_item_lens=[512, 1024],
@@ -176,6 +407,7 @@ class TestMoriDCPTransfer(unittest.TestCase):
             dst_kv_layer_ids=[7, 2],
             dst_dcp_size=4,
             dst_dcp_rank=3,
+            supports_dcp_drain=True,
         )
 
         manager._add_remote_peer(peer_info)
@@ -183,6 +415,7 @@ class TestMoriDCPTransfer(unittest.TestCase):
         self.assertTrue(peer_info.requires_dcp_relayout)
         self.assertEqual(peer_info.dcp_dst_region_indices, [1, 0])
         self.assertEqual(peer_info.dcp_token_item_lens, [8, 16])
+        manager._init_dcp_pack_buffers_once.assert_called_once_with(4)
         self.assertIs(manager.decode_kv_args_table["peer"], peer_info)
         manager.engine.register_remote_engine.assert_called_once_with(
             peer_info.engine_desc
@@ -197,6 +430,7 @@ class TestMoriDCPTransfer(unittest.TestCase):
         manager.is_mla_backend = True
         manager.is_hybrid_mla_backend = False
         manager.kv_mem_descs = ["src2", "src3"]
+        manager._init_dcp_pack_buffers_once = MagicMock()
         manager.kv_args = SimpleNamespace(
             kv_layer_ids=[],
             kv_item_lens=[512, 512],
@@ -221,20 +455,26 @@ class TestMoriDCPTransfer(unittest.TestCase):
             dst_kv_item_lens=[512, 512, 512, 512],
             dst_dcp_size=4,
             dst_dcp_rank=3,
+            supports_dcp_drain=True,
         )
 
         manager._add_remote_peer(peer_info)
 
         self.assertEqual(peer_info.dcp_dst_region_indices, [2, 3])
         self.assertEqual(peer_info.dcp_token_item_lens, [8, 8])
+        manager._init_dcp_pack_buffers_once.assert_called_once_with(4)
 
-    def test_dcp_registration_guard_is_accepted(self):
+    def test_dcp_peer_without_drain_capability_is_rejected(self):
         manager = MoriKVManager.__new__(MoriKVManager)
-
-        self.assertEqual(
-            manager._validate_message([MORI_DCP_GUARD, b"None"]),
-            [b"None"],
+        manager.decode_kv_args_table = {}
+        peer_info = SimpleNamespace(
+            engine_key="legacy-peer",
+            dst_dcp_size=2,
+            supports_dcp_drain=False,
         )
+
+        with self.assertRaisesRegex(RuntimeError, "drain-ACK support"):
+            manager._add_remote_peer(peer_info)
 
     def test_submit_routes_nonzero_dcp_chunk_with_full_destination_pages(self):
         manager = MoriKVManager.__new__(MoriKVManager)
@@ -259,9 +499,14 @@ class TestMoriDCPTransfer(unittest.TestCase):
         manager.kv_args = SimpleNamespace(page_size=4)
         manager.state_mem_descs = []
         manager.update_status = MagicMock()
-        manager.send_kvcache_dcp = MagicMock(return_value=["status"])
 
-        statuses = manager._submit_kv_transfer(
+        def send_kvcache_dcp(*args, status_sink=None):
+            status_sink.append("status")
+            return status_sink
+
+        manager.send_kvcache_dcp = MagicMock(side_effect=send_kvcache_dcp)
+
+        statuses, _ = manager._submit_kv_transfer(
             23,
             np.array([3], dtype=np.int32),
             slice(1, 2),
@@ -273,6 +518,223 @@ class TestMoriDCPTransfer(unittest.TestCase):
         plan = manager.send_kvcache_dcp.call_args.args[1]
         np.testing.assert_array_equal(plan.target_src_token_indices, [12, 14])
         np.testing.assert_array_equal(plan.target_dst_token_indices, [30, 31])
+
+
+class TestMoriDCPPackedTransfer(unittest.TestCase):
+    def test_pack_workers_are_budgeted_and_fall_back_to_raw(self):
+        manager = MoriKVManager.__new__(MoriKVManager)
+        manager._dcp_pack_init_lock = threading.Lock()
+        manager._dcp_pack_dcp_size = None
+        manager._dcp_pack_worker_count = 0
+        manager._dcp_pack_disabled_workers = set()
+        manager._dcp_pack_buffers = None
+        manager._num_shards = 8
+        manager.kv_args = SimpleNamespace(kv_item_lens=[1024])
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.common.dcp_pack."
+                "dcp_pack_buffer_bytes_for_args",
+                return_value=3 * 1024**3,
+            ),
+            patch.object(
+                type(envs.SGLANG_MORI_DCP_PACK_BUFFER_BUDGET_GB),
+                "get",
+                return_value=8.0,
+            ),
+        ):
+            manager._init_dcp_pack_buffers_once(4)
+
+        self.assertEqual(manager._dcp_pack_worker_count, 2)
+        self.assertEqual(manager._dcp_pack_dcp_size, 4)
+        self.assertEqual(manager._dcp_pack_buffers, [None] * 8)
+
+        manager.disaggregation_mode = DisaggregationMode.PREFILL
+        manager.request_status = {23: KVPoll.WaitingForInput}
+        manager.transfer_infos = {23: {"decode": SimpleNamespace(engine_key="peer")}}
+        manager.decode_kv_args_table = {
+            "peer": SimpleNamespace(requires_dcp_relayout=True)
+        }
+        manager.transfer_lock = threading.Lock()
+        manager._num_shards = 8
+        manager._dcp_pack_worker_count = 2
+        manager._staging_outstanding = {23: 0}
+        manager._deferred_ack_lock = threading.Lock()
+        manager._transfer_queues = [MagicMock() for _ in range(8)]
+
+        manager.add_transfer_request(
+            23, np.array([2], dtype=np.int32), slice(0, 1), False, num_kv_tokens=4
+        )
+
+        manager._transfer_queues[1].put.assert_called_once()
+
+        with patch(
+            "sglang.srt.disaggregation.common.dcp_pack.init_dcp_pack_buffers",
+            side_effect=RuntimeError("out of memory"),
+        ):
+            pack_buffer = manager._get_or_init_dcp_pack_buffer(1)
+
+        self.assertIsNone(pack_buffer)
+        self.assertEqual(manager._dcp_pack_disabled_workers, {1})
+        self.assertIsNone(manager._get_or_init_dcp_pack_buffer(1))
+
+    def test_packed_source_collapses_to_one_block_per_layer(self):
+        manager = MoriKVManager.__new__(MoriKVManager)
+        manager.kv_mem_descs = ["raw0", "raw1"]
+        manager.kv_args = SimpleNamespace(num_draft_entries=0)
+        submitted_statuses = iter(("status0", "status1"))
+
+        def submit_plan(*args, status_sink=None):
+            result = [next(submitted_statuses)]
+            if status_sink is not None:
+                status_sink.extend(result)
+            return result
+
+        manager._submit_batch_transfer_plan = MagicMock(side_effect=submit_plan)
+        peer_info = SimpleNamespace(
+            dst_kv_mem_descs=["dst0", "dst1"],
+            dcp_dst_region_indices=[1, 0],
+            dcp_token_item_lens=[8, 16],
+        )
+        plan = build_dcp_token_transfer_plan(
+            np.array([2], dtype=np.int32),
+            np.array([7], dtype=np.int32),
+            physical_page_size=4,
+            dcp_size=2,
+            dcp_rank=0,
+            num_kv_tokens=4,
+        )
+        packed_src = MoriPackedDCPSource(
+            mem_desc="pack",
+            layer_offsets=[100, 200],
+            token_indices=np.arange(2, dtype=np.int64),
+        )
+
+        statuses = manager.send_kvcache_dcp(peer_info, plan, packed_src)
+
+        self.assertEqual(statuses, ["status0", "status1"])
+        first_call, second_call = manager._submit_batch_transfer_plan.call_args_list
+        self.assertEqual(first_call.args[:2], ("pack", "dst1"))
+        self.assertEqual(first_call.args[2].local_offsets, [100])
+        self.assertEqual(first_call.args[2].remote_offsets, [224])
+        self.assertEqual(first_call.args[2].sizes, [16])
+        self.assertEqual(second_call.args[:2], ("pack", "dst0"))
+        self.assertEqual(second_call.args[2].local_offsets, [200])
+        self.assertEqual(second_call.args[2].remote_offsets, [448])
+        self.assertEqual(second_call.args[2].sizes, [32])
+
+    def test_partial_submission_drains_before_error_propagates(self):
+        manager = MoriKVManager.__new__(MoriKVManager)
+        manager.disaggregation_mode = DisaggregationMode.PREFILL
+        manager.request_status = {23: KVPoll.WaitingForInput}
+        manager.transfer_lock = threading.Lock()
+        manager.kv_mem_descs = ["raw0", "raw1"]
+        manager.kv_args = SimpleNamespace(page_size=4)
+        manager.state_mem_descs = []
+        manager._dcp_pack_buffers = None
+        inflight_status = object()
+        manager.engine = SimpleNamespace(
+            allocate_transfer_uid=MagicMock(side_effect=[1, 2]),
+            batch_write=MagicMock(
+                side_effect=[[inflight_status], RuntimeError("submit failed")]
+            ),
+        )
+        manager.transfer_infos = {
+            23: {
+                "peer": SimpleNamespace(
+                    engine_key="peer",
+                    is_dummy=False,
+                    dst_kv_indices=np.array([7], dtype=np.int32),
+                    decode_prefix_len=0,
+                    dst_state_indices=[],
+                    dst_aux_index=-1,
+                )
+            }
+        }
+        manager.decode_kv_args_table = {
+            "peer": SimpleNamespace(
+                requires_dcp_relayout=True,
+                dst_dcp_size=2,
+                dst_dcp_rank=0,
+                dst_kv_mem_descs=["dst0", "dst1"],
+                dcp_dst_region_indices=[0, 1],
+                dcp_token_item_lens=[8, 16],
+            )
+        }
+        manager._wait_transfer_completion = MagicMock(return_value=None)
+        chunk = SimpleNamespace(
+            room=23,
+            room_owner=None,
+            wait_event=None,
+            prefill_kv_indices=np.array([2], dtype=np.int32),
+            index_slice=slice(0, 1),
+            is_last_chunk=False,
+            prefill_aux_index=None,
+            state_indices=None,
+            num_kv_tokens=4,
+        )
+
+        with self.assertRaises(MoriKVSubmissionError):
+            manager._process_transfer_chunk(chunk, worker_index=0)
+
+        manager._wait_transfer_completion.assert_called_once_with([inflight_status])
+
+    def test_failed_strict_abort_delivery_is_retried(self):
+        receiver = object.__new__(MoriKVReceiver)
+        receiver.bootstrap_room = 23
+        receiver.bootstrap_infos = [{"rank_ip": "10.0.0.1", "rank_port": 8000}]
+        receiver.abort_notified = False
+        receiver.abort_generation = "request-a"
+        receiver.metadata_published = True
+        receiver._abort_pending_infos = None
+        receiver._abort_retry_lock = threading.Lock()
+        receiver._abort_retry_stopped = False
+        receiver._abort_retry_scheduled = False
+        receiver._connection_pool_entries = {}
+        receiver.kv_mgr = SimpleNamespace(
+            enable_deferred_decode_kv_release=True,
+            requires_strict_deferred_release=True,
+            local_ip="10.0.0.2",
+            rank_port=9000,
+            failure_lock=threading.Lock(),
+            failure_records={},
+            request_status={23: KVPoll.WaitingForInput},
+            required_prefill_response_num_table={},
+            prefill_response_tracker={},
+            record_failure=MagicMock(),
+            update_status=MagicMock(),
+            register_deferred_abort_room=MagicMock(),
+            is_abort_release_safe=MagicMock(return_value=False),
+            clear_decode_room_generation=MagicMock(),
+        )
+        receiver._connect_to_bootstrap_server = MagicMock(
+            side_effect=RuntimeError("connection refused")
+        )
+        receiver._schedule_abort_notification_retry = MagicMock()
+
+        receiver.abort()
+
+        self.assertTrue(receiver.abort_notified)
+        self.assertFalse(receiver._abort_retry_stopped)
+        receiver.kv_mgr.register_deferred_abort_room.assert_called_once_with(
+            23, "request-a"
+        )
+        self.assertEqual(len(receiver._abort_pending_infos), 1)
+        receiver._schedule_abort_notification_retry.assert_called_once_with()
+
+        socket = MagicMock()
+        receiver._connect_to_bootstrap_server = MagicMock(
+            return_value=(socket, threading.Lock())
+        )
+        receiver._send_abort_notification()
+        self.assertEqual(len(receiver._abort_pending_infos), 1)
+        self.assertEqual(receiver._schedule_abort_notification_retry.call_count, 2)
+
+        receiver.kv_mgr.is_abort_release_safe.return_value = True
+        receiver._send_abort_notification()
+        self.assertEqual(receiver._abort_pending_infos, {})
+        sent_frames = socket.send_multipart.call_args.args[0]
+        self.assertEqual(sent_frames[-1], b"request-a")
 
 
 class MoriTransferEngineBase(PDDisaggregationServerBase):

--- a/test/registered/unit/disaggregation/test_dcp_pack.py
+++ b/test/registered/unit/disaggregation/test_dcp_pack.py
@@ -255,6 +255,29 @@ class TestTryDcpPack(CustomTestCase):
         self.assertEqual(pack_view.storage_offset(), pack_offset)
         self.assertEqual(pack_view.numel(), src.size * item_len)
 
+    def test_try_pack_does_not_cross_rank_region(self):
+        pack = torch.zeros(128, dtype=torch.uint8)
+        buf = type(
+            "Buf",
+            (),
+            {
+                "buffer": pack,
+                "get_ptr": lambda self: 0x1000,
+                "get_size": lambda self: pack.numel(),
+            },
+        )()
+
+        packed = try_pack_dcp_src(
+            pack_buffer=buf,
+            kv_data_ptrs=[0x2000],
+            src_token_indices=np.arange(5, dtype=np.int64),
+            token_item_lens=[8],
+            pack_offset_bytes=32,
+            pack_limit_bytes=64,
+        )
+
+        self.assertIsNone(packed)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/disaggregation/test_dcp_pack.py
+++ b/test/registered/unit/disaggregation/test_dcp_pack.py
@@ -9,6 +9,7 @@ import torch
 from sglang.srt.disaggregation.common.conn import CommonKVManager
 from sglang.srt.disaggregation.common.dcp_pack import (
     dcp_pack_buffer_bytes,
+    dcp_pack_buffer_bytes_for_args,
     try_pack_dcp_src,
 )
 from sglang.srt.disaggregation.common.utils import (
@@ -198,6 +199,20 @@ class TestDcpPackBufferBytes(CustomTestCase):
             ),
             4 * 3 * (16 + 16),
         )
+
+    def test_for_args_excludes_draft_tail(self):
+        kv_args = SimpleNamespace(
+            kv_item_lens=[64 * 16, 64 * 16, 64 * 8],
+            num_draft_entries=1,
+            page_size=64,
+        )
+        with patch(
+            "sglang.srt.disaggregation.common.dcp_pack.max_prefill_buffer_tokens",
+            return_value=10,
+        ):
+            size = dcp_pack_buffer_bytes_for_args(kv_args, dcp_size=4)
+
+        self.assertEqual(size, 4 * 3 * (16 + 16))
 
     def test_rejects_invalid_item_lens(self):
         with self.assertRaisesRegex(ValueError, "at least one page"):

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -379,11 +379,41 @@ class TestDecodeQueueCleanup(CustomTestCase):
             req, queue.tree_cache, is_insert=False
         )
 
+        events = []
         receiver = FakeReceiver()
-        receiver.kv_mgr = FakeKVManager.__new__(FakeKVManager)
+        receiver.abort_notified = False
+        receiver.abort_generation = "request-a"
+        receiver.bootstrap_infos = [{}]
+        receiver.kv_mgr = SimpleNamespace(enable_deferred_decode_kv_release=True)
+
+        def ensure_abort():
+            events.append("abort")
+            receiver.abort_notified = True
+
+        receiver.ensure_abort_notified_for_drain = ensure_abort
+        receiver.failure_exception = lambda: events.append("failure")
         decode_req.kv_receiver = receiver
         queue.queue = [decode_req]
         queue.enable_deferred_kv_release = True
+        queue.strict_deferred_kv_release = True
+        queue.deferred_kv_release_timeout = 0.0
+        queue._deferred_releases = []
+        queue.req_to_metadata_buffer_idx_allocator.reset_mock()
+        mock_prepare_abort.reset_mock()
+        mock_release_kv_cache.reset_mock()
+
+        self.assertEqual(queue.pop_transferred(), [])
+        self.assertEqual(events, ["abort", "failure"])
+        self.assertEqual(len(queue._deferred_releases), 1)
+        self.assertIs(decode_req.kv_receiver, receiver)
+        queue.req_to_metadata_buffer_idx_allocator.free.assert_not_called()
+        mock_release_kv_cache.assert_not_called()
+
+        receiver = FakeKVReceiver(FakeKVManager.__new__(FakeKVManager), "")
+        decode_req.kv_receiver = receiver
+        queue.queue = [decode_req]
+        queue.enable_deferred_kv_release = True
+        queue.strict_deferred_kv_release = True
         queue.req_to_metadata_buffer_idx_allocator.reset_mock()
         mock_release_kv_cache.reset_mock()
 
@@ -391,19 +421,21 @@ class TestDecodeQueueCleanup(CustomTestCase):
 
         self.assertEqual(transferred, [])
         self.assertEqual(queue.queue, [])
-        self.assertTrue(receiver.clear_called)
         self.assertIsNone(decode_req.kv_receiver)
         queue.req_to_metadata_buffer_idx_allocator.free.assert_called_once_with(3)
         mock_release_kv_cache.assert_called_once_with(
             req, queue.tree_cache, is_insert=False
         )
 
-    def test_fake_receiver_initializes_deferred_release_state(self):
-        manager = MagicMock()
-        receiver = FakeKVReceiver(manager, "")
+    def test_fake_manager_uses_non_strict_release(self):
+        queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
+        queue.enable_deferred_kv_release = False
+        queue.strict_deferred_kv_release = False
 
-        self.assertIs(receiver.kv_mgr, manager)
-        self.assertFalse(receiver.abort_notified)
+        queue.configure_deferred_release(FakeKVManager.__new__(FakeKVManager))
+
+        self.assertFalse(queue.enable_deferred_kv_release)
+        self.assertFalse(queue.strict_deferred_kv_release)
 
     def test_retracted_decode_requests_keep_scheduler_non_idle(self):
         scheduler = Scheduler.__new__(Scheduler)
@@ -423,11 +455,22 @@ class TestDecodeQueueCleanup(CustomTestCase):
         scheduler.disagg_decode_prealloc_queue = SimpleNamespace(
             queue=[], retracted_queue=[object()]
         )
-        scheduler.disagg_decode_transfer_queue = SimpleNamespace(queue=[])
+        scheduler.disagg_decode_transfer_queue = MagicMock()
+        scheduler.disagg_decode_transfer_queue.queue = []
+        scheduler.disagg_decode_transfer_queue.has_pending_deferred_releases.return_value = False
         scheduler.decode_offload_manager = None
         scheduler.enable_hisparse = False
         scheduler.enable_hierarchical_cache = False
+        scheduler.metrics_reporter = MagicMock()
 
+        self.assertFalse(scheduler.is_fully_idle())
+        scheduler.disagg_decode_transfer_queue.has_pending_deferred_releases.return_value = True
+        scheduler.disagg_decode_prealloc_queue.retracted_queue = []
+
+        scheduler._record_scheduler_state_for_paused_engine()
+
+        scheduler.disagg_decode_transfer_queue.resolve_deferred_releases.assert_called_once_with()
+        scheduler.metrics_reporter.record_scheduler_active.assert_called_once_with()
         self.assertFalse(scheduler.is_fully_idle())
 
 

--- a/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
+++ b/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
@@ -8,6 +8,7 @@ that its transfer drained (CommonKVManager.is_abort_release_safe), or a timeout
 fires. See DecodeTransferQueue.resolve_deferred_releases.
 """
 
+import threading
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -25,6 +26,7 @@ def _make_manager():
     """A bare CommonKVManager carrying only the deferred-ack state the helpers
     touch (avoids the heavy real __init__)."""
     mgr = CommonKVManager.__new__(CommonKVManager)
+    mgr._deferred_abort_lock = threading.Lock()
     mgr._deferred_abort_ack_tracker = {}
     return mgr
 
@@ -64,7 +66,7 @@ class TestAbortAckAggregation(CustomTestCase):
         mgr.register_deferred_abort_room(room)
         mgr.note_abort_ack(room, 0)
         mgr.clear_deferred_abort_state(room)
-        self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
+        self.assertNotIn((room, None), mgr._deferred_abort_ack_tracker)
         self.assertFalse(mgr.is_abort_release_safe(room, required_acks=1))
 
     def test_ack_before_register_is_dropped(self):
@@ -73,7 +75,7 @@ class TestAbortAckAggregation(CustomTestCase):
         mgr = _make_manager()
         room = 104
         mgr.note_abort_ack(room, 0)  # no register yet
-        self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
+        self.assertNotIn((room, None), mgr._deferred_abort_ack_tracker)
         self.assertFalse(mgr.is_abort_release_safe(room, required_acks=1))
 
     def test_late_ack_after_release_does_not_pollute_reused_room(self):
@@ -91,7 +93,7 @@ class TestAbortAckAggregation(CustomTestCase):
 
         # Late ack from A's other rank arrives after release -> dropped.
         mgr.note_abort_ack(room, 1)
-        self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
+        self.assertNotIn((room, None), mgr._deferred_abort_ack_tracker)
 
         # Req B reuses room R.
         mgr.register_deferred_abort_room(room)
@@ -112,6 +114,23 @@ class TestAbortAckAggregation(CustomTestCase):
         mgr.register_deferred_abort_room(room)
         self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
 
+    def test_overlapping_generations_keep_independent_ack_sets(self):
+        mgr = _make_manager()
+        room = 111
+        mgr.register_deferred_abort_room(room, generation="request-a")
+        mgr.register_deferred_abort_room(room, generation="request-b")
+
+        mgr.note_abort_ack(room, 0, generation="request-a")
+
+        self.assertTrue(
+            mgr.is_abort_release_safe(room, required_acks=1, generation="request-a")
+        )
+        self.assertFalse(
+            mgr.is_abort_release_safe(room, required_acks=1, generation="request-b")
+        )
+        mgr.clear_deferred_abort_state(room, generation="request-a")
+        self.assertIn((room, "request-b"), mgr._deferred_abort_ack_tracker)
+
 
 class _FakeIdxAllocator:
     def __init__(self):
@@ -125,6 +144,7 @@ def _make_queue(timeout=30.0):
     q = DecodeTransferQueue.__new__(DecodeTransferQueue)
     q._deferred_releases = []
     q.deferred_kv_release_timeout = timeout
+    q.strict_deferred_kv_release = False
     q.enable_staging = False
     q.staging_handler = None
     q.tree_cache = object()
@@ -133,12 +153,13 @@ def _make_queue(timeout=30.0):
     return q
 
 
-def _make_decode_req(room, idx, mgr, n_prefill_ranks=1):
+def _make_decode_req(room, idx, mgr, n_prefill_ranks=1, generation=None):
     receiver = SimpleNamespace(
         kv_mgr=mgr,
         # One entry per prefill rank the decode notified of the abort; its length
         # is the required drain-ack count (see DecodeTransferQueue._defer_release).
         bootstrap_infos=[{"rank": r} for r in range(n_prefill_ranks)],
+        abort_generation=generation,
         clear=lambda: None,
     )
     return SimpleNamespace(
@@ -154,6 +175,15 @@ class TestResolveDeferredReleases(CustomTestCase):
         with patch.object(decode_mod, "release_kv_cache") as rel:
             q.resolve_deferred_releases()
         rel.assert_not_called()
+
+    def test_manager_capability_enables_strict_release(self):
+        q = _make_queue()
+        manager = SimpleNamespace(requires_strict_deferred_release=True)
+
+        q.configure_deferred_release(manager)
+
+        self.assertTrue(q.enable_deferred_kv_release)
+        self.assertTrue(q.strict_deferred_kv_release)
 
     def test_holds_until_drained_then_releases(self):
         mgr = _make_manager()
@@ -186,7 +216,7 @@ class TestResolveDeferredReleases(CustomTestCase):
         self.assertEqual(q._deferred_releases, [])
         self.assertEqual(q.req_to_metadata_buffer_idx_allocator.freed, [idx])
         self.assertEqual(q.metadata_buffers.bootstrap_room[idx], 0)
-        self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
+        self.assertNotIn((room, None), mgr._deferred_abort_ack_tracker)
         self.assertIsNone(dreq.kv_receiver)
 
     def test_releases_on_timeout_without_ack(self):
@@ -195,7 +225,7 @@ class TestResolveDeferredReleases(CustomTestCase):
         q = _make_queue(timeout=30.0)
         dreq = _make_decode_req(room, idx, mgr, n_prefill_ranks=1)
         # Force an already-expired deadline (no ack will ever arrive).
-        q._deferred_releases.append((dreq, float("-inf"), idx, 1))
+        q._deferred_releases.append((dreq, float("-inf"), idx, 1, None))
 
         with patch.object(decode_mod, "release_kv_cache") as rel:
             q.resolve_deferred_releases()
@@ -205,6 +235,32 @@ class TestResolveDeferredReleases(CustomTestCase):
         self.assertEqual(q.req_to_metadata_buffer_idx_allocator.freed, [idx])
         self.assertIsNone(dreq.kv_receiver)
 
+    def test_strict_release_never_expires_without_ack(self):
+        mgr = _make_manager()
+        room, idx = 301, 4
+        q = _make_queue(timeout=0.0)
+        q.strict_deferred_kv_release = True
+        dreq = _make_decode_req(
+            room, idx, mgr, n_prefill_ranks=1, generation="request-a"
+        )
+        mgr.register_deferred_abort_room(room, generation="request-a")
+        q._defer_release(dreq)
+
+        with patch.object(decode_mod, "release_kv_cache") as release:
+            q.resolve_deferred_releases()
+
+        release.assert_not_called()
+        self.assertEqual(len(q._deferred_releases), 1)
+        self.assertEqual(q._deferred_releases[0][1], float("inf"))
+
+    def test_memory_release_rejects_pending_deferred_holds(self):
+        q = _make_queue()
+        q.queue = []
+        q._deferred_releases.append((object(), float("inf"), 1, 1, None))
+
+        with self.assertRaisesRegex(RuntimeError, "drain acknowledgements"):
+            q.release_memory_occupation()
+
     def test_failed_release_is_isolated_and_not_retried(self):
         # A raising _do_release must drop the entry (no double-free on retry) and
         # not brick resolve for the remaining entries or subsequent calls.
@@ -213,8 +269,8 @@ class TestResolveDeferredReleases(CustomTestCase):
         good = _make_decode_req(700, 1, mgr)
         bad = _make_decode_req(701, 2, mgr)
         # Both already past deadline -> both selected for release.
-        q._deferred_releases.append((bad, float("-inf"), 2, 1))
-        q._deferred_releases.append((good, float("-inf"), 1, 1))
+        q._deferred_releases.append((bad, float("-inf"), 2, 1, None))
+        q._deferred_releases.append((good, float("-inf"), 1, 1, None))
 
         calls = []
 
@@ -237,10 +293,11 @@ class TestResolveDeferredReleases(CustomTestCase):
         dreq = _make_decode_req(room=400, idx=9, mgr=mgr)
         q._defer_release(dreq)
         self.assertEqual(len(q._deferred_releases), 1)
-        held_req, deadline, held_idx, required = q._deferred_releases[0]
+        held_req, deadline, held_idx, required, generation = q._deferred_releases[0]
         self.assertIs(held_req, dreq)
         self.assertEqual(held_idx, 9)
         self.assertIsInstance(deadline, float)
+        self.assertIsNone(generation)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -854,6 +854,10 @@ class TestNixlReceiverPoll(CustomTestCase):
         receiver.init_time = None
         receiver.conclude_state = None
         receiver.abort_notified = False
+        receiver._abort_pending_infos = None
+        receiver._abort_retry_lock = threading.Lock()
+        receiver._abort_retry_scheduled = False
+        receiver._abort_retry_stopped = False
         receiver._connection_pool_entries = {}
         return receiver, mgr
 

--- a/test/registered/unit/disaggregation/test_nixl_deferred_kv_release.py
+++ b/test/registered/unit/disaggregation/test_nixl_deferred_kv_release.py
@@ -7,6 +7,7 @@ worker polls check_xfer_state), so the ack must come from the transfer worker
 after its DONE barrier -- never from the bootstrap thread for an active room.
 """
 
+import threading
 import unittest
 from unittest.mock import MagicMock
 
@@ -24,11 +25,15 @@ def _prefill_mgr(cls=CommonKVManager, enabled=True):
     mgr = cls.__new__(cls)
     mgr.enable_deferred_decode_kv_release = enabled
     mgr._deferred_ack_targets = {}
+    mgr._deferred_ack_lock = threading.Lock()
+    mgr._deferred_ack_retry_rooms = set()
     mgr._staging_outstanding = {}
     mgr.request_status = {}
     mgr._sent = []
     # Capture acks instead of opening a socket.
-    mgr._send_abort_ack = lambda ip, port, room: mgr._sent.append((ip, port, room))
+    mgr._send_abort_ack = lambda ip, port, room, generation=None: mgr._sent.append(
+        (ip, port, room)
+    )
     return mgr
 
 
@@ -94,7 +99,7 @@ class TestNixlAbortNotification(CustomTestCase):
         mgr._staging_outstanding[11] = 1
         self.assertTrue(mgr._handle_abort_notification(self._abort_msg()))
 
-        self.assertEqual(mgr._deferred_ack_targets[11], ("10.0.0.3", 6000))
+        self.assertEqual(mgr._deferred_ack_targets[11], {("10.0.0.3", 6000, None)})
         self.assertEqual(mgr._sent, [])
         # Marked Failed first, so no new chunk can be enqueued for the room.
         self.assertEqual(mgr.request_status[11], KVPoll.Failed)
@@ -173,6 +178,7 @@ class TestNixlDecodeAckIngest(CustomTestCase):
     def test_abort_ack_is_aggregated_per_rank(self):
         # Mirrors the decode listener thread's ABORT_ACK branch.
         mgr = CommonKVManager.__new__(CommonKVManager)
+        mgr._deferred_abort_lock = threading.Lock()
         mgr._deferred_abort_ack_tracker = {}
         mgr.register_deferred_abort_room(21)
 

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -766,15 +766,23 @@ class TestLoadBalanceMethod(unittest.TestCase):
         )
         self.assertTrue(resolution_result(server_args, "disable_radix_cache"))
 
-    def test_pd_decode_dcp_rejects_unsupported_transfer_backend(self):
-        server_args = ServerArgs(
-            model_path="dummy",
+    def test_pd_decode_dcp_allows_mori_transfer_backend(self):
+        server_args = self._load_balance_args(
             disaggregation_mode="decode",
             disaggregation_transfer_backend="mori",
             dcp_size=4,
         )
+        self.assertTrue(resolution_result(server_args, "disable_radix_cache"))
+
+    def test_pd_decode_dcp_rejects_unsupported_transfer_backend(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            disaggregation_mode="decode",
+            disaggregation_transfer_backend="deepep",
+            dcp_size=4,
+        )
         with self.assertRaisesRegex(
-            ValueError, "mooncake, nixl, or fake for synthetic benchmarking"
+            ValueError, "mooncake, nixl, mori, or fake for synthetic benchmarking"
         ):
             handle_pd_disaggregation(server_args)
 


### PR DESCRIPTION
## Summary

MORI counterpart to #37709, stacked on #38317 (the MORI counterpart to #35762).

For DCP1 -> DCP-N DSPARK transfers, target KV remains owner-strided and uses the packed path from #38317. Draft KV is replicated, so every row is sent un-packed with the widened virtual-page destination mapping from #37709.

## Changes

- Split MORI DCP descriptors into target and draft tails using `num_draft_entries`.
- Exclude the draft tail from pack-buffer sizing and target gather.
- Keep target rows packed; submit draft rows as a separate replicated transfer part.
- Retain both parts in the shared status sink so earlier RDMA writes are drained if a later submission fails.
- Test packed-target/raw-draft addressing, draft-only and empty plans, permuted destination mapping, and partial-submission status retention.

## Validation

- `130 passed, 16 subtests passed` in the focused disaggregation/MORI regression suite.
- Repository AST, isort, Ruff, Ruff format, codespell, and merge-conflict checks passed.

Out of scope, matching #37709: DCP>1 prefill and heterogeneous prefill/decode TP with DSPARK.

Dependency: #38317. Until it merges, GitHub includes the base series in this PR; the isolated follow-up diff is [here](https://github.com/AMD-yanfeiwang/sglang/compare/rocm/mori-dcp-packed-transfer...rocm/mori-dcp-dspark-draft-kv).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34681016924](https://github.com/sgl-project/sglang/actions/runs/34681016924)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34681016826](https://github.com/sgl-project/sglang/actions/runs/34681016826)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34681016849](https://github.com/sgl-project/sglang/actions/runs/34681016849)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

