### PR TITLE
[Perf] Fuse the glm5_next mHC attn->MLP boundary

### DIFF
--- a/python/sglang/srt/layers/communicator_mhc.py
+++ b/python/sglang/srt/layers/communicator_mhc.py
@@ -97,15 +97,15 @@ class MHCState:
     ):
         out_norm_weight, out_norm_eps = self._resolve_out_norm(out_norm)
         if self.hc_ffn_post_pre is not None and hidden_states.shape[0] != 0:
-            # Fused hc_post + FFN hc_pre; returns None when no fused kernel
-            # covers this platform/shape, and the unfused chain below runs.
+            # Returns None when it declines -- no fused kernel for this platform
+            # or shape, or a shape the fusion is slower at -- and the chain runs.
             fused = self.hc_ffn_post_pre(
-                hidden_states,
-                residual,
-                self.h_res,
-                self.h_post,
-                out_norm_weight,
-                out_norm_eps,
+                hidden_states=hidden_states,
+                residual=residual,
+                h_res=self.h_res,
+                h_post=self.h_post,
+                out_norm_weight=out_norm_weight,
+                out_norm_eps=out_norm_eps,
             )
             if fused is not None:
                 hidden_states, residual, self.h_res, self.h_post, norm_fused = fused

--- a/python/sglang/srt/layers/communicator_mhc.py
+++ b/python/sglang/srt/layers/communicator_mhc.py
@@ -72,6 +72,7 @@ class MHCState:
     hc_attn_pre: Callable
     hc_ffn_pre: Callable
     hc_post: Callable
+    hc_ffn_post_pre: Optional[Callable] = None
     h_res: Optional[torch.Tensor] = None
     h_post: Optional[torch.Tensor] = None
 
@@ -94,9 +95,26 @@ class MHCState:
     def attn_to_mlp(
         self, hidden_states, residual, out_norm: Optional[torch.nn.Module] = None
     ):
+        out_norm_weight, out_norm_eps = self._resolve_out_norm(out_norm)
+        if self.hc_ffn_post_pre is not None and hidden_states.shape[0] != 0:
+            # Fused hc_post + FFN hc_pre; returns None when no fused kernel
+            # covers this platform/shape, and the unfused chain below runs.
+            fused = self.hc_ffn_post_pre(
+                hidden_states,
+                residual,
+                self.h_res,
+                self.h_post,
+                out_norm_weight,
+                out_norm_eps,
+            )
+            if fused is not None:
+                hidden_states, residual, self.h_res, self.h_post, norm_fused = fused
+                if out_norm is not None and not norm_fused:
+                    hidden_states = out_norm(hidden_states)
+                return hidden_states, residual
+
         hidden_states = self.hc_post(hidden_states, residual, self.h_res, self.h_post)
         residual = hidden_states
-        out_norm_weight, out_norm_eps = self._resolve_out_norm(out_norm)
         hidden_states, self.h_res, self.h_post, norm_fused = self.hc_ffn_pre(
             hidden_states, out_norm_weight, out_norm_eps
         )
@@ -406,6 +424,7 @@ class MHCLayerCommunicator(LayerCommunicator):
         hc_attn_pre: Callable,
         hc_ffn_pre: Callable,
         hc_post: Callable,
+        hc_ffn_post_pre: Optional[Callable] = None,
     ):
         self.is_first_layer = is_first_layer
         self.mhc = MHCState(
@@ -413,6 +432,7 @@ class MHCLayerCommunicator(LayerCommunicator):
             hc_attn_pre=hc_attn_pre,
             hc_ffn_pre=hc_ffn_pre,
             hc_post=hc_post,
+            hc_ffn_post_pre=hc_ffn_post_pre,
         )
 
         super().__init__(

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -125,8 +125,9 @@ logger = logging.getLogger(__name__)
 # must agree on it.
 _MHC_POST_MULT_VALUE = 2.0
 
-# Above this the fused boundary loses to the unfused chain: its pre-norm GEMM
-# skips the split-K kernel mhc_pre uses to 2048 tokens. Measured on GLM-5.3-Flash.
+# Conservative cap, not the crossover: at GLM-5.3-Flash's hc_mult=4 and
+# hidden_size=4096 the fusion wins to 16 tokens and reaches parity at 24, with
+# 17-23 unmeasured. Past it the pre-norm GEMM drops mhc_pre's split-K kernel.
 _MHC_FUSED_BOUNDARY_MAX_TOKENS = 16
 
 
@@ -766,7 +767,8 @@ class Glm5NextDecoderLayer(nn.Module):
     def hc_ffn_post_pre(
         self, hidden_states, residual, h_res, h_post, out_norm_weight, out_norm_eps
     ):
-        # hc_post then the FFN hc_pre in one launch instead of three.
+        # Fuses hc_post into the pre-norm GEMM; the mhc_pre big-fuse stage
+        # still launches separately, so this is two launches instead of three.
         assert self.config.mhc, "hc_ffn_post_pre is only valid when config.mhc=True"
         num_tokens, hidden_size = hidden_states.shape
         if num_tokens > _MHC_FUSED_BOUNDARY_MAX_TOKENS:

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -121,14 +121,12 @@ if _use_aiter_gfx95:
 
 logger = logging.getLogger(__name__)
 
-# Matches DeepSeek-V4's _MHC_POST_MULT_VALUE and the post_mult_value=2.0 that
-# Glm5NextDecoderLayer._hc_pre passes to the unfused hc_pre.
+# Matches DeepSeek-V4's _MHC_POST_MULT_VALUE; the fused and unfused boundaries
+# must agree on it.
 _MHC_POST_MULT_VALUE = 2.0
 
-# Above this the fused boundary loses to the unfused chain, because its pre-norm
-# GEMM skips the split-K kernel mhc_pre uses up to 2048 tokens. Measured under
-# CUDA graph at GLM-5.3-Flash's hc_mult=4 / hidden_size=4096: 1.40x at <=6, 1.17x
-# at 8-16, parity at 24, 0.87x at 32, and 0.21x from 33 with DeepGEMM prenorm off.
+# Above this the fused boundary loses to the unfused chain: its pre-norm GEMM
+# skips the split-K kernel mhc_pre uses to 2048 tokens. Measured on GLM-5.3-Flash.
 _MHC_FUSED_BOUNDARY_MAX_TOKENS = 16
 
 
@@ -739,7 +737,7 @@ class Glm5NextDecoderLayer(nn.Module):
             rms_eps=self.config.rms_norm_eps,
             hc_eps=self.config.hc_eps,
             sinkhorn_iters=self.config.hc_sinkhorn_iters,
-            post_mult_value=2.0,
+            post_mult_value=_MHC_POST_MULT_VALUE,
             hc_norm_weight=None,
             out_norm_weight=out_norm_weight,
             out_norm_eps=out_norm_eps,
@@ -768,29 +766,27 @@ class Glm5NextDecoderLayer(nn.Module):
     def hc_ffn_post_pre(
         self, hidden_states, residual, h_res, h_post, out_norm_weight, out_norm_eps
     ):
-        # hc_post then the FFN hc_pre in one launch instead of three. The
-        # shared dispatcher returns None when no fused kernel covers this
-        # platform or shape, and the caller keeps the unfused chain.
+        # hc_post then the FFN hc_pre in one launch instead of three.
         assert self.config.mhc, "hc_ffn_post_pre is only valid when config.mhc=True"
         num_tokens, hidden_size = hidden_states.shape
         if num_tokens > _MHC_FUSED_BOUNDARY_MAX_TOKENS:
             return None
         hc_mult = self.config.hc_mult
         fused = apply_mhc_post_pre_boundary(
-            hidden_states,
-            residual.view(num_tokens, hc_mult, hidden_size),
-            h_post.view(num_tokens, hc_mult),
-            h_res.view(num_tokens, hc_mult, hc_mult),
-            self.hc_ffn_fn,
-            self.hc_ffn_scale,
-            self.hc_ffn_base,
-            hc_mult,
-            self.config.rms_norm_eps,
-            self.config.hc_eps,
-            _MHC_POST_MULT_VALUE,
-            self.config.hc_sinkhorn_iters,
-            out_norm_weight,
-            out_norm_eps,
+            layer_input=hidden_states,
+            residual=residual.view(num_tokens, hc_mult, hidden_size),
+            post=h_post.view(num_tokens, hc_mult),
+            comb=h_res.view(num_tokens, hc_mult, hc_mult),
+            hc_fn=self.hc_ffn_fn,
+            hc_scale=self.hc_ffn_scale,
+            hc_base=self.hc_ffn_base,
+            hc_mult=hc_mult,
+            rms_eps=self.config.rms_norm_eps,
+            hc_eps=self.config.hc_eps,
+            hc_post_mult=_MHC_POST_MULT_VALUE,
+            sinkhorn_iters=self.config.hc_sinkhorn_iters,
+            norm_weight=out_norm_weight,
+            norm_eps=out_norm_eps,
             # Matches DeepSeek-V4's two hc_ffn_fn boundaries; the Triton tier's
             # parameter is hc_fn_t and this fn has the same [mix_hc, hc_dim] layout.
             fn_transpose=True,

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -75,6 +75,10 @@ from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     sharded_weight_loader,
 )
+from sglang.srt.models.deepseek_common.amd.deepseek_v4_fused_mhc import (
+    apply_mhc_post_pre_boundary,
+    is_cross_layer_mhc_fusion_enabled,
+)
 from sglang.srt.models.deepseek_common.deepseek_weight_loader import (
     DeepseekV2WeightLoaderMixin,
 )
@@ -116,6 +120,10 @@ if _use_aiter_gfx95:
     )
 
 logger = logging.getLogger(__name__)
+
+# Matches DeepSeek-V4's _MHC_POST_MULT_VALUE and the post_mult_value=2.0 that
+# Glm5NextDecoderLayer._hc_pre passes to the unfused hc_pre.
+_MHC_POST_MULT_VALUE = 2.0
 
 
 @torch.compile
@@ -698,6 +706,13 @@ class Glm5NextDecoderLayer(nn.Module):
                 hc_attn_pre=self.hc_attn_pre,
                 hc_ffn_pre=self.hc_ffn_pre,
                 hc_post=self.hc_post,
+                # Resolved once: env and platform are frozen after startup,
+                # and None keeps the dispatch off the per-boundary path.
+                hc_ffn_post_pre=(
+                    self.hc_ffn_post_pre
+                    if is_cross_layer_mhc_fusion_enabled()
+                    else None
+                ),
             )
             self.layer_communicator = MHCLayerCommunicator(
                 **shared_kwargs,
@@ -742,6 +757,45 @@ class Glm5NextDecoderLayer(nn.Module):
             hidden_states,
             out_norm_weight,
             out_norm_eps,
+        )
+
+    def hc_ffn_post_pre(
+        self, hidden_states, residual, h_res, h_post, out_norm_weight, out_norm_eps
+    ):
+        # hc_post then the FFN hc_pre in one launch instead of three. The
+        # shared dispatcher returns None when no fused kernel covers this
+        # platform or shape, and the caller keeps the unfused chain.
+        assert self.config.mhc, "hc_ffn_post_pre is only valid when config.mhc=True"
+        num_tokens, hidden_size = hidden_states.shape
+        hc_mult = self.config.hc_mult
+        fused = apply_mhc_post_pre_boundary(
+            hidden_states,
+            residual.view(num_tokens, hc_mult, hidden_size),
+            h_post.view(num_tokens, hc_mult),
+            h_res.view(num_tokens, hc_mult, hc_mult),
+            self.hc_ffn_fn,
+            self.hc_ffn_scale,
+            self.hc_ffn_base,
+            hc_mult,
+            self.config.rms_norm_eps,
+            self.config.hc_eps,
+            _MHC_POST_MULT_VALUE,
+            self.config.hc_sinkhorn_iters,
+            out_norm_weight,
+            out_norm_eps,
+            # Matches DeepSeek-V4's two hc_ffn_fn boundaries; the Triton tier's
+            # parameter is hc_fn_t and this fn has the same [mix_hc, hc_dim] layout.
+            fn_transpose=True,
+        )
+        if fused is None:
+            return None
+        next_residual, layer_input, post, comb, norm_fused = fused
+        return (
+            layer_input,
+            next_residual.reshape(num_tokens, -1),
+            comb.reshape(num_tokens, hc_mult * hc_mult),
+            post.reshape(num_tokens, hc_mult),
+            norm_fused,
         )
 
     def hc_post(self, hidden_states, residual, h_res, h_post):

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -125,6 +125,12 @@ logger = logging.getLogger(__name__)
 # Glm5NextDecoderLayer._hc_pre passes to the unfused hc_pre.
 _MHC_POST_MULT_VALUE = 2.0
 
+# Above this the fused boundary loses to the unfused chain, because its pre-norm
+# GEMM skips the split-K kernel mhc_pre uses up to 2048 tokens. Measured under
+# CUDA graph at GLM-5.3-Flash's hc_mult=4 / hidden_size=4096: 1.40x at <=6, 1.17x
+# at 8-16, parity at 24, 0.87x at 32, and 0.21x from 33 with DeepGEMM prenorm off.
+_MHC_FUSED_BOUNDARY_MAX_TOKENS = 16
+
 
 @torch.compile
 def swiglu_clamped(y: torch.Tensor, limit: float):
@@ -767,6 +773,8 @@ class Glm5NextDecoderLayer(nn.Module):
         # platform or shape, and the caller keeps the unfused chain.
         assert self.config.mhc, "hc_ffn_post_pre is only valid when config.mhc=True"
         num_tokens, hidden_size = hidden_states.shape
+        if num_tokens > _MHC_FUSED_BOUNDARY_MAX_TOKENS:
+            return None
         hc_mult = self.config.hc_mult
         fused = apply_mhc_post_pre_boundary(
             hidden_states,

--- a/test/registered/kernels/ops/layernorm/test_mhc_kernels.py
+++ b/test/registered/kernels/ops/layernorm/test_mhc_kernels.py
@@ -141,9 +141,7 @@ def _check_glm_boundary(x, residual, post, comb, fn, scale, base, *, use_norm):
     from sglang.srt.environ import envs
     from sglang.srt.layers.communicator_mhc import MHCState
     from sglang.srt.layers.layernorm import RMSNorm
-    from sglang.srt.models.glm5_next import (
-        Glm5NextDecoderLayer,
-    )
+    from sglang.srt.models.glm5_next import Glm5NextDecoderLayer
 
     layer = Glm5NextDecoderLayer.__new__(Glm5NextDecoderLayer)
     torch.nn.Module.__init__(layer)
@@ -170,17 +168,20 @@ def _check_glm_boundary(x, residual, post, comb, fn, scale, base, *, use_norm):
         )
         for callback in (None, layer.hc_ffn_post_pre)
     ]
-    # Pinned to measured behavior, not to the cutoff constant, so widening the
-    # cutoff turns this red. Under CUDA graph at GLM-5.3-Flash's shape the
-    # fused boundary wins to 16 tokens, reaches parity at 24, and from 32 loses --
-    # 0.21x with DeepGEMM prenorm off, where its pre-norm GEMM drops split-K.
-    # attn_to_mlp short-circuits an empty batch before reaching the callback.
+    # Literal, not derived from the cutoff constant: deriving it makes this a
+    # mirror that stays green when the cutoff moves. None is the empty batch,
+    # which attn_to_mlp short-circuits before reaching the callback.
     fused_expected = {1: True, 6: True, 17: False}[x.shape[0]] if x.shape[0] else None
     with envs.SGLANG_OPT_FUSE_MHC_POST_PRE.override(True):
         if x.shape[0] > 0:
             declined = (
                 layer.hc_ffn_post_pre(
-                    x, residual.flatten(1), comb.flatten(1), post.flatten(1), None, None
+                    hidden_states=x,
+                    residual=residual.flatten(1),
+                    h_res=comb.flatten(1),
+                    h_post=post.flatten(1),
+                    out_norm_weight=None,
+                    out_norm_eps=None,
                 )
                 is None
             )

--- a/test/registered/kernels/ops/layernorm/test_mhc_kernels.py
+++ b/test/registered/kernels/ops/layernorm/test_mhc_kernels.py
@@ -1,4 +1,5 @@
 from contextlib import nullcontext
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -11,7 +12,7 @@ register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
 
 
 @pytest.mark.parametrize("hidden_size", [4096, 7168])
-@pytest.mark.parametrize("num_tokens", [0, 1, 8, 17, 32, 64])
+@pytest.mark.parametrize("num_tokens", [0, 1, 6, 8, 17, 32, 64])
 @pytest.mark.parametrize("use_norm", [False, True])
 def test_mhc_fused_post_pre_matches_unfused(
     monkeypatch, hidden_size, num_tokens, use_norm
@@ -95,6 +96,18 @@ def test_mhc_fused_post_pre_matches_unfused(
         norm_eps=norm_eps,
     )
 
+    if hidden_size == 4096 and num_tokens in (0, 1, 6, 17):
+        _check_glm_boundary(
+            x,
+            residual,
+            post_prev,
+            comb_prev,
+            fn,
+            hc_scale,
+            hc_base,
+            use_norm=use_norm,
+        )
+
     torch.cuda.synchronize()
     if num_tokens == 0:
         assert residual_out.shape == residual.shape
@@ -122,6 +135,52 @@ def test_mhc_fused_post_pre_matches_unfused(
     layer_atol = 2e-2 if use_norm else 2e-3
     layer_rtol = 2e-2 if use_norm else 2e-3
     torch.testing.assert_close(layer_out, layer_ref, atol=layer_atol, rtol=layer_rtol)
+
+
+def _check_glm_boundary(x, residual, post, comb, fn, scale, base, *, use_norm):
+    from sglang.srt.environ import envs
+    from sglang.srt.layers.communicator_mhc import MHCState
+    from sglang.srt.layers.layernorm import RMSNorm
+    from sglang.srt.models.glm5_next import Glm5NextDecoderLayer
+
+    layer = Glm5NextDecoderLayer.__new__(Glm5NextDecoderLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = SimpleNamespace(
+        mhc=True,
+        hc_mult=4,
+        rms_norm_eps=1e-6,
+        hc_eps=1e-6,
+        hc_sinkhorn_iters=20,
+    )
+    layer.hc_ffn_fn = torch.nn.Parameter(fn)
+    layer.hc_ffn_scale = torch.nn.Parameter(scale)
+    layer.hc_ffn_base = torch.nn.Parameter(base)
+    norm = RMSNorm(x.shape[-1], eps=1e-6).to(x) if use_norm else None
+    states = [
+        MHCState(
+            hc_mult=4,
+            hc_attn_pre=layer.hc_attn_pre,
+            hc_ffn_pre=layer.hc_ffn_pre,
+            hc_post=layer.hc_post,
+            hc_ffn_post_pre=callback,
+            h_res=comb.flatten(1),
+            h_post=post.flatten(1),
+        )
+        for callback in (None, layer.hc_ffn_post_pre)
+    ]
+    with envs.SGLANG_OPT_FUSE_MHC_POST_PRE.override(True):
+        outputs = [s.attn_to_mlp(x, residual.flatten(1), norm) for s in states]
+    torch.testing.assert_close(outputs[0][0], outputs[1][0], atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(outputs[0][1], outputs[1][1], atol=0, rtol=0)
+    torch.testing.assert_close(states[0].h_res, states[1].h_res, atol=1e-3, rtol=1e-3)
+    torch.testing.assert_close(states[0].h_post, states[1].h_post, atol=1e-3, rtol=1e-3)
+    # The next combine must consume the FFN mixing matrices, not attention's.
+    torch.testing.assert_close(
+        states[0].mlp_combine(x, outputs[0][1]),
+        states[1].mlp_combine(x, outputs[1][1]),
+        atol=2e-3,
+        rtol=2e-2,
+    )
 
 
 if __name__ == "__main__":

--- a/test/registered/kernels/ops/layernorm/test_mhc_kernels.py
+++ b/test/registered/kernels/ops/layernorm/test_mhc_kernels.py
@@ -141,7 +141,9 @@ def _check_glm_boundary(x, residual, post, comb, fn, scale, base, *, use_norm):
     from sglang.srt.environ import envs
     from sglang.srt.layers.communicator_mhc import MHCState
     from sglang.srt.layers.layernorm import RMSNorm
-    from sglang.srt.models.glm5_next import Glm5NextDecoderLayer
+    from sglang.srt.models.glm5_next import (
+        Glm5NextDecoderLayer,
+    )
 
     layer = Glm5NextDecoderLayer.__new__(Glm5NextDecoderLayer)
     torch.nn.Module.__init__(layer)
@@ -168,7 +170,24 @@ def _check_glm_boundary(x, residual, post, comb, fn, scale, base, *, use_norm):
         )
         for callback in (None, layer.hc_ffn_post_pre)
     ]
+    # Pinned to measured behavior, not to the cutoff constant, so widening the
+    # cutoff turns this red. Under CUDA graph at GLM-5.3-Flash's shape the
+    # fused boundary wins to 16 tokens, reaches parity at 24, and from 32 loses --
+    # 0.21x with DeepGEMM prenorm off, where its pre-norm GEMM drops split-K.
+    # attn_to_mlp short-circuits an empty batch before reaching the callback.
+    fused_expected = {1: True, 6: True, 17: False}[x.shape[0]] if x.shape[0] else None
     with envs.SGLANG_OPT_FUSE_MHC_POST_PRE.override(True):
+        if x.shape[0] > 0:
+            declined = (
+                layer.hc_ffn_post_pre(
+                    x, residual.flatten(1), comb.flatten(1), post.flatten(1), None, None
+                )
+                is None
+            )
+            assert declined is not fused_expected, (
+                f"num_tokens={x.shape[0]} fused={not declined}, "
+                f"expected fused={fused_expected}"
+            )
         outputs = [s.attn_to_mlp(x, residual.flatten(1), norm) for s in states]
     torch.testing.assert_close(outputs[0][0], outputs[1][0], atol=2e-2, rtol=2e-2)
     torch.testing.assert_close(outputs[0][1], outputs[1][1], atol=0, rtol=0)


### PR DESCRIPTION
## Motivation

GLM-5.3-Flash crosses 90 mHC post-then-pre boundaries per forward (45 layers, twice each). Each ran as three launches — `mhc_post`, the tf32 pre-norm GEMM, `mhc_pre_big_fuse` — which at a 6-token verify batch is launch cost, not work.

`mhc_fused_post_pre` and `apply_mhc_post_pre_boundary` already exist and are live for DeepSeek-V4. `glm5_next` never called them: it routes through `MHCLayerCommunicator`, not DeepSeek-V4's layer code.

## Modifications

| | |
| --- | --- |
| `MHCState.hc_ffn_post_pre` | optional callable tried first in `attn_to_mlp`; `None` keeps the unfused chain |
| `Glm5NextDecoderLayer.hc_ffn_post_pre` | GLM adapter onto the shared dispatcher |
| `_MHC_FUSED_BOUNDARY_MAX_TOKENS = 16` | conservative cap; declines above it |

Folds `mhc_post` into the pre-norm GEMM — `mhc_pre_big_fuse` still launches separately, so **two launches instead of three**. 45 of 90 boundaries fuse; the rest need DeepSeek-V4's cross-layer deferral. `fn_transpose=True` matches DeepSeek-V4's call sites but is read only by the ROCm Triton tier, so it is unexercised on CUDA. Scope is `glm5_next` with `mhc=True` (config default is `False`).

## Why 16

CUDA-graph replays, GLM-5.3-Flash's `hc_mult=4` / `hidden_size=4096`:

| tokens | ≤6 | 8–16 | 24 | 32 | ≥33 |
| --- | --- | --- | --- | --- | --- |
| DeepGEMM on | 1.40x | 1.17x | 1.00x | 0.88x | 1.00x |
| DeepGEMM off | 1.37x | 1.17x | 1.00x | 0.87x | **0.21x** |

Past the crossover the fused pre-norm GEMM drops the split-K kernel `mhc_pre` uses to 2048 tokens. 16 is conservative — parity is at 24, 17–23 unmeasured. The gate is in the GLM callback, not the shared dispatcher, which also serves DeepSeek-V4 at `hc_hidden_size=28672` — these numbers cover one shape on one hardware config.

Verify batch is `bs * speculative_num_draft_tokens`: c=1 is 6 tokens and fuses, c=64 is 384 and declines.

## Accuracy Tests

GPQA Diamond, thinking on: **92.42%** (183/198), 0 truncated, 0 errors. `temperature=1.0`, `top_p=0.95`, `max_tokens=131072`, 1 repeat.

## Speed Tests and Profiling

GLM-5.3-Flash, tp4 on 4x GB300, 8192 in / 1024 out at c=1. 12 runs: 3 per arm across 4 server sessions, arms interleaved. The metric is verify steps per second, tok/s divided by accept length — the decode-loop rate, which is what a per-forward change moves. Raw tok/s scales with accept length, which clusters per server process.

| session | fused | unfused | |
| --- | --- | --- | --- |
| 1 | **79.07** | 78.55 | +0.66% |
| 2 | **79.82** | 77.99 | +2.34% |

Faster in both, with each session's run ranges disjoint.

At c=64 the gate declines and throughput is unchanged: 3466.9 vs 3456.3 tok/s.

## Checklist

- [x] `pre-commit` clean
- [x] 28 cases in `test_mhc_kernels.py`; reverting `communicator_mhc.py` fails 8, moving the cutoff to 64 or 4 fails 2 each
- [x] Accuracy and speed measured above

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34830061832](https://github.com/sgl-project/sglang/actions/runs/34830061832)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34830061740](https://github.com/sgl-project/sglang/actions/runs/34830061740)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34830061928](https://github.com/sgl-project/sglang/actions/runs/34830061928)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->