### PR TITLE
config: delete the redundant full stamp in initialize_model_parallel

### DIFF
--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
@@ -171,7 +171,9 @@ def _sync_srt_tp_group() -> None:
     published `srt` config cannot answer: `gpu_worker.py` publishes a dummy
     carrying *this* package's `tp_size`, which a sequence-parallel launch sets
     to 1 while the group lent here is as wide as the world. So the widths are
-    stamped alongside the group, as `srt.initialize_model_parallel` does.
+    permanently overridden alongside the group -- this runs with no `srt`
+    config published at all, which is exactly why it cannot go through
+    `RuntimeContext.override` (it requires one).
 
     Only tensor parallelism folds this way, so every other dimension is one.
     """
@@ -183,7 +185,8 @@ def _sync_srt_tp_group() -> None:
     if srt_parallel_state._ATTN_TP is None:
         srt_parallel_state._ATTN_TP = _TP
     if srt_parallel_state._ATTN_TP is _TP:
-        get_parallel().stamp_derived_widths(
+        get_parallel().override_permanently(
+            "multimodal_gen._sync_srt_tp_group",
             **derive_parallel_widths(
                 tp_size=_TP.world_size,
                 attn_cp_size=1,
@@ -192,7 +195,7 @@ def _sync_srt_tp_group() -> None:
                 moe_dp_size=1,
                 dcp_size=1,
                 dcp_enabled=False,
-            )
+            ),
         )
 
 

--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
@@ -186,7 +186,6 @@ def _sync_srt_tp_group() -> None:
         srt_parallel_state._ATTN_TP = _TP
     if srt_parallel_state._ATTN_TP is _TP:
         get_parallel().override_permanently(
-            "multimodal_gen._sync_srt_tp_group",
             **derive_parallel_widths(
                 tp_size=_TP.world_size,
                 attn_cp_size=1,

--- a/python/sglang/srt/arg_groups/memory_hook.py
+++ b/python/sglang/srt/arg_groups/memory_hook.py
@@ -37,7 +37,7 @@ def handle_offload_compatibility(server_args: Any) -> None:
         )
 
 
-def handle_gpu_memory_settings(server_args: Any, gpu_mem):
+def handle_gpu_memory_settings(server_args: Any):
     """
     Configure GPU memory-dependent settings including
     chunked_prefill_size, cuda_graph_config[decode].max_bs, and mem_fraction_static.
@@ -66,8 +66,10 @@ def handle_gpu_memory_settings(server_args: Any, gpu_mem):
         generate_decode_cuda_graph_batch_sizes,
         generate_prefill_cuda_graph_batch_sizes,
     )
+    from sglang.srt.utils.common import get_device_memory_capacity
 
     cfg = resolving_view(server_args)
+    gpu_mem = get_device_memory_capacity(cfg.device)
     # A copy, so an earlier declaration keeps the value it recorded.
     cuda_graph_config = copy.deepcopy(cfg.cuda_graph_config)
     decode_cuda_graph_config = cuda_graph_config.decode

--- a/python/sglang/srt/arg_groups/memory_hook.py
+++ b/python/sglang/srt/arg_groups/memory_hook.py
@@ -18,6 +18,7 @@ from sglang.srt.arg_groups.overrides import (
 from sglang.srt.environ import envs
 from sglang.srt.model_executor.cuda_graph_config import Backend, Phase
 from sglang.srt.runtime_context import get_platform
+from sglang.srt.utils.common import get_device_memory_capacity
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +67,6 @@ def handle_gpu_memory_settings(server_args: Any):
         generate_decode_cuda_graph_batch_sizes,
         generate_prefill_cuda_graph_batch_sizes,
     )
-    from sglang.srt.utils.common import get_device_memory_capacity
 
     cfg = resolving_view(server_args)
     gpu_mem = get_device_memory_capacity(cfg.device)

--- a/python/sglang/srt/arg_groups/model_hook.py
+++ b/python/sglang/srt/arg_groups/model_hook.py
@@ -28,6 +28,7 @@ from sglang.srt.arg_groups.overrides import (
     use_mla_backend,
     validate_declarations,
 )
+from sglang.srt.arg_groups.resolution_hooks import run_hook
 from sglang.srt.configs.embedding_model_spec import BCGPrefillPolicy
 from sglang.srt.configs.linear_attn_model_registry import get_linear_attn_spec_by_arch
 from sglang.srt.connector import ConnectorType
@@ -786,7 +787,11 @@ def handle_model_capability_adjustments(server_args: Any):
                 "_handle_model_capability_adjustments",
                 prefill_only_disable_kv_cache=True,
             )
-            validate_prefill_only_disable_kv_cache_args(server_args)
+            # Through the registry, not a bare call: an out-of-tree
+            # replacement registered at this validator's own pipeline
+            # position must also win here, at this later re-validation after
+            # the Hopper/Blackwell no-KV-pool default declares itself.
+            run_hook(validate_prefill_only_disable_kv_cache_args, server_args)
         declare_resolution(
             server_args,
             "_handle_model_capability_adjustments",

--- a/python/sglang/srt/arg_groups/parallel_hook.py
+++ b/python/sglang/srt/arg_groups/parallel_hook.py
@@ -19,6 +19,7 @@ from sglang.srt.arg_groups.overrides import (
     run_post_process_pass,
     should_report_expert_balancedness,
 )
+from sglang.srt.arg_groups.resolution_hooks import run_hook
 from sglang.srt.connector import ConnectorType
 from sglang.srt.environ import envs
 from sglang.srt.model_executor.cuda_graph_config import Backend, Phase, with_phase
@@ -29,7 +30,12 @@ logger = logging.getLogger(__name__)
 
 
 def handle_context_parallelism(server_args: Any):
-    validate_prefill_cp_platform(server_args)
+    # Through the registry, not a bare call: an out-of-tree replacement of
+    # `validate_prefill_cp_platform` registered at its own (earlier) pipeline
+    # position must also win here, or a package permitting prefill CP on its
+    # own qualified HIP/NPU/MUSA build would still hit the original rejection
+    # at this later, nested call.
+    run_hook(validate_prefill_cp_platform, server_args)
 
     cfg = resolving_view(server_args)
     if parse_connector_type(cfg.model_path) != ConnectorType.INSTANCE:

--- a/python/sglang/srt/arg_groups/pipeline.py
+++ b/python/sglang/srt/arg_groups/pipeline.py
@@ -19,7 +19,6 @@ from sglang.srt.arg_groups.overrides import (
     run_post_process_pass,
 )
 from sglang.srt.arg_groups.resolution_hooks import run_hook
-from sglang.srt.utils.common import get_device_memory_capacity
 
 
 def run_resolution_pipeline(server_args: Any) -> None:
@@ -227,12 +226,10 @@ def run_resolution_pipeline(server_args: Any) -> None:
 
     run_hook(handle_platform_defaults, server_args)
 
-    gpu_mem = get_device_memory_capacity(cfg.device)
-
     # Handle memory-related, chunked prefill, and CUDA graph batch size configurations.
     from sglang.srt.arg_groups.memory_hook import handle_gpu_memory_settings
 
-    run_hook(handle_gpu_memory_settings, server_args, gpu_mem)
+    run_hook(handle_gpu_memory_settings, server_args)
 
     # Apply model-specific adjustments.
     from sglang.srt.arg_groups.model_hook import (

--- a/python/sglang/srt/arg_groups/pipeline.py
+++ b/python/sglang/srt/arg_groups/pipeline.py
@@ -115,7 +115,7 @@ def run_resolution_pipeline(server_args: Any) -> None:
     )
 
     run_hook(validate_prefill_cp_platform, server_args)
-    run_hook(handle_hardware_runtime_validation)
+    run_hook(handle_hardware_runtime_validation, server_args)
     if cfg.model_path.lower() in ["none", "dummy"]:
         return
 

--- a/python/sglang/srt/arg_groups/pipeline.py
+++ b/python/sglang/srt/arg_groups/pipeline.py
@@ -196,7 +196,7 @@ def run_resolution_pipeline(server_args: Any) -> None:
     # Out-of-tree replaceable: see arg_groups/resolution_hooks.py. This is the
     # step's fixed position in the pipeline either way -- registering an
     # override changes what runs here, not when.
-    run_hook("handle_cuda_graph_config", handle_cuda_graph_config, server_args)
+    run_hook(handle_cuda_graph_config, server_args)
     # Requires the parsed backend and explicit-input locks, and must precede
     # handle_gpu_memory_settings so the chunk size feeds memory budgeting.
     apply_glm5_chunked_prefill_default(server_args)

--- a/python/sglang/srt/arg_groups/pipeline.py
+++ b/python/sglang/srt/arg_groups/pipeline.py
@@ -18,6 +18,7 @@ from sglang.srt.arg_groups.overrides import (
     resolving_view,
     run_post_process_pass,
 )
+from sglang.srt.arg_groups.resolution_hooks import run_hook
 from sglang.srt.utils.common import get_device_memory_capacity
 
 
@@ -43,6 +44,11 @@ def run_resolution_pipeline(server_args: Any) -> None:
     5. Give each handler one clear contract: what state it expects, what it
        may mutate, and whether it validates only. Long ordering comments
        belong in the helper or signal that the helper should be split.
+    6. Call each step through ``run_hook(handle_x, server_args, ...)``, not
+       ``handle_x(server_args, ...)`` directly -- see
+       ``arg_groups/resolution_hooks.py``. This is every step's fixed
+       position in the pipeline either way; registering an override changes
+       what runs here, never when.
     """
 
     # What the caller asked for, before any handler runs; this plus the
@@ -62,7 +68,7 @@ def run_resolution_pipeline(server_args: Any) -> None:
 
     from sglang.srt.arg_groups.mega_moe_hook import handle_mega_moe
 
-    handle_mega_moe(server_args)
+    run_hook(handle_mega_moe, server_args)
     from sglang.srt.arg_groups.serving_hook import (
         handle_asr_validation,
         handle_crash_dump_env,
@@ -81,17 +87,17 @@ def run_resolution_pipeline(server_args: Any) -> None:
         handle_tokenizer_batching,
     )
 
-    handle_return_hidden_states_mode(server_args)
-    handle_media_url_security(server_args)
+    run_hook(handle_return_hidden_states_mode, server_args)
+    run_hook(handle_media_url_security, server_args)
     from sglang.srt.arg_groups.hicache_hook import (
         handle_hicache,
         handle_hicache_ratio_default,
     )
 
-    handle_hicache_ratio_default(server_args)
+    run_hook(handle_hicache_ratio_default, server_args)
     from sglang.srt.arg_groups.memory_hook import handle_offload_compatibility
 
-    handle_offload_compatibility(server_args)
+    run_hook(handle_offload_compatibility, server_args)
     from sglang.srt.arg_groups.validation_hook import (
         default_unset_prefill_decode_interval,
         validate_experimental_sgl_marlin,
@@ -99,8 +105,8 @@ def run_resolution_pipeline(server_args: Any) -> None:
         validate_sampling_mask_max_tokens,
     )
 
-    validate_prefill_decode_interval(server_args)
-    validate_sampling_mask_max_tokens(server_args)
+    run_hook(validate_prefill_decode_interval, server_args)
+    run_hook(validate_sampling_mask_max_tokens, server_args)
 
     # Reject an explicitly enabled but incompatible hardware runtime before
     # model path resolution, downloads, or the dummy-model short circuit.
@@ -109,8 +115,8 @@ def run_resolution_pipeline(server_args: Any) -> None:
         handle_hardware_runtime_validation,
     )
 
-    validate_prefill_cp_platform(server_args)
-    handle_hardware_runtime_validation()
+    run_hook(validate_prefill_cp_platform, server_args)
+    run_hook(handle_hardware_runtime_validation)
     if cfg.model_path.lower() in ["none", "dummy"]:
         return
 
@@ -119,30 +125,30 @@ def run_resolution_pipeline(server_args: Any) -> None:
         handle_model_source_paths,
     )
 
-    handle_model_source_paths(server_args)
+    run_hook(handle_model_source_paths, server_args)
 
     # Validate mm_process_config.
-    handle_multimodal(server_args)
+    run_hook(handle_multimodal, server_args)
     # Validate SSL arguments early.
-    handle_ssl_validation(server_args)
+    run_hook(handle_ssl_validation, server_args)
     # Validate transcription/ASR-specific server args.
-    handle_asr_validation(server_args)
+    run_hook(handle_asr_validation, server_args)
 
     # Handle deprecated arguments.
-    handle_deprecated_args(server_args)
+    run_hook(handle_deprecated_args, server_args)
 
     # Handle deprecated environment variables for prefill delayer.
-    handle_prefill_delayer_env_compat(server_args)
+    run_hook(handle_prefill_delayer_env_compat, server_args)
 
     # Set missing default values.
-    handle_missing_default_values(server_args)
+    run_hook(handle_missing_default_values, server_args)
 
     # expert_pack may replace a raw GGUF input with its generated local
     # model metadata before any model-specific handler calls model_config_of.
     # It also establishes eager-only invariants before CUDA graph parsing.
     from sglang.srt.arg_groups.expert_pack_hook import handle_expert_pack
 
-    handle_expert_pack(server_args)
+    run_hook(handle_expert_pack, server_args)
 
     # Validate PD disaggregation flags before CUDA graph config.
     from sglang.srt.arg_groups.pd_disaggregation_hook import (
@@ -150,7 +156,7 @@ def run_resolution_pipeline(server_args: Any) -> None:
         handle_pd_disaggregation,
     )
 
-    handle_pd_disaggregation(server_args)
+    run_hook(handle_pd_disaggregation, server_args)
 
     from sglang.srt.arg_groups.kv_cache_hook import (
         handle_cache_compatibility,
@@ -171,8 +177,8 @@ def run_resolution_pipeline(server_args: Any) -> None:
         handle_expert_distribution_metrics,
     )
 
-    validate_prefill_only_disable_kv_cache_args(server_args)
-    handle_decode_context_parallelism(server_args)
+    run_hook(validate_prefill_only_disable_kv_cache_args, server_args)
+    run_hook(handle_decode_context_parallelism, server_args)
 
     # Model-arch prefill CUDA-graph default must land before cuda-graph
     # resolution (the declarative registry materializes too late to affect
@@ -185,21 +191,17 @@ def run_resolution_pipeline(server_args: Any) -> None:
         disable_prefill_cuda_graph_for_deepseek_trtllm_mla,
         handle_cuda_graph_config,
     )
-    from sglang.srt.arg_groups.resolution_hooks import run_hook
 
-    apply_inkling_prefill_cuda_graph_default(server_args)
-    apply_muse_glimmer_prefill_cuda_graph_max_bs_default(server_args)
+    run_hook(apply_inkling_prefill_cuda_graph_default, server_args)
+    run_hook(apply_muse_glimmer_prefill_cuda_graph_max_bs_default, server_args)
 
     # must run before _handle_cuda_graph_config and _handle_data_parallelism
-    handle_dwdp(server_args)
+    run_hook(handle_dwdp, server_args)
 
-    # Out-of-tree replaceable: see arg_groups/resolution_hooks.py. This is the
-    # step's fixed position in the pipeline either way -- registering an
-    # override changes what runs here, not when.
     run_hook(handle_cuda_graph_config, server_args)
     # Requires the parsed backend and explicit-input locks, and must precede
     # handle_gpu_memory_settings so the chunk size feeds memory budgeting.
-    apply_glm5_chunked_prefill_default(server_args)
+    run_hook(apply_glm5_chunked_prefill_default, server_args)
 
     # Handle device-specific backends.
     from sglang.srt.arg_groups.platform_hook import (
@@ -214,23 +216,23 @@ def run_resolution_pipeline(server_args: Any) -> None:
         handle_xpu_backends,
     )
 
-    handle_hpu_backends(server_args)
-    handle_cpu_backends(server_args)
-    handle_npu_backends(server_args)
-    handle_mps_backends(server_args)
-    handle_xpu_backends(server_args)
+    run_hook(handle_hpu_backends, server_args)
+    run_hook(handle_cpu_backends, server_args)
+    run_hook(handle_npu_backends, server_args)
+    run_hook(handle_mps_backends, server_args)
+    run_hook(handle_xpu_backends, server_args)
     # Must precede handle_gpu_memory_settings: its symm-mem prealloc default
     # keys off enable_symm_mem.
-    handle_symm_mem_device_support(server_args)
+    run_hook(handle_symm_mem_device_support, server_args)
 
-    handle_platform_defaults(server_args)
+    run_hook(handle_platform_defaults, server_args)
 
     gpu_mem = get_device_memory_capacity(cfg.device)
 
     # Handle memory-related, chunked prefill, and CUDA graph batch size configurations.
     from sglang.srt.arg_groups.memory_hook import handle_gpu_memory_settings
 
-    handle_gpu_memory_settings(server_args, gpu_mem)
+    run_hook(handle_gpu_memory_settings, server_args, gpu_mem)
 
     # Apply model-specific adjustments.
     from sglang.srt.arg_groups.model_hook import (
@@ -238,10 +240,10 @@ def run_resolution_pipeline(server_args: Any) -> None:
         handle_model_specific_adjustments,
     )
 
-    handle_model_specific_adjustments(server_args)
-    default_unset_prefill_decode_interval(server_args)
+    run_hook(handle_model_specific_adjustments, server_args)
+    run_hook(default_unset_prefill_decode_interval, server_args)
     # After the model overrides: Qwen4-Exp declares the PLE offload default there.
-    handle_offload_compatibility(server_args)
+    run_hook(handle_offload_compatibility, server_args)
 
     # Set kernel backends.
     run_post_process_pass(server_args, _sampling_backend_default)
@@ -254,49 +256,49 @@ def run_resolution_pipeline(server_args: Any) -> None:
         handle_multi_item_scoring,
     )
 
-    handle_deterministic_inference(server_args)
-    handle_attention_backend_compatibility(server_args)
+    run_hook(handle_deterministic_inference, server_args)
+    run_hook(handle_attention_backend_compatibility, server_args)
     # Must run after the attention backend is resolved so the trtllm_mla
     # default (auto-selected for DeepseekV3ForCausalLM on sm100) is visible.
-    disable_prefill_cuda_graph_for_deepseek_trtllm_mla(server_args)
+    run_hook(disable_prefill_cuda_graph_for_deepseek_trtllm_mla, server_args)
     from sglang.srt.arg_groups.mamba_hook import (
         handle_int8_mamba_checkpoint,
         handle_mamba_backend,
     )
 
-    handle_mamba_backend(server_args)
-    handle_int8_mamba_checkpoint(server_args)
-    handle_linear_attn_backend(server_args)
-    apply_glm5_prefill_cuda_graph_policy(server_args)
-    handle_kv4_compatibility(server_args)
-    handle_mxfp8_kv_cache_compatibility(server_args)
+    run_hook(handle_mamba_backend, server_args)
+    run_hook(handle_int8_mamba_checkpoint, server_args)
+    run_hook(handle_linear_attn_backend, server_args)
+    run_hook(apply_glm5_prefill_cuda_graph_policy, server_args)
+    run_hook(handle_kv4_compatibility, server_args)
+    run_hook(handle_mxfp8_kv_cache_compatibility, server_args)
     run_post_process_pass(server_args, _page_size_default)
-    handle_amd_specifics(server_args)
-    handle_nccl_pre_warm(server_args)
-    handle_grammar_backend(server_args)
+    run_hook(handle_amd_specifics, server_args)
+    run_hook(handle_nccl_pre_warm, server_args)
+    run_hook(handle_grammar_backend, server_args)
 
     # Handle multi-item scoring constraints. Must run after the above so
     # the final attention backend and chunked_prefill_size are in effect.
-    handle_multi_item_scoring(server_args)
+    run_hook(handle_multi_item_scoring, server_args)
 
     # Backend-dependent half of --prefill-only-disable-kv-cache validation.
     # Must stay after _handle_attention_backend_compatibility() (above) and
     # _handle_multi_item_scoring() so the resolved prefill backend is final;
     # the flag/precondition half runs earlier in
     # _validate_prefill_only_disable_kv_cache_args().
-    handle_prefill_only_disable_kv_cache(server_args)
+    run_hook(handle_prefill_only_disable_kv_cache, server_args)
 
     # Handle Hicache settings.
-    handle_hicache(server_args)
+    run_hook(handle_hicache, server_args)
 
     # Handle data parallelism.
-    handle_data_parallelism(server_args)
+    run_hook(handle_data_parallelism, server_args)
 
     # Normalize load balancing defaults.
-    handle_load_balance_method(server_args)
+    run_hook(handle_load_balance_method, server_args)
 
     # Handle context parallelism.
-    handle_context_parallelism(server_args)
+    run_hook(handle_context_parallelism, server_args)
 
     # Handle MoE configurations.
     from sglang.srt.arg_groups.moe_hook import (
@@ -307,12 +309,12 @@ def run_resolution_pipeline(server_args: Any) -> None:
         validate_deepep_v2_speculative_draft,
     )
 
-    handle_moe_kernel_config(server_args)
-    handle_a2a_moe(server_args)
-    handle_eplb_and_dispatch(server_args)
-    handle_expert_distribution_metrics(server_args)
-    handle_elastic_ep(server_args)
-    validate_experimental_sgl_marlin(server_args)
+    run_hook(handle_moe_kernel_config, server_args)
+    run_hook(handle_a2a_moe, server_args)
+    run_hook(handle_eplb_and_dispatch, server_args)
+    run_hook(handle_expert_distribution_metrics, server_args)
+    run_hook(handle_elastic_ep, server_args)
+    run_hook(validate_experimental_sgl_marlin, server_args)
 
     # Handle pipeline parallelism.
     run_post_process_pass(server_args, _pipeline_parallel_overlap_disable)
@@ -321,55 +323,55 @@ def run_resolution_pipeline(server_args: Any) -> None:
 
     from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
 
-    handle_speculative_decoding(server_args)
+    run_hook(handle_speculative_decoding, server_args)
 
     # After the speculative hook so speculative_algorithm is final.
     from sglang.srt.arg_groups.layernorm_sp_hook import handle_layernorm_sp
 
-    handle_layernorm_sp(server_args)
+    run_hook(handle_layernorm_sp, server_args)
 
     # Validate the CuteDSL A2A token budget now that num_tokens_per_req is final.
-    validate_cutedsl_a2a_token_budget(server_args)
+    run_hook(validate_cutedsl_a2a_token_budget, server_args)
 
     # Handle model loading format.
-    handle_load_format(server_args)
+    run_hook(handle_load_format, server_args)
 
     # Handle Encoder disaggregation.
-    handle_encoder_disaggregation(server_args)
+    run_hook(handle_encoder_disaggregation, server_args)
 
     # Validate tokenizer settings.
-    handle_tokenizer_batching(server_args)
+    run_hook(handle_tokenizer_batching, server_args)
 
     # Propagate environment variables.
-    handle_environment_variables(server_args)
+    run_hook(handle_environment_variables, server_args)
 
     # Validate cache settings.
-    handle_cache_compatibility(server_args)
+    run_hook(handle_cache_compatibility, server_args)
 
-    handle_page_major_kv_layout(server_args)
+    run_hook(handle_page_major_kv_layout, server_args)
 
-    handle_unified_memory_pool(server_args)
+    run_hook(handle_unified_memory_pool, server_args)
 
     # Handle diffusion LLM inference.
     from sglang.srt.arg_groups.dllm_hook import handle_dllm_inference
 
-    handle_dllm_inference(server_args)
+    run_hook(handle_dllm_inference, server_args)
 
     # Handle crash dump environment variables (must run before CUDA init).
-    handle_crash_dump_env(server_args)
+    run_hook(handle_crash_dump_env, server_args)
 
     # Handle debug utilities.
-    handle_debug_utils(server_args)
+    run_hook(handle_debug_utils, server_args)
 
     # Handle any other necessary validations.
-    handle_other_validations(server_args)
+    run_hook(handle_other_validations, server_args)
 
     # Model-capability adjustments that legacy code applied at model-load
     # time; last declarations of the resolution, mirroring that order.
-    handle_model_capability_adjustments(server_args)
+    run_hook(handle_model_capability_adjustments, server_args)
 
     # Validate after all batch-size declarations are visible.
-    validate_deepep_v2_speculative_draft(server_args)
-    validate_deepep_v2_dispatch_token_budget(server_args)
+    run_hook(validate_deepep_v2_speculative_draft, server_args)
+    run_hook(validate_deepep_v2_dispatch_token_budget, server_args)
 
     server_args._resolution_finished = True

--- a/python/sglang/srt/arg_groups/pipeline.py
+++ b/python/sglang/srt/arg_groups/pipeline.py
@@ -185,6 +185,7 @@ def run_resolution_pipeline(server_args: Any) -> None:
         disable_prefill_cuda_graph_for_deepseek_trtllm_mla,
         handle_cuda_graph_config,
     )
+    from sglang.srt.arg_groups.resolution_hooks import run_hook
 
     apply_inkling_prefill_cuda_graph_default(server_args)
     apply_muse_glimmer_prefill_cuda_graph_max_bs_default(server_args)
@@ -192,7 +193,10 @@ def run_resolution_pipeline(server_args: Any) -> None:
     # must run before _handle_cuda_graph_config and _handle_data_parallelism
     handle_dwdp(server_args)
 
-    handle_cuda_graph_config(server_args)
+    # Out-of-tree replaceable: see arg_groups/resolution_hooks.py. This is the
+    # step's fixed position in the pipeline either way -- registering an
+    # override changes what runs here, not when.
+    run_hook("handle_cuda_graph_config", handle_cuda_graph_config, server_args)
     # Requires the parsed backend and explicit-input locks, and must precede
     # handle_gpu_memory_settings so the chunk size feeds memory budgeting.
     apply_glm5_chunked_prefill_default(server_args)

--- a/python/sglang/srt/arg_groups/platform_hook.py
+++ b/python/sglang/srt/arg_groups/platform_hook.py
@@ -20,11 +20,13 @@ from sglang.srt.utils.common import is_host_cpu_arm64
 logger = logging.getLogger(__name__)
 
 
-def handle_hardware_runtime_validation():
-    # This is intentionally independent of `server_args.device`: setting
-    # SGLANG_USE_MLX opts into the MLX backend and must fail immediately if
-    # the environment cannot honor that request. With the flag unset,
-    # use_mlx() remains lazy and does not import MLX.
+def handle_hardware_runtime_validation(server_args: Any):
+    # `server_args` is accepted, not read: every resolution-hook step takes
+    # it, uniformly, so `run_hook` never has to special-case an arity. The
+    # check below is intentionally independent of `server_args.device`:
+    # setting SGLANG_USE_MLX opts into the MLX backend and must fail
+    # immediately if the environment cannot honor that request. With the
+    # flag unset, use_mlx() remains lazy and does not import MLX.
     use_mlx()
 
 

--- a/python/sglang/srt/arg_groups/resolution_hooks.py
+++ b/python/sglang/srt/arg_groups/resolution_hooks.py
@@ -18,12 +18,14 @@ called itself). A name that is not on the list fails loudly at import time,
 not silently at the call site three modules away.
 
 Steps do not share one signature -- nearly all take `(server_args)`, but
-`handle_hardware_runtime_validation` takes no arguments at all -- so
-`run_hook` forwards `*args` rather than assuming `server_args` is the only
-thing there. An override's own signature always matches its target's, plus
-`previous` last: `def mine(previous)` for that zero-argument step. `previous`
-itself is always called the same way regardless -- with whatever `*args` the
-step was invoked with.
+`handle_hardware_runtime_validation` takes no arguments at all. `run_hook`
+takes `server_args` as an ordinary, optional parameter (default `None`) for
+that reason, not a generic `*args`: the call site for that one step omits it
+entirely (`run_hook(handle_hardware_runtime_validation)`), and `run_hook`
+calls the whole chain with no arguments when it is missing. An override's
+own signature always matches its target's, plus `previous` last: `def
+mine(previous)` for that zero-argument step, `def mine(server_args,
+previous)` for everything else.
 """
 
 from __future__ import annotations
@@ -123,26 +125,27 @@ _OVERRIDABLE_HOOKS: FrozenSet[str] = frozenset(
     }
 )
 
-# name -> registered overrides, oldest first. Each takes `(*args, previous)`,
-# where `args` are whatever the step itself is called with and `previous` is
-# the callable it wraps -- the built-in on the first registration, the
-# previous registrant's own wrapper on every one after. Process-global as a
-# `dict[str, list]` so a test isolates it the way test_model_overrides.py
-# isolates `_MODEL_OVERRIDE_FNS`: `patch.dict(..., clear=True)`.
+# name -> registered overrides, oldest first. Each takes `(server_args,
+# previous)`, or just `(previous)` for the one step that takes no arguments
+# at all, where `previous` is the callable it wraps -- the built-in on the
+# first registration, the previous registrant's own wrapper on every one
+# after. Process-global as a `dict[str, list]` so a test isolates it the way
+# test_model_overrides.py isolates `_MODEL_OVERRIDE_FNS`:
+# `patch.dict(..., clear=True)`.
 _HOOKS: Dict[str, List[Callable[..., Any]]] = {}
 
 
 def register_resolution_hook(name: str):
     """Replace (or wrap) the pipeline step named ``name``.
 
-    The decorated function is called as ``fn(*args, previous)``, where
-    ``args`` match whatever the step itself is invoked with (most take just
-    ``server_args``; a few take more, or none) and ``previous`` is always
-    last. Call ``previous(*args)`` to run what would have run without this
-    override -- the ``super().handle_x()`` shape, expressed as an explicit
-    argument instead of a method-resolution lookup, because there is no class
-    hierarchy here for ``super()`` to walk. Not calling it is a full
-    replacement.
+    The decorated function is called as ``fn(server_args, previous)`` -- or
+    just ``fn(previous)`` for the one step, `handle_hardware_runtime_validation`,
+    that takes no arguments at all -- with ``previous`` always last. Call
+    ``previous(server_args)`` (or ``previous()``) to run what would have run
+    without this override -- the ``super().handle_x()`` shape, expressed as
+    an explicit argument instead of a method-resolution lookup, because there
+    is no class hierarchy here for ``super()`` to walk. Not calling it is a
+    full replacement.
 
     Registering twice for the same name does not replace the first
     registration; it wraps it. The **last** registration is outermost --
@@ -175,7 +178,7 @@ def register_resolution_hook(name: str):
     return decorator
 
 
-def run_hook(builtin: Callable[..., Any], *args: Any) -> Any:
+def run_hook(builtin: Callable[..., Any], server_args: Any = None) -> Any:
     """Run ``builtin`` -- the registered chain if anything overrode it under
     its name, ``builtin`` directly otherwise.
 
@@ -186,9 +189,12 @@ def run_hook(builtin: Callable[..., Any], *args: Any) -> Any:
     removing elsewhere. ``builtin`` must therefore be a plain, named
     function -- every real call site is -- not a lambda or a bound method.
 
-    ``*args`` are forwarded exactly as given, to `builtin` and to every
-    registered override -- this makes no assumption that a step takes
-    `server_args` and only `server_args`.
+    ``server_args`` defaults to ``None``, meaning "this step takes no
+    arguments at all" -- the one real case is
+    ``handle_hardware_runtime_validation``, called as plain
+    ``run_hook(handle_hardware_runtime_validation)``. Every other call site
+    passes its ``server_args`` explicitly, and every registered override for
+    it takes ``(server_args, previous)``.
 
     Called from the step's fixed position in `run_resolution_pipeline`. The
     chain is rebuilt from the registry on every call rather than cached at
@@ -200,11 +206,15 @@ def run_hook(builtin: Callable[..., Any], *args: Any) -> Any:
     step = builtin
     for fn in _HOOKS.get(builtin.__name__, ()):
         step = _bind(fn, step)
-    return step(*args)
+    if server_args is None:
+        return step()
+    return step(server_args)
 
 
 def _bind(fn, previous):
-    def wrapped(*args):
-        return fn(*args, previous)
+    def wrapped(server_args=None):
+        if server_args is None:
+            return fn(previous)
+        return fn(server_args, previous)
 
     return wrapped

--- a/python/sglang/srt/arg_groups/resolution_hooks.py
+++ b/python/sglang/srt/arg_groups/resolution_hooks.py
@@ -17,13 +17,13 @@ and `_handle_cuda_graph_config` merged under one rename and the dispatcher
 called itself). A name that is not on the list fails loudly at import time,
 not silently at the call site three modules away.
 
-Steps do not share one signature -- most take `(server_args)`, one takes
-`(server_args, gpu_mem)`, one takes no arguments at all -- so `run_hook`
-forwards `*args` rather than assuming `server_args` is the only thing there.
-An override's own signature always matches its target's, plus `previous`
-last: `def mine(server_args, gpu_mem, previous)` for a step that takes
-`(server_args, gpu_mem)`. `previous` itself is always called the same way
-regardless -- with whatever `*args` the step was invoked with.
+Steps do not share one signature -- nearly all take `(server_args)`, but
+`handle_hardware_runtime_validation` takes no arguments at all -- so
+`run_hook` forwards `*args` rather than assuming `server_args` is the only
+thing there. An override's own signature always matches its target's, plus
+`previous` last: `def mine(previous)` for that zero-argument step. `previous`
+itself is always called the same way regardless -- with whatever `*args` the
+step was invoked with.
 """
 
 from __future__ import annotations

--- a/python/sglang/srt/arg_groups/resolution_hooks.py
+++ b/python/sglang/srt/arg_groups/resolution_hooks.py
@@ -4,7 +4,11 @@
 per-step dispatch through `self` -- there is nothing on `ServerArgs` left to
 subclass in order to change how one step decides. This is the replacement
 for that: a decorator that wraps whatever currently runs under a given name,
-and a dispatcher the pipeline calls instead of the bare function.
+and a dispatcher the pipeline calls instead of the bare function. The name
+itself is never spelled out at the call site -- `run_hook` reads it off the
+function it was handed -- so there is exactly one place a step's name is
+written by hand: the whitelist below, and whatever a downstream registrant
+passes to the decorator.
 
 Whitelisted names only, the same discipline `Arg(resolvable=True)` uses for
 declarable fields: this project has already been bitten once by an
@@ -75,20 +79,26 @@ def register_resolution_hook(name: str):
     return decorator
 
 
-def run_hook(name: str, builtin: Callable[[Any], None], server_args: Any) -> None:
-    """Run the pipeline step named ``name`` -- the registered chain if
-    anything overrode it, ``builtin`` otherwise.
+def run_hook(builtin: Callable[[Any], None], server_args: Any) -> None:
+    """Run ``builtin`` -- the registered chain if anything overrode it under
+    its name, ``builtin`` directly otherwise.
 
-    Called from the step's fixed position in `run_resolution_pipeline`;
-    `builtin` is that position's own local import, so this never needs the
-    built-in registered anywhere in advance. The chain is rebuilt from the
-    registry on every call rather than cached at registration time, because
-    at registration time (import time, before any `ServerArgs` exists) there
-    is no `server_args` yet and the first registrant's `previous` cannot be
-    bound to anything real until a call actually happens.
+    The name is ``builtin.__name__``, not a second argument: the call site
+    already has the function in scope (a function-local import, same as
+    every other step), and spelling the name out again next to it is the
+    exact "two copies that can silently disagree" shape this project keeps
+    removing elsewhere. ``builtin`` must therefore be a plain, named
+    function -- every real call site is -- not a lambda or a bound method.
+
+    Called from the step's fixed position in `run_resolution_pipeline`. The
+    chain is rebuilt from the registry on every call rather than cached at
+    registration time, because at registration time (import time, before any
+    `ServerArgs` exists) there is no `server_args` yet and the first
+    registrant's `previous` cannot be bound to anything real until a call
+    actually happens.
     """
     step = builtin
-    for fn in _HOOKS.get(name, ()):
+    for fn in _HOOKS.get(builtin.__name__, ()):
         step = _bind(fn, step)
     step(server_args)
 

--- a/python/sglang/srt/arg_groups/resolution_hooks.py
+++ b/python/sglang/srt/arg_groups/resolution_hooks.py
@@ -1,4 +1,4 @@
-"""Out-of-tree replacement for one named step of the resolution pipeline.
+"""Out-of-tree replacement for a named step of the resolution pipeline.
 
 `run_resolution_pipeline` calls its steps by name, hardcoded, with no
 per-step dispatch through `self` -- there is nothing on `ServerArgs` left to
@@ -16,37 +16,133 @@ unqualified name collision in this exact pipeline (`_parse_cuda_graph_config`
 and `_handle_cuda_graph_config` merged under one rename and the dispatcher
 called itself). A name that is not on the list fails loudly at import time,
 not silently at the call site three modules away.
+
+Steps do not share one signature -- most take `(server_args)`, one takes
+`(server_args, gpu_mem)`, one takes no arguments at all -- so `run_hook`
+forwards `*args` rather than assuming `server_args` is the only thing there.
+An override's own signature always matches its target's, plus `previous`
+last: `def mine(server_args, gpu_mem, previous)` for a step that takes
+`(server_args, gpu_mem)`. `previous` itself is always called the same way
+regardless -- with whatever `*args` the step was invoked with.
 """
 
 from __future__ import annotations
 
 from typing import Any, Callable, Dict, FrozenSet, List
 
-# The only step open to replacement so far. Add a name here only alongside
-# the call site's own switch to `run_hook` -- an entry with no matching
-# `run_hook(...)` call is a name nothing will ever look up.
-_OVERRIDABLE_HOOKS: FrozenSet[str] = frozenset({"handle_cuda_graph_config"})
+# Every step this pipeline runs by name that a downstream package may replace.
+# Add a name here only alongside the call site's own switch to `run_hook` --
+# an entry with no matching `run_hook(...)` call is a name nothing will ever
+# look up. `test_every_whitelisted_hook_has_a_call_site` in
+# test_resolution_hook_registry.py holds the two directions of this equal by
+# construction, so this list cannot drift from `pipeline.py` silently.
+#
+# `handle_offload_compatibility` runs at two different points in the pipeline
+# (once before model-specific adjustments, once after -- see the comments at
+# its call sites). An override registered for it applies at both, identically;
+# there is no way to target "just the second call" through this mechanism,
+# because the name is all `run_hook` has to key on.
+_OVERRIDABLE_HOOKS: FrozenSet[str] = frozenset(
+    {
+        "handle_mega_moe",
+        "handle_return_hidden_states_mode",
+        "handle_media_url_security",
+        "handle_hicache_ratio_default",
+        "handle_offload_compatibility",
+        "validate_prefill_decode_interval",
+        "default_unset_prefill_decode_interval",
+        "validate_sampling_mask_max_tokens",
+        "validate_prefill_cp_platform",
+        "handle_hardware_runtime_validation",
+        "handle_model_source_paths",
+        "handle_multimodal",
+        "handle_ssl_validation",
+        "handle_asr_validation",
+        "handle_deprecated_args",
+        "handle_prefill_delayer_env_compat",
+        "handle_missing_default_values",
+        "handle_expert_pack",
+        "handle_pd_disaggregation",
+        "validate_prefill_only_disable_kv_cache_args",
+        "handle_decode_context_parallelism",
+        "apply_inkling_prefill_cuda_graph_default",
+        "apply_muse_glimmer_prefill_cuda_graph_max_bs_default",
+        "handle_dwdp",
+        "handle_cuda_graph_config",
+        "apply_glm5_chunked_prefill_default",
+        "handle_hpu_backends",
+        "handle_cpu_backends",
+        "handle_npu_backends",
+        "handle_mps_backends",
+        "handle_xpu_backends",
+        "handle_symm_mem_device_support",
+        "handle_platform_defaults",
+        "handle_gpu_memory_settings",
+        "handle_model_specific_adjustments",
+        "handle_deterministic_inference",
+        "handle_attention_backend_compatibility",
+        "disable_prefill_cuda_graph_for_deepseek_trtllm_mla",
+        "handle_mamba_backend",
+        "handle_int8_mamba_checkpoint",
+        "handle_linear_attn_backend",
+        "apply_glm5_prefill_cuda_graph_policy",
+        "handle_kv4_compatibility",
+        "handle_mxfp8_kv_cache_compatibility",
+        "handle_amd_specifics",
+        "handle_nccl_pre_warm",
+        "handle_grammar_backend",
+        "handle_multi_item_scoring",
+        "handle_prefill_only_disable_kv_cache",
+        "handle_hicache",
+        "handle_data_parallelism",
+        "handle_load_balance_method",
+        "handle_context_parallelism",
+        "handle_moe_kernel_config",
+        "handle_a2a_moe",
+        "handle_eplb_and_dispatch",
+        "handle_expert_distribution_metrics",
+        "handle_elastic_ep",
+        "validate_experimental_sgl_marlin",
+        "handle_speculative_decoding",
+        "handle_layernorm_sp",
+        "validate_cutedsl_a2a_token_budget",
+        "handle_load_format",
+        "handle_encoder_disaggregation",
+        "handle_tokenizer_batching",
+        "handle_environment_variables",
+        "handle_cache_compatibility",
+        "handle_page_major_kv_layout",
+        "handle_unified_memory_pool",
+        "handle_dllm_inference",
+        "handle_crash_dump_env",
+        "handle_debug_utils",
+        "handle_other_validations",
+        "handle_model_capability_adjustments",
+        "validate_deepep_v2_speculative_draft",
+        "validate_deepep_v2_dispatch_token_budget",
+    }
+)
 
-# name -> registered overrides, oldest first. Each takes `(server_args,
-# previous)`, where `previous` is the callable it wraps -- the built-in on
-# the first registration, the previous registrant's override on every one
-# after. Process-global as a `dict[str, list]` so a test isolates it the way
-# `test_model_overrides.py` isolates `_MODEL_OVERRIDE_FNS`: `patch.dict(...,
-# clear=True)`.
-_HOOKS: Dict[str, List[Callable[[Any, Callable[[Any], None]], None]]] = {}
+# name -> registered overrides, oldest first. Each takes `(*args, previous)`,
+# where `args` are whatever the step itself is called with and `previous` is
+# the callable it wraps -- the built-in on the first registration, the
+# previous registrant's own wrapper on every one after. Process-global as a
+# `dict[str, list]` so a test isolates it the way test_model_overrides.py
+# isolates `_MODEL_OVERRIDE_FNS`: `patch.dict(..., clear=True)`.
+_HOOKS: Dict[str, List[Callable[..., Any]]] = {}
 
 
 def register_resolution_hook(name: str):
     """Replace (or wrap) the pipeline step named ``name``.
 
-    The decorated function is called as ``fn(server_args, previous)``.
-    ``previous`` is a plain ``server_args -> None`` callable: the built-in
-    step on the first registration for this name, or the previous
-    registrant's own wrapper on every registration after that. Call it to
-    run what would have run without this override -- the `super().handle_x()`
-    shape, expressed as an explicit argument instead of a method-resolution
-    lookup, because there is no class hierarchy here for `super()` to walk.
-    Not calling it is a full replacement.
+    The decorated function is called as ``fn(*args, previous)``, where
+    ``args`` match whatever the step itself is invoked with (most take just
+    ``server_args``; a few take more, or none) and ``previous`` is always
+    last. Call ``previous(*args)`` to run what would have run without this
+    override -- the ``super().handle_x()`` shape, expressed as an explicit
+    argument instead of a method-resolution lookup, because there is no class
+    hierarchy here for ``super()`` to walk. Not calling it is a full
+    replacement.
 
     Registering twice for the same name does not replace the first
     registration; it wraps it. The **last** registration is outermost --
@@ -79,7 +175,7 @@ def register_resolution_hook(name: str):
     return decorator
 
 
-def run_hook(builtin: Callable[[Any], None], server_args: Any) -> None:
+def run_hook(builtin: Callable[..., Any], *args: Any) -> Any:
     """Run ``builtin`` -- the registered chain if anything overrode it under
     its name, ``builtin`` directly otherwise.
 
@@ -89,6 +185,10 @@ def run_hook(builtin: Callable[[Any], None], server_args: Any) -> None:
     exact "two copies that can silently disagree" shape this project keeps
     removing elsewhere. ``builtin`` must therefore be a plain, named
     function -- every real call site is -- not a lambda or a bound method.
+
+    ``*args`` are forwarded exactly as given, to `builtin` and to every
+    registered override -- this makes no assumption that a step takes
+    `server_args` and only `server_args`.
 
     Called from the step's fixed position in `run_resolution_pipeline`. The
     chain is rebuilt from the registry on every call rather than cached at
@@ -100,11 +200,11 @@ def run_hook(builtin: Callable[[Any], None], server_args: Any) -> None:
     step = builtin
     for fn in _HOOKS.get(builtin.__name__, ()):
         step = _bind(fn, step)
-    step(server_args)
+    return step(*args)
 
 
 def _bind(fn, previous):
-    def wrapped(server_args):
-        fn(server_args, previous)
+    def wrapped(*args):
+        return fn(*args, previous)
 
     return wrapped

--- a/python/sglang/srt/arg_groups/resolution_hooks.py
+++ b/python/sglang/srt/arg_groups/resolution_hooks.py
@@ -17,15 +17,11 @@ and `_handle_cuda_graph_config` merged under one rename and the dispatcher
 called itself). A name that is not on the list fails loudly at import time,
 not silently at the call site three modules away.
 
-Steps do not share one signature -- nearly all take `(server_args)`, but
-`handle_hardware_runtime_validation` takes no arguments at all. `run_hook`
-takes `server_args` as an ordinary, optional parameter (default `None`) for
-that reason, not a generic `*args`: the call site for that one step omits it
-entirely (`run_hook(handle_hardware_runtime_validation)`), and `run_hook`
-calls the whole chain with no arguments when it is missing. An override's
-own signature always matches its target's, plus `previous` last: `def
-mine(previous)` for that zero-argument step, `def mine(server_args,
-previous)` for everything else.
+Every step takes exactly `(server_args)`, `handle_hardware_runtime_validation`
+included -- it does not read `server_args` (see the comment at its
+definition), but it takes the parameter anyway so `run_hook` never has to
+special-case an arity. An override's own signature always matches: `def
+mine(server_args, previous)`.
 """
 
 from __future__ import annotations
@@ -126,26 +122,25 @@ _OVERRIDABLE_HOOKS: FrozenSet[str] = frozenset(
 )
 
 # name -> registered overrides, oldest first. Each takes `(server_args,
-# previous)`, or just `(previous)` for the one step that takes no arguments
-# at all, where `previous` is the callable it wraps -- the built-in on the
-# first registration, the previous registrant's own wrapper on every one
+# previous)`, where `previous` is the callable it wraps -- the built-in on
+# the first registration, the previous registrant's own wrapper on every one
 # after. Process-global as a `dict[str, list]` so a test isolates it the way
 # test_model_overrides.py isolates `_MODEL_OVERRIDE_FNS`:
 # `patch.dict(..., clear=True)`.
-_HOOKS: Dict[str, List[Callable[..., Any]]] = {}
+_HOOKS: Dict[str, List[Callable[[Any, Callable[[Any], None]], None]]] = {}
 
 
 def register_resolution_hook(name: str):
     """Replace (or wrap) the pipeline step named ``name``.
 
-    The decorated function is called as ``fn(server_args, previous)`` -- or
-    just ``fn(previous)`` for the one step, `handle_hardware_runtime_validation`,
-    that takes no arguments at all -- with ``previous`` always last. Call
-    ``previous(server_args)`` (or ``previous()``) to run what would have run
-    without this override -- the ``super().handle_x()`` shape, expressed as
-    an explicit argument instead of a method-resolution lookup, because there
-    is no class hierarchy here for ``super()`` to walk. Not calling it is a
-    full replacement.
+    The decorated function is called as ``fn(server_args, previous)``.
+    ``previous`` is a plain ``server_args -> None`` callable: the built-in
+    step on the first registration for this name, or the previous
+    registrant's own wrapper on every registration after that. Call it to
+    run what would have run without this override -- the `super().handle_x()`
+    shape, expressed as an explicit argument instead of a method-resolution
+    lookup, because there is no class hierarchy here for `super()` to walk.
+    Not calling it is a full replacement.
 
     Registering twice for the same name does not replace the first
     registration; it wraps it. The **last** registration is outermost --
@@ -178,7 +173,7 @@ def register_resolution_hook(name: str):
     return decorator
 
 
-def run_hook(builtin: Callable[..., Any], server_args: Any = None) -> Any:
+def run_hook(builtin: Callable[[Any], None], server_args: Any) -> None:
     """Run ``builtin`` -- the registered chain if anything overrode it under
     its name, ``builtin`` directly otherwise.
 
@@ -188,13 +183,6 @@ def run_hook(builtin: Callable[..., Any], server_args: Any = None) -> Any:
     exact "two copies that can silently disagree" shape this project keeps
     removing elsewhere. ``builtin`` must therefore be a plain, named
     function -- every real call site is -- not a lambda or a bound method.
-
-    ``server_args`` defaults to ``None``, meaning "this step takes no
-    arguments at all" -- the one real case is
-    ``handle_hardware_runtime_validation``, called as plain
-    ``run_hook(handle_hardware_runtime_validation)``. Every other call site
-    passes its ``server_args`` explicitly, and every registered override for
-    it takes ``(server_args, previous)``.
 
     Called from the step's fixed position in `run_resolution_pipeline`. The
     chain is rebuilt from the registry on every call rather than cached at
@@ -206,15 +194,11 @@ def run_hook(builtin: Callable[..., Any], server_args: Any = None) -> Any:
     step = builtin
     for fn in _HOOKS.get(builtin.__name__, ()):
         step = _bind(fn, step)
-    if server_args is None:
-        return step()
-    return step(server_args)
+    step(server_args)
 
 
 def _bind(fn, previous):
-    def wrapped(server_args=None):
-        if server_args is None:
-            return fn(previous)
-        return fn(server_args, previous)
+    def wrapped(server_args):
+        fn(server_args, previous)
 
     return wrapped

--- a/python/sglang/srt/arg_groups/resolution_hooks.py
+++ b/python/sglang/srt/arg_groups/resolution_hooks.py
@@ -1,0 +1,100 @@
+"""Out-of-tree replacement for one named step of the resolution pipeline.
+
+`run_resolution_pipeline` calls its steps by name, hardcoded, with no
+per-step dispatch through `self` -- there is nothing on `ServerArgs` left to
+subclass in order to change how one step decides. This is the replacement
+for that: a decorator that wraps whatever currently runs under a given name,
+and a dispatcher the pipeline calls instead of the bare function.
+
+Whitelisted names only, the same discipline `Arg(resolvable=True)` uses for
+declarable fields: this project has already been bitten once by an
+unqualified name collision in this exact pipeline (`_parse_cuda_graph_config`
+and `_handle_cuda_graph_config` merged under one rename and the dispatcher
+called itself). A name that is not on the list fails loudly at import time,
+not silently at the call site three modules away.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, FrozenSet, List
+
+# The only step open to replacement so far. Add a name here only alongside
+# the call site's own switch to `run_hook` -- an entry with no matching
+# `run_hook(...)` call is a name nothing will ever look up.
+_OVERRIDABLE_HOOKS: FrozenSet[str] = frozenset({"handle_cuda_graph_config"})
+
+# name -> registered overrides, oldest first. Each takes `(server_args,
+# previous)`, where `previous` is the callable it wraps -- the built-in on
+# the first registration, the previous registrant's override on every one
+# after. Process-global as a `dict[str, list]` so a test isolates it the way
+# `test_model_overrides.py` isolates `_MODEL_OVERRIDE_FNS`: `patch.dict(...,
+# clear=True)`.
+_HOOKS: Dict[str, List[Callable[[Any, Callable[[Any], None]], None]]] = {}
+
+
+def register_resolution_hook(name: str):
+    """Replace (or wrap) the pipeline step named ``name``.
+
+    The decorated function is called as ``fn(server_args, previous)``.
+    ``previous`` is a plain ``server_args -> None`` callable: the built-in
+    step on the first registration for this name, or the previous
+    registrant's own wrapper on every registration after that. Call it to
+    run what would have run without this override -- the `super().handle_x()`
+    shape, expressed as an explicit argument instead of a method-resolution
+    lookup, because there is no class hierarchy here for `super()` to walk.
+    Not calling it is a full replacement.
+
+    Registering twice for the same name does not replace the first
+    registration; it wraps it. The **last** registration is outermost --
+    runs first, and decides whether/when its `previous` (everything
+    registered before it, down to the built-in) runs at all. Two downstream
+    packages that both target the same name compose in whichever order they
+    happened to import in; if that order matters to you, make one of them
+    import the other first.
+
+    This changes *what* runs at the step's existing position in the
+    pipeline, never *when*: the call site in `pipeline.py` is unmoved, so
+    every other step keeps the order it already had. A wrapped step's own
+    declarations reach `resolution_result` the same way any declaration
+    does -- only readers from this position onward see them; a step that
+    already ran and read the old value before this one's `previous` (or the
+    built-in) declared its replacement has already made its decision on it.
+    """
+    if name not in _OVERRIDABLE_HOOKS:
+        raise ValueError(
+            f"{name!r} is not an overridable resolution hook; the "
+            f"overridable set is {sorted(_OVERRIDABLE_HOOKS)}. A new entry "
+            "needs a matching `run_hook(...)` call at the step's site in "
+            "pipeline.py, not just a name here."
+        )
+
+    def decorator(fn):
+        _HOOKS.setdefault(name, []).append(fn)
+        return fn
+
+    return decorator
+
+
+def run_hook(name: str, builtin: Callable[[Any], None], server_args: Any) -> None:
+    """Run the pipeline step named ``name`` -- the registered chain if
+    anything overrode it, ``builtin`` otherwise.
+
+    Called from the step's fixed position in `run_resolution_pipeline`;
+    `builtin` is that position's own local import, so this never needs the
+    built-in registered anywhere in advance. The chain is rebuilt from the
+    registry on every call rather than cached at registration time, because
+    at registration time (import time, before any `ServerArgs` exists) there
+    is no `server_args` yet and the first registrant's `previous` cannot be
+    bound to anything real until a call actually happens.
+    """
+    step = builtin
+    for fn in _HOOKS.get(name, ()):
+        step = _bind(fn, step)
+    step(server_args)
+
+
+def _bind(fn, previous):
+    def wrapped(server_args):
+        fn(server_args, previous)
+
+    return wrapped

--- a/python/sglang/srt/disaggregation/encoder/server.py
+++ b/python/sglang/srt/disaggregation/encoder/server.py
@@ -590,7 +590,10 @@ class MMEncoder:
             distributed_init_method=dist_init_method,
             local_rank=rank,
         )
-        initialize_model_parallel(tensor_model_parallel_size=get_parallel().tp_size)
+        initialize_model_parallel(
+            tensor_model_parallel_size=get_parallel().tp_size,
+            attention_context_model_parallel_size=get_parallel().attn_cp_size,
+        )
         initialize_dp_attention(server_args, self.model_config)
 
         self.model = load_model(

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2621,8 +2621,11 @@ def initialize_model_parallel(
 
     attn_dp_size = attention_data_parallel_size
     attn_cp_size = attention_context_model_parallel_size
-    # The groups below are built at these numbers, and the same dict is stamped
-    # once they exist.
+    # The groups below are built at this width. Not stamped: every real
+    # caller of this function forwards leaves already published from this
+    # same config, so `get_parallel().attn_tp_size` and its siblings already
+    # answer with this value (see 16-field-registry-design.md §6e and
+    # TestDerivedWidths.test_recomputing_from_published_leaves_matches_the_publish_bag).
     derived_widths = derive_parallel_widths(
         tp_size=tensor_model_parallel_size,
         attn_cp_size=attn_cp_size,
@@ -2831,8 +2834,6 @@ def initialize_model_parallel(
             use_custom_allreduce=False,
             group_name="self_pp",
         )
-
-    get_parallel().stamp_derived_widths(**derived_widths)
 
 
 def create_custom_parallel_group(

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2621,11 +2621,8 @@ def initialize_model_parallel(
 
     attn_dp_size = attention_data_parallel_size
     attn_cp_size = attention_context_model_parallel_size
-    # The groups below are built at this width. Not stamped: every real
-    # caller of this function forwards leaves already published from this
-    # same config, so `get_parallel().attn_tp_size` and its siblings already
-    # answer with this value (see 16-field-registry-design.md §6e and
-    # TestDerivedWidths.test_recomputing_from_published_leaves_matches_the_publish_bag).
+    # The groups below are built at these numbers, and the same dict is stamped
+    # once they exist.
     derived_widths = derive_parallel_widths(
         tp_size=tensor_model_parallel_size,
         attn_cp_size=attn_cp_size,
@@ -2834,6 +2831,8 @@ def initialize_model_parallel(
             use_custom_allreduce=False,
             group_name="self_pp",
         )
+
+    get_parallel().stamp_derived_widths(**derived_widths)
 
 
 def create_custom_parallel_group(

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -11,8 +11,7 @@ It takes over the control of the distributed environment from PyTorch.
 The typical workflow is:
 
 - call `init_distributed_environment` to initialize the distributed environment.
-- call `initialize_model_parallel` or `ensure_model_parallel_initialized` to
- initialize the model parallel groups.
+- call `initialize_model_parallel` to initialize the model parallel groups.
 
 - any code dealing with the distributed stuff
 
@@ -2883,46 +2882,6 @@ def create_custom_parallel_group(
             )
 
     return my_new_group
-
-
-def ensure_model_parallel_initialized(
-    tensor_model_parallel_size: int,
-    expert_model_parallel_size: int,
-    pipeline_model_parallel_size: int,
-    decode_context_parallel_size: int = 1,
-    backend: Optional[str] = None,
-) -> None:
-    """Helper to initialize model parallel groups if they are not initialized,
-    or ensure tensor-parallel and pipeline-parallel sizes are equal to expected
-    values if the model parallel groups are initialized.
-    """
-    backend = backend or torch.distributed.get_backend(get_world_group().device_group)
-    if not model_parallel_is_initialized():
-        initialize_model_parallel(
-            tensor_model_parallel_size=tensor_model_parallel_size,
-            expert_model_parallel_size=expert_model_parallel_size,
-            pipeline_model_parallel_size=pipeline_model_parallel_size,
-            decode_context_parallel_size=decode_context_parallel_size,
-            backend=backend,
-        )
-        return
-
-    assert get_tensor_model_parallel_world_size() == tensor_model_parallel_size, (
-        "tensor parallel group already initialized, but of unexpected size: "
-        f"{get_tensor_model_parallel_world_size()=} vs. "
-        f"{tensor_model_parallel_size=}"
-    )
-    pp_world_size = get_pp_group().world_size
-    assert pp_world_size == pipeline_model_parallel_size, (
-        "pipeline parallel group already initialized, but of unexpected size: "
-        f"{pp_world_size=} vs. "
-        f"{pipeline_model_parallel_size=}"
-    )
-    if decode_context_parallel_size > 1:
-        dcp_world_size = get_dcp_group().world_size
-        assert dcp_world_size == decode_context_parallel_size, (
-            f"decode context parallel group already initialized, but of unexpected size: {dcp_world_size=} {decode_context_parallel_size=}"
-        )
 
 
 def model_parallel_is_initialized():

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2832,8 +2832,6 @@ def initialize_model_parallel(
             group_name="self_pp",
         )
 
-    get_parallel().stamp_derived_widths(**derived_widths)
-
 
 def create_custom_parallel_group(
     group_ranks: List[int], backend: str = "gloo"

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -71,7 +71,9 @@ def update_dp_attention_post_scale(new_dp_size: int, new_dp_rank: int):
     global _ATTN_DP_SIZE, _ATTN_DP_RANK
     _ATTN_DP_SIZE = new_dp_size
     _ATTN_DP_RANK = new_dp_rank
-    get_parallel().stamp_derived_widths(attn_dp_size=new_dp_size)
+    get_parallel().override_permanently(
+        "update_dp_attention_post_scale", attn_dp_size=new_dp_size
+    )
     get_flags().dp.use_world_group_for_gather = True
     logger.debug(
         "[Elastic EP] dp_attention switched to WORLD: dp_size=%d dp_rank=%d",
@@ -350,7 +352,8 @@ def compute_dp_attention_world_info(
     """This rank's place in the attention topology, plus the widths it sits in.
 
     The widths come from `derive_attention_widths`; what this adds is the two
-    ranks, which are per-process and so are not part of the stamped set.
+    ranks, which are per-process and so are not among the widths
+    `override_permanently` records.
     """
     attn_dp_size, attn_tp_size = derive_attention_widths(
         tp_size=tp_size,
@@ -391,7 +394,9 @@ def initialize_dp_attention(
     _, _, _ATTN_DP_RANK, _ATTN_DP_SIZE = compute_dp_attention_world_info(
         enable_dp_attention, tp_rank, tp_size, dp_size, attn_cp_size
     )
-    get_parallel().stamp_derived_widths(attn_dp_size=_ATTN_DP_SIZE)
+    get_parallel().override_permanently(
+        "initialize_dp_attention", attn_dp_size=_ATTN_DP_SIZE
+    )
 
     if get_exec().moe.elastic_ep_backend is not None and get_parallel().max_ep_size:
         _ATTN_DP_RANK = tp_rank + get_parallel().ep_join_rank_offset

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -71,9 +71,7 @@ def update_dp_attention_post_scale(new_dp_size: int, new_dp_rank: int):
     global _ATTN_DP_SIZE, _ATTN_DP_RANK
     _ATTN_DP_SIZE = new_dp_size
     _ATTN_DP_RANK = new_dp_rank
-    get_parallel().override_permanently(
-        "update_dp_attention_post_scale", attn_dp_size=new_dp_size
-    )
+    get_parallel().override_permanently(attn_dp_size=new_dp_size)
     get_flags().dp.use_world_group_for_gather = True
     logger.debug(
         "[Elastic EP] dp_attention switched to WORLD: dp_size=%d dp_rank=%d",
@@ -394,9 +392,7 @@ def initialize_dp_attention(
     _, _, _ATTN_DP_RANK, _ATTN_DP_SIZE = compute_dp_attention_world_info(
         enable_dp_attention, tp_rank, tp_size, dp_size, attn_cp_size
     )
-    get_parallel().override_permanently(
-        "initialize_dp_attention", attn_dp_size=_ATTN_DP_SIZE
-    )
+    get_parallel().override_permanently(attn_dp_size=_ATTN_DP_SIZE)
 
     if get_exec().moe.elastic_ep_backend is not None and get_parallel().max_ep_size:
         _ATTN_DP_RANK = tp_rank + get_parallel().ep_join_rank_offset

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -262,13 +262,12 @@ class ParallelContext:
     different names rather than two answers to one name.
     """
 
-    __slots__ = ("_overrides", "_config", "_derived", "_derived_log")
+    __slots__ = ("_overrides", "_config", "_derived")
 
     def __init__(self):
         self._overrides = {}
         self._config = None  # parallel config bag, wired at publish
         self._derived = {}  # widths overridden permanently, as the groups are built
-        self._derived_log = []  # [(source, {name: value})], provenance for _derived
 
     def __getattr__(self, name):
         if name.startswith("_"):
@@ -291,33 +290,22 @@ class ParallelContext:
         overrides = self._overrides
         return overrides[name] if name in overrides else getter()
 
-    def override_permanently(self, source: str, **widths) -> None:
+    def override_permanently(self, **widths) -> None:
         """Permanently correct a derived width the published bag can't answer
-        or no longer answers correctly -- the `RuntimeContext.override(source,
-        **fields)` shape, not that method, because a derived width is not a
-        resolved config leaf and this must work with no config published at
-        all (`multimodal_gen` lends a TP group to `srt` layers with no `srt`
-        config to publish against).
+        or no longer answers correctly -- not `RuntimeContext.override`,
+        because a derived width is not a resolved config leaf and this must
+        work with no config published at all (`multimodal_gen` lends a TP
+        group to `srt` layers with no `srt` config to publish against).
 
-        `initialize_dp_attention` calls this once `attn_dp_size` is known, and
-        an elastic EP scale-up calls it again where it already updates the
-        live one; `source` is provenance for both, kept for the same reason
-        `RuntimeContext.override` keeps one. Lives beside, not inside, the
-        `@contextmanager` `override` above -- a name it cannot also have on
-        this class -- because these are permanent for the process, not scoped
-        to a `with` block: none of the real callers ever restore the value
-        they set here.
+        Lives beside, not inside, the `@contextmanager` `override` above -- a
+        name it cannot also have on this class -- because these are permanent
+        for the process, not scoped to a `with` block: none of the real
+        callers ever restore the value they set here.
         """
         self._derived.update(widths)
-        self._derived_log.append((source, dict(widths)))
 
     def clear_derived_widths(self) -> None:
         self._derived.clear()
-        self._derived_log.clear()
-
-    def derived_widths_log(self) -> list:
-        """Provenance of `override_permanently` calls: `[(source, {name: value})]`."""
-        return [(source, dict(widths)) for source, widths in self._derived_log]
 
     def _derived_width(self, name):
         """A width the configuration implies: scoped override, else permanent

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -163,7 +163,7 @@ def derive_parallel_widths(
 
     `world_size` is not among them: it is not a quotient, and `get_world_size()`
     answers with the live WORLD group, which stays right through an elastic
-    scale-up that a stamp taken at group build would not survive.
+    scale-up that a value fixed at group build would not survive.
     """
     return {
         "attn_dp_size": attn_dp_size,
@@ -262,12 +262,13 @@ class ParallelContext:
     different names rather than two answers to one name.
     """
 
-    __slots__ = ("_overrides", "_config", "_derived")
+    __slots__ = ("_overrides", "_config", "_derived", "_derived_log")
 
     def __init__(self):
         self._overrides = {}
         self._config = None  # parallel config bag, wired at publish
-        self._derived = {}  # widths stamped when the groups are built
+        self._derived = {}  # widths overridden permanently, as the groups are built
+        self._derived_log = []  # [(source, {name: value})], provenance for _derived
 
     def __getattr__(self, name):
         if name.startswith("_"):
@@ -290,28 +291,42 @@ class ParallelContext:
         overrides = self._overrides
         return overrides[name] if name in overrides else getter()
 
-    def stamp_derived_widths(self, **widths) -> None:
-        """Record the widths derived from the leaves, as the groups are built.
+    def override_permanently(self, source: str, **widths) -> None:
+        """Permanently correct a derived width the published bag can't answer
+        or no longer answers correctly -- the `RuntimeContext.override(source,
+        **fields)` shape, not that method, because a derived width is not a
+        resolved config leaf and this must work with no config published at
+        all (`multimodal_gen` lends a TP group to `srt` layers with no `srt`
+        config to publish against).
 
-        `initialize_model_parallel` computes the set through
-        `derive_parallel_widths` and hands it here; `initialize_dp_attention`
-        stamps `attn_dp_size` again once it knows the effective width, and
-        elastic EP restamps it where it already updates the live one. A stamped
-        width is what the readers answer with.
+        `initialize_dp_attention` calls this once `attn_dp_size` is known, and
+        an elastic EP scale-up calls it again where it already updates the
+        live one; `source` is provenance for both, kept for the same reason
+        `RuntimeContext.override` keeps one. Lives beside, not inside, the
+        `@contextmanager` `override` above -- a name it cannot also have on
+        this class -- because these are permanent for the process, not scoped
+        to a `with` block: none of the real callers ever restore the value
+        they set here.
         """
         self._derived.update(widths)
+        self._derived_log.append((source, dict(widths)))
 
     def clear_derived_widths(self) -> None:
         self._derived.clear()
+        self._derived_log.clear()
+
+    def derived_widths_log(self) -> list:
+        """Provenance of `override_permanently` calls: `[(source, {name: value})]`."""
+        return [(source, dict(widths)) for source, widths in self._derived_log]
 
     def _derived_width(self, name):
-        """A width the configuration implies: override, else stamp, else the
-        published leaf.
+        """A width the configuration implies: scoped override, else permanent
+        override, else the published leaf.
 
-        The leaf is computed at publish by `parallel_widths_of`; the stamp sits
-        above it because an elastic scale-up restamps `attn_dp_size` after
-        publish, and a scope that swaps in another TP group states the quotients
-        through `override`.
+        The leaf is computed at publish by `parallel_widths_of`; the permanent
+        override sits above it because an elastic scale-up corrects
+        `attn_dp_size` after publish, and a scope that swaps in another TP
+        group states the quotients through the scoped `override` above that.
 
         Nothing is recomputed on read, so overriding `tp_size` does not move
         `attn_tp_size`: name the width, or publish a config.
@@ -327,10 +342,10 @@ class ParallelContext:
             return getattr(config, name)
         raise RuntimeError(
             f"derived parallel width {name!r} is not available: it is computed "
-            "from the configured leaves at publish, and restamped when the "
-            "process groups are built. Nothing is published and nothing has "
-            "been stamped -- publish a parallel config, or state the width "
-            f"with get_parallel().override({name}=...)"
+            "from the configured leaves at publish, and permanently corrected "
+            "when the process groups are built. Nothing is published and "
+            "nothing has been set with override_permanently -- publish a "
+            f"parallel config, or state the width with get_parallel().override({name}=...)"
         )
 
     @contextmanager
@@ -1752,9 +1767,10 @@ def reset_context() -> None:
     """Clear the context-owned store (unit-test teardown): drop the published
     ``server_args`` and install fresh ``Flags`` and ``Resources``.
 
-    ``parallel`` holds the stamped derived widths, which go with the lifecycle
-    that stamped them: `_derived_width` prefers the stamp over the leaves, so
-    leaving one behind lets the next test read the previous topology.
+    ``parallel`` holds the permanently-overridden derived widths, which go
+    with the lifecycle that set them: `_derived_width` prefers them over the
+    published leaves, so leaving one behind lets the next test read the
+    previous topology.
     """
     _CONTEXT._server_args = None
     _CONTEXT._config_bags = None

--- a/test/manual/ep/test_flashinfer_dispatcher.py
+++ b/test/manual/ep/test_flashinfer_dispatcher.py
@@ -20,14 +20,9 @@ from sglang.test.test_utils import CustomTestCase
 class TestFlashinferDispatcher(CustomTestCase):
     @classmethod
     def setUpClass(cls):
-        server_args = ServerArgs(model_path="dummy")
-        server_args.moe_runner_backend = "flashinfer_cutlass"
-        server_args.moe_a2a_backend = "flashinfer"
-        cls.server_args = server_args
-        set_global_server_args_for_scheduler(server_args)
-        publish(server_args, role="scheduler")
-        initialize_moe_config()
-
+        # Dist-init first: world_size (and so the tp/ep width ServerArgs must
+        # carry) is only known after it, and init_distributed_environment
+        # itself reads no published config.
         init_distributed_environment(
             world_size=-1,  # Auto-detect from environment
             rank=-1,  # Auto-detect from environment
@@ -38,13 +33,17 @@ class TestFlashinferDispatcher(CustomTestCase):
         rank = torch.distributed.get_rank()
         device = torch.device(f"cuda:{rank % torch.cuda.device_count()}")
         torch.cuda.set_device(device)
-        # world_size is only known post-dist-init, so the first publish above
-        # necessarily used the tp/ep defaults (1); republish with the width
-        # about to be built so get_parallel()'s derived widths (moe_ep_size,
-        # attn_tp_size, ...) reflect it too.
-        server_args.tp_size = world_size
-        server_args.ep_size = world_size
+
+        server_args = ServerArgs(
+            model_path="dummy", tp_size=world_size, ep_size=world_size
+        )
+        server_args.moe_runner_backend = "flashinfer_cutlass"
+        server_args.moe_a2a_backend = "flashinfer"
+        cls.server_args = server_args
+        set_global_server_args_for_scheduler(server_args)
         publish(server_args, role="scheduler")
+        initialize_moe_config()
+
         initialize_model_parallel(
             tensor_model_parallel_size=world_size, expert_model_parallel_size=world_size
         )

--- a/test/manual/ep/test_flashinfer_dispatcher.py
+++ b/test/manual/ep/test_flashinfer_dispatcher.py
@@ -38,6 +38,13 @@ class TestFlashinferDispatcher(CustomTestCase):
         rank = torch.distributed.get_rank()
         device = torch.device(f"cuda:{rank % torch.cuda.device_count()}")
         torch.cuda.set_device(device)
+        # world_size is only known post-dist-init, so the first publish above
+        # necessarily used the tp/ep defaults (1); republish with the width
+        # about to be built so get_parallel()'s derived widths (moe_ep_size,
+        # attn_tp_size, ...) reflect it too.
+        server_args.tp_size = world_size
+        server_args.ep_size = world_size
+        publish(server_args, role="scheduler")
         initialize_model_parallel(
             tensor_model_parallel_size=world_size, expert_model_parallel_size=world_size
         )

--- a/test/registered/eplb/test_lplb_distributed.py
+++ b/test/registered/eplb/test_lplb_distributed.py
@@ -212,6 +212,13 @@ def _worker_main(local_rank: int, world_size: int):
     set_global_server_args_for_scheduler(
         ServerArgs(
             model_path="dummy",
+            # Match the tp/ep width initialize_model_parallel is about to
+            # build below -- get_parallel()'s derived widths (attn_tp_size,
+            # moe_ep_size, ...) are projected from this at publish time, and
+            # nothing here should leave that projection reflecting a width
+            # this process never actually runs at.
+            tp_size=world_size,
+            ep_size=world_size,
         )
     )
 

--- a/test/registered/unit/distributed/test_mmencoder_forwards_attn_cp_size.py
+++ b/test/registered/unit/distributed/test_mmencoder_forwards_attn_cp_size.py
@@ -1,0 +1,67 @@
+"""MMEncoder must forward attn_cp_size to initialize_model_parallel, not just
+tp_size.
+
+Real 2-GPU hardware confirmed a live mismatch this test guards against
+statically: with `tp_size=2, attn_cp_size=2` published, calling
+`initialize_model_parallel(tensor_model_parallel_size=2)` alone builds the
+live attention-TP group at width 2, while `get_parallel().attn_tp_size`
+(derived from the published config) answers 1 -- `VisionAttention`
+(`layers/attention/vision.py`) reads that derived value as its own
+weight-sharding width, so the mismatch is a real, silent wrong-sharding bug,
+not just a reporting discrepancy. Forwarding
+`attention_context_model_parallel_size=get_parallel().attn_cp_size` too
+makes the two agree (confirmed on the same hardware).
+
+A full `MMEncoder` instantiation needs real weights and a live process
+group, so this checks the one line that matters statically: the call passes
+`attention_context_model_parallel_size` as well as
+`tensor_model_parallel_size`. Not a substitute for testing `MMEncoder`
+end-to-end under `--attn-cp-size > 1` on real hardware, but cheap enough to
+run everywhere and catches the specific regression class (a future edit
+that reverts to the tp-only call).
+"""
+
+import ast
+import os
+
+import sglang.srt.disaggregation.encoder.server as encoder_server_module
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestMMEncoderForwardsAttnCpSize(CustomTestCase):
+    def test_initialize_model_parallel_call_forwards_attn_cp_size(self):
+        path = encoder_server_module.__file__
+        tree = ast.parse(open(path).read())
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "initialize_model_parallel"
+        ]
+        self.assertEqual(
+            len(calls),
+            1,
+            f"expected exactly one initialize_model_parallel(...) call in "
+            f"{os.path.basename(path)}, found {len(calls)} -- update this "
+            "test if that's now intentional",
+        )
+        kwarg_names = {kw.arg for kw in calls[0].keywords}
+        self.assertIn(
+            "attention_context_model_parallel_size",
+            kwarg_names,
+            "MMEncoder's initialize_model_parallel(...) call must forward "
+            "attention_context_model_parallel_size (not just "
+            "tensor_model_parallel_size), or get_parallel().attn_tp_size "
+            "silently disagrees with the group actually built whenever "
+            "--attn-cp-size > 1 -- confirmed on real 2-GPU hardware",
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/test/registered/unit/server_args/test_resolution_hook_registry.py
+++ b/test/registered/unit/server_args/test_resolution_hook_registry.py
@@ -1,0 +1,178 @@
+"""Unit tests for the out-of-tree resolution-hook registry: whitelist
+enforcement, wrap-vs-replace semantics, multi-registrant composition, and the
+end-to-end proof that an override reaches a real `resolve_once()`."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.arg_groups import resolution_hooks as hooks_module
+from sglang.srt.arg_groups.overrides import resolution_result
+from sglang.srt.arg_groups.resolution_hooks import register_resolution_hook, run_hook
+from sglang.srt.server_args import ServerArgs
+from sglang.test.test_utils import CustomTestCase
+
+# `model_path="dummy"` short-circuits the pipeline before this step ever
+# runs (the fixture the rest of this file uses on purpose, since it does not
+# need the step to have run). The end-to-end proof below needs the real
+# pipeline, so it needs a real, tiny HF config on disk instead.
+_MINI_CONFIG = {
+    "architectures": ["LlamaForCausalLM"],
+    "model_type": "llama",
+    "hidden_size": 16,
+    "intermediate_size": 32,
+    "num_attention_heads": 2,
+    "num_key_value_heads": 2,
+    "num_hidden_layers": 2,
+    "vocab_size": 128,
+    "max_position_embeddings": 2048,
+}
+
+
+class _IsolatedRegistry(CustomTestCase):
+    """Run each test against an empty registry (it is process-global)."""
+
+    def setUp(self):
+        super().setUp()
+        self._patch = patch.dict(hooks_module._HOOKS, clear=True)
+        self._patch.start()
+        self.addCleanup(self._patch.stop)
+
+
+class TestWhitelist(_IsolatedRegistry):
+    def test_an_unlisted_name_is_refused_at_registration(self):
+        with self.assertRaisesRegex(ValueError, "not an overridable resolution hook"):
+
+            @register_resolution_hook("handle_something_nobody_whitelisted")
+            def _fn(server_args, previous):
+                pass
+
+    def test_the_whitelisted_name_registers(self):
+        @register_resolution_hook("handle_cuda_graph_config")
+        def _fn(server_args, previous):
+            pass
+
+        self.assertIn(_fn, hooks_module._HOOKS["handle_cuda_graph_config"])
+
+
+class TestRunHook(_IsolatedRegistry):
+    def test_nothing_registered_runs_the_builtin_directly(self):
+        calls = []
+        run_hook("handle_cuda_graph_config", calls.append, "sa")
+        self.assertEqual(calls, ["sa"])
+
+    def test_an_override_that_calls_previous_wraps_the_builtin(self):
+        order = []
+
+        @register_resolution_hook("handle_cuda_graph_config")
+        def _wraps(server_args, previous):
+            order.append(("before", server_args))
+            previous(server_args)
+            order.append(("after", server_args))
+
+        run_hook(
+            "handle_cuda_graph_config", lambda sa: order.append(("builtin", sa)), "sa"
+        )
+        self.assertEqual(
+            order,
+            [("before", "sa"), ("builtin", "sa"), ("after", "sa")],
+        )
+
+    def test_an_override_that_never_calls_previous_replaces_the_builtin(self):
+        builtin_ran = []
+
+        @register_resolution_hook("handle_cuda_graph_config")
+        def _replaces(server_args, previous):
+            pass  # deliberately does not call `previous`
+
+        run_hook("handle_cuda_graph_config", builtin_ran.append, "sa")
+        self.assertEqual(builtin_ran, [], "the replaced builtin must not have run")
+
+    def test_two_registrants_compose_last_registered_outermost(self):
+        order = []
+
+        @register_resolution_hook("handle_cuda_graph_config")
+        def _first(server_args, previous):
+            order.append("first-before")
+            previous(server_args)
+            order.append("first-after")
+
+        @register_resolution_hook("handle_cuda_graph_config")
+        def _second(server_args, previous):
+            order.append("second-before")
+            previous(server_args)
+            order.append("second-after")
+
+        run_hook(
+            "handle_cuda_graph_config",
+            lambda sa: order.append("builtin"),
+            "sa",
+        )
+        self.assertEqual(
+            order,
+            [
+                "second-before",  # last registered runs first (outermost)
+                "first-before",
+                "builtin",
+                "first-after",
+                "second-after",
+            ],
+        )
+
+
+class TestEndToEnd(_IsolatedRegistry):
+    """The proof that matters: a real `resolve_once()` picks up the override,
+    at the same position the built-in occupied, without disturbing the
+    neighboring steps documented at that call site."""
+
+    def setUp(self):
+        super().setUp()
+        self._config_dir = tempfile.mkdtemp(prefix="resolution_hook_registry_")
+        self.addCleanup(shutil.rmtree, self._config_dir, ignore_errors=True)
+        with open(os.path.join(self._config_dir, "config.json"), "w") as handle:
+            json.dump(_MINI_CONFIG, handle)
+
+    def test_an_override_reaches_resolution_result(self):
+        @register_resolution_hook("handle_cuda_graph_config")
+        def _mark_it(server_args, previous):
+            previous(server_args)
+            from sglang.srt.arg_groups.overrides import declare_resolution
+
+            declare_resolution(server_args, "test_plugin", random_seed=999)
+            server_args._test_plugin_ran = True
+
+        sa = ServerArgs(model_path=self._config_dir, device="cuda")
+        sa.resolve_once()
+        self.assertTrue(getattr(sa, "_test_plugin_ran", False))
+        self.assertEqual(resolution_result(sa, "random_seed"), 999)
+        # And the neighboring step (must run right after, per the comment at
+        # the call site) still ran and still saw a real config to chunk.
+        self.assertIsNotNone(
+            resolution_result(sa, "chunked_prefill_size"),
+            "apply_glm5_chunked_prefill_default's neighbor did not run",
+        )
+
+    def test_with_nothing_registered_resolution_is_unchanged(self):
+        baseline = ServerArgs(model_path=self._config_dir, device="cuda")
+        baseline.resolve_once()
+        sa = ServerArgs(model_path=self._config_dir, device="cuda")
+        sa.resolve_once()
+        self.assertEqual(
+            resolution_result(sa, "chunked_prefill_size"),
+            resolution_result(baseline, "chunked_prefill_size"),
+        )
+        self.assertEqual(
+            resolution_result(sa, "cuda_graph_config"),
+            resolution_result(baseline, "cuda_graph_config"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_resolution_hook_registry.py
+++ b/test/registered/unit/server_args/test_resolution_hook_registry.py
@@ -6,6 +6,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
+import ast
 import json
 import os
 import shutil
@@ -13,9 +14,14 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+from sglang.srt.arg_groups import pipeline as pipeline_module
 from sglang.srt.arg_groups import resolution_hooks as hooks_module
 from sglang.srt.arg_groups.overrides import resolution_result
-from sglang.srt.arg_groups.resolution_hooks import register_resolution_hook, run_hook
+from sglang.srt.arg_groups.resolution_hooks import (
+    _OVERRIDABLE_HOOKS,
+    register_resolution_hook,
+    run_hook,
+)
 from sglang.srt.server_args import ServerArgs
 from sglang.test.test_utils import CustomTestCase
 
@@ -62,6 +68,40 @@ class TestWhitelist(_IsolatedRegistry):
         self.assertIn(_fn, hooks_module._HOOKS["handle_cuda_graph_config"])
 
 
+class TestWhitelistMatchesThePipeline(CustomTestCase):
+    """The whitelist and `pipeline.py` are two hand-written lists that have to
+    agree; nothing keeps them in sync on its own. This derives both sides
+    fresh and asserts they are the same set, so a name added to one without
+    the other fails here instead of surfacing as "my override never runs" or
+    "this step nobody can ever replace" months later."""
+
+    def _run_hook_call_targets(self) -> set:
+        """The first argument of every `run_hook(...)` call in pipeline.py,
+        statically -- the set of steps the pipeline actually dispatches
+        through the registry."""
+        tree = ast.parse(open(pipeline_module.__file__).read())
+        names = set()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "run_hook"
+                and node.args
+                and isinstance(node.args[0], ast.Name)
+            ):
+                names.add(node.args[0].id)
+        return names
+
+    def test_every_whitelisted_hook_has_a_call_site(self):
+        called = self._run_hook_call_targets()
+        self.assertEqual(
+            (sorted(_OVERRIDABLE_HOOKS - called), sorted(called - _OVERRIDABLE_HOOKS)),
+            ([], []),
+            "(whitelisted but never called, called but not whitelisted) -- "
+            "both should be empty",
+        )
+
+
 class TestRunHook(_IsolatedRegistry):
     """``run_hook`` reads the name off the function it is handed
     (``builtin.__name__``), so every ``builtin`` stand-in below that needs to
@@ -73,6 +113,48 @@ class TestRunHook(_IsolatedRegistry):
         calls = []
         run_hook(calls.append, "sa")
         self.assertEqual(calls, ["sa"])
+
+    def test_a_zero_argument_step_can_be_overridden(self):
+        """`handle_hardware_runtime_validation` is the one real step that
+        takes no arguments at all -- `previous` takes none either."""
+        order = []
+
+        @register_resolution_hook("handle_hardware_runtime_validation")
+        def _wraps(previous):
+            order.append("before")
+            previous()
+            order.append("after")
+
+        def handle_hardware_runtime_validation():
+            order.append("builtin")
+
+        run_hook(handle_hardware_runtime_validation)
+        self.assertEqual(order, ["before", "builtin", "after"])
+
+    def test_a_two_argument_step_forwards_both(self):
+        """`handle_gpu_memory_settings(server_args, gpu_mem)` is the one real
+        step that takes more than `server_args` -- `previous` takes the same
+        two positional arguments."""
+        order = []
+
+        @register_resolution_hook("handle_gpu_memory_settings")
+        def _wraps(server_args, gpu_mem, previous):
+            order.append(("before", server_args, gpu_mem))
+            previous(server_args, gpu_mem)
+            order.append(("after", server_args, gpu_mem))
+
+        def handle_gpu_memory_settings(server_args, gpu_mem):
+            order.append(("builtin", server_args, gpu_mem))
+
+        run_hook(handle_gpu_memory_settings, "sa", 16.0)
+        self.assertEqual(
+            order,
+            [
+                ("before", "sa", 16.0),
+                ("builtin", "sa", 16.0),
+                ("after", "sa", 16.0),
+            ],
+        )
 
     def test_an_override_that_calls_previous_wraps_the_builtin(self):
         order = []

--- a/test/registered/unit/server_args/test_resolution_hook_registry.py
+++ b/test/registered/unit/server_args/test_resolution_hook_registry.py
@@ -63,9 +63,15 @@ class TestWhitelist(_IsolatedRegistry):
 
 
 class TestRunHook(_IsolatedRegistry):
+    """``run_hook`` reads the name off the function it is handed
+    (``builtin.__name__``), so every ``builtin`` stand-in below that needs to
+    line up with a registration is a real named function called
+    ``handle_cuda_graph_config`` -- a lambda's ``__name__`` is ``'<lambda>'``
+    and would silently miss the registry entirely."""
+
     def test_nothing_registered_runs_the_builtin_directly(self):
         calls = []
-        run_hook("handle_cuda_graph_config", calls.append, "sa")
+        run_hook(calls.append, "sa")
         self.assertEqual(calls, ["sa"])
 
     def test_an_override_that_calls_previous_wraps_the_builtin(self):
@@ -77,9 +83,10 @@ class TestRunHook(_IsolatedRegistry):
             previous(server_args)
             order.append(("after", server_args))
 
-        run_hook(
-            "handle_cuda_graph_config", lambda sa: order.append(("builtin", sa)), "sa"
-        )
+        def handle_cuda_graph_config(server_args):
+            order.append(("builtin", server_args))
+
+        run_hook(handle_cuda_graph_config, "sa")
         self.assertEqual(
             order,
             [("before", "sa"), ("builtin", "sa"), ("after", "sa")],
@@ -92,7 +99,10 @@ class TestRunHook(_IsolatedRegistry):
         def _replaces(server_args, previous):
             pass  # deliberately does not call `previous`
 
-        run_hook("handle_cuda_graph_config", builtin_ran.append, "sa")
+        def handle_cuda_graph_config(server_args):
+            builtin_ran.append(server_args)
+
+        run_hook(handle_cuda_graph_config, "sa")
         self.assertEqual(builtin_ran, [], "the replaced builtin must not have run")
 
     def test_two_registrants_compose_last_registered_outermost(self):
@@ -110,11 +120,10 @@ class TestRunHook(_IsolatedRegistry):
             previous(server_args)
             order.append("second-after")
 
-        run_hook(
-            "handle_cuda_graph_config",
-            lambda sa: order.append("builtin"),
-            "sa",
-        )
+        def handle_cuda_graph_config(server_args):
+            order.append("builtin")
+
+        run_hook(handle_cuda_graph_config, "sa")
         self.assertEqual(
             order,
             [

--- a/test/registered/unit/server_args/test_resolution_hook_registry.py
+++ b/test/registered/unit/server_args/test_resolution_hook_registry.py
@@ -114,23 +114,6 @@ class TestRunHook(_IsolatedRegistry):
         run_hook(calls.append, "sa")
         self.assertEqual(calls, ["sa"])
 
-    def test_a_zero_argument_step_can_be_overridden(self):
-        """`handle_hardware_runtime_validation` is the one real step that
-        takes no arguments at all -- `previous` takes none either."""
-        order = []
-
-        @register_resolution_hook("handle_hardware_runtime_validation")
-        def _wraps(previous):
-            order.append("before")
-            previous()
-            order.append("after")
-
-        def handle_hardware_runtime_validation():
-            order.append("builtin")
-
-        run_hook(handle_hardware_runtime_validation)
-        self.assertEqual(order, ["before", "builtin", "after"])
-
     def test_an_override_that_calls_previous_wraps_the_builtin(self):
         order = []
 

--- a/test/registered/unit/server_args/test_resolution_hook_registry.py
+++ b/test/registered/unit/server_args/test_resolution_hook_registry.py
@@ -131,31 +131,6 @@ class TestRunHook(_IsolatedRegistry):
         run_hook(handle_hardware_runtime_validation)
         self.assertEqual(order, ["before", "builtin", "after"])
 
-    def test_a_two_argument_step_forwards_both(self):
-        """`handle_gpu_memory_settings(server_args, gpu_mem)` is the one real
-        step that takes more than `server_args` -- `previous` takes the same
-        two positional arguments."""
-        order = []
-
-        @register_resolution_hook("handle_gpu_memory_settings")
-        def _wraps(server_args, gpu_mem, previous):
-            order.append(("before", server_args, gpu_mem))
-            previous(server_args, gpu_mem)
-            order.append(("after", server_args, gpu_mem))
-
-        def handle_gpu_memory_settings(server_args, gpu_mem):
-            order.append(("builtin", server_args, gpu_mem))
-
-        run_hook(handle_gpu_memory_settings, "sa", 16.0)
-        self.assertEqual(
-            order,
-            [
-                ("before", "sa", 16.0),
-                ("builtin", "sa", 16.0),
-                ("after", "sa", 16.0),
-            ],
-        )
-
     def test_an_override_that_calls_previous_wraps_the_builtin(self):
         order = []
 

--- a/test/registered/unit/server_args/test_resolution_hook_registry.py
+++ b/test/registered/unit/server_args/test_resolution_hook_registry.py
@@ -7,6 +7,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
 import ast
+import glob
 import json
 import os
 import shutil
@@ -100,6 +101,46 @@ class TestWhitelistMatchesThePipeline(CustomTestCase):
             "(whitelisted but never called, called but not whitelisted) -- "
             "both should be empty",
         )
+
+    def test_no_bare_calls_to_a_whitelisted_hook_anywhere_in_arg_groups(self):
+        """A step called through `run_hook` at its own pipeline position can
+        still be called *again*, directly, from inside another hook's body --
+        a re-validation after a later declaration, say. That nested call
+        bypasses the registry: an out-of-tree replacement registered for the
+        name wins at the pipeline position but not here, which is exactly the
+        kind of gap `test_every_whitelisted_hook_has_a_call_site` cannot see,
+        since it only looks at `run_hook(...)` call targets, not at every
+        other way a whitelisted name's bare function can be invoked.
+
+        Two real instances of this existed (`validate_prefill_cp_platform`
+        called directly inside `handle_context_parallelism`,
+        `validate_prefill_only_disable_kv_cache_args` called directly inside
+        `handle_model_capability_adjustments`) before both were routed
+        through `run_hook` too. This asserts the count stays at zero rather
+        than grandfathering it, since a bare call to a whitelisted name from
+        inside `arg_groups/` is never correct -- it always means the same
+        function is reachable two ways, only one of which a downstream
+        override can see.
+        """
+        hook_dir = os.path.dirname(pipeline_module.__file__)
+        bypasses = []
+        for path in sorted(
+            glob.glob(os.path.join(hook_dir, "**", "*.py"), recursive=True)
+        ):
+            if os.path.basename(path) in ("pipeline.py", "resolution_hooks.py"):
+                continue
+            tree = ast.parse(open(path).read())
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id in _OVERRIDABLE_HOOKS
+                ):
+                    bypasses.append(
+                        f"{os.path.relpath(path, hook_dir)}:{node.lineno} "
+                        f"calls {node.func.id}(...) directly"
+                    )
+        self.assertEqual(bypasses, [])
 
 
 class TestRunHook(_IsolatedRegistry):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -2153,11 +2153,23 @@ class TestPipelineParallelPrefillCudaGraphPolicy(CustomTestCase):
                 args._cuda_graph_config_locked = {(Phase.PREFILL, "backend")} | (
                     {(Phase.PREFILL, "max_bs")} if max_bs is not None else set()
                 )
-                with patch(
-                    "sglang.srt.arg_groups.memory_hook.use_mla_backend",
-                    return_value=False,
+                with (
+                    patch(
+                        "sglang.srt.arg_groups.memory_hook.use_mla_backend",
+                        return_value=False,
+                    ),
+                    patch(
+                        # `handle_gpu_memory_settings` computes `gpu_mem` itself
+                        # now (`get_device_memory_capacity(cfg.device)`), imported
+                        # function-locally from its source module -- the same
+                        # reason `handle_platform_defaults`'s test patches
+                        # `platforms.current_platform` rather than a name on
+                        # `pipeline`.
+                        "sglang.srt.utils.common.get_device_memory_capacity",
+                        return_value=None,
+                    ),
                 ):
-                    handle_gpu_memory_settings(args, gpu_mem=None)
+                    handle_gpu_memory_settings(args)
                 prefill = resolution_result(args, "cuda_graph_config").prefill
                 self.assertEqual((prefill.max_bs, prefill.bs[-1]), (expected, expected))
 

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -2160,12 +2160,11 @@ class TestPipelineParallelPrefillCudaGraphPolicy(CustomTestCase):
                     ),
                     patch(
                         # `handle_gpu_memory_settings` computes `gpu_mem` itself
-                        # now (`get_device_memory_capacity(cfg.device)`), imported
-                        # function-locally from its source module -- the same
-                        # reason `handle_platform_defaults`'s test patches
-                        # `platforms.current_platform` rather than a name on
-                        # `pipeline`.
-                        "sglang.srt.utils.common.get_device_memory_capacity",
+                        # now (`get_device_memory_capacity(cfg.device)`),
+                        # imported at module scope into `memory_hook` -- patch
+                        # the name where it is looked up, not its origin
+                        # module.
+                        "sglang.srt.arg_groups.memory_hook.get_device_memory_capacity",
                         return_value=None,
                     ),
                 ):

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -1590,6 +1590,57 @@ class TestDerivedWidths(_IsolatedOverrides):
             self.assertEqual(attn_tp_size, widths["attn_tp_size"])
             self.assertEqual(attn_dp_size, widths["attn_dp_size"])
 
+    def test_recomputing_from_published_leaves_matches_the_publish_bag(self):
+        """§6e's precondition for deleting `initialize_model_parallel`'s full
+        stamp: does anything between that stamp and `publish` depend on the
+        stamp giving a *different* answer than the bag already has? It
+        cannot, for any of the three real callers -- every one of them
+        forwards leaves read off this same published bag
+        (`ps.attn_dp_size`/`ps.moe_ep_size`/etc. in `scheduler.py`, or the
+        daemon's own already-published config), through the very functions
+        (`derive_attention_widths`, `derive_parallel_widths`) the bag itself
+        was projected with. This pins that across the widths
+        `test_the_rank_helper_agrees_with_the_stamp` does not vary --
+        moe_ep_size, moe_dp_size, and dcp_size -- using real `publish()`,
+        not bare integers, so a change to either the projection or a
+        caller's forwarding would surface here.
+        """
+        shapes = (
+            dict(tp_size=8),
+            dict(tp_size=8, dp_size=2, enable_dp_attention=True),
+            dict(tp_size=8, ep_size=4, moe_dp_size=2),
+            dict(tp_size=8, dcp_size=8),
+        )
+        for shape in shapes:
+            with self.subTest(shape=shape):
+                reset_context()
+                self.addCleanup(reset_context)
+                publish(ServerArgs(model_path="dummy", **shape), role="test")
+                parallel = get_parallel()
+                published = {
+                    "attn_tp_size": parallel.attn_tp_size,
+                    "attn_dp_size": parallel.attn_dp_size,
+                    "moe_ep_size": parallel.moe_ep_size,
+                    "moe_tp_size": parallel.moe_tp_size,
+                    "dcp_enabled": parallel.dcp_enabled,
+                    "attn_dcp_size": parallel.attn_dcp_size,
+                }
+                # What every real `initialize_model_parallel` caller forwards:
+                # its own already-published leaves, through the same two
+                # functions the bag was projected with.
+                recomputed = derive_parallel_widths(
+                    tp_size=parallel.tp_size,
+                    attn_cp_size=parallel.attn_cp_size,
+                    attn_dp_size=(
+                        parallel.dp_size if parallel.enable_dp_attention else 1
+                    ),
+                    moe_ep_size=parallel.ep_size,
+                    moe_dp_size=parallel.moe_dp_size,
+                    dcp_size=parallel.dcp_size,
+                    dcp_enabled=parallel.dcp_size > 1,
+                )
+                self.assertEqual(published, recomputed)
+
 
 class TestTheDerivedHalfIsDeclared(CustomTestCase):
     """The quotients are declared beside the leaves, in the same class.

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -1391,7 +1391,7 @@ class TestDerivedWidths(_IsolatedOverrides):
         self.addCleanup(
             lambda: (
                 parallel.clear_derived_widths(),
-                parallel.override_permanently("test-restore", **self._saved_derived),
+                parallel.override_permanently(**self._saved_derived),
             )
         )
 
@@ -1447,7 +1447,7 @@ class TestDerivedWidths(_IsolatedOverrides):
         answers where there is none.
         """
         parallel = get_parallel()
-        parallel.override_permanently("test", attn_tp_size=7)
+        parallel.override_permanently(attn_tp_size=7)
         self.addCleanup(parallel.clear_derived_widths)
         with parallel.override(tp_size=8, attn_dp_size=2):
             self.assertEqual(parallel.attn_tp_size, 7)
@@ -1483,13 +1483,13 @@ class TestDerivedWidths(_IsolatedOverrides):
         )
         self.assertNotIn("world_size", widths)
         parallel = get_parallel()
-        parallel.override_permanently("test", attn_tp_size=4)
+        parallel.override_permanently(attn_tp_size=4)
         with patch(f"{_PS}.get_world_size", return_value=9):
             self.assertEqual(parallel.world_size, 9)
 
     def test_a_permanently_overridden_width_is_what_the_reader_answers_with(self):
         parallel = get_parallel()
-        parallel.override_permanently("test", attn_tp_size=4, moe_tp_size=1)
+        parallel.override_permanently(attn_tp_size=4, moe_tp_size=1)
         with patch(
             f"{_PS}.get_attn_tensor_model_parallel_world_size",
             side_effect=AssertionError("the group must not be asked"),
@@ -1498,7 +1498,7 @@ class TestDerivedWidths(_IsolatedOverrides):
 
     def test_a_scoped_override_still_wins_over_the_permanent_one(self):
         parallel = get_parallel()
-        parallel.override_permanently("test", attn_tp_size=4)
+        parallel.override_permanently(attn_tp_size=4)
         with parallel.override(attn_tp_size=1):
             self.assertEqual(parallel.attn_tp_size, 1)
         self.assertEqual(parallel.attn_tp_size, 4)
@@ -1538,7 +1538,7 @@ class TestDerivedWidths(_IsolatedOverrides):
         from sglang.srt.layers import dp_attention
 
         parallel = get_parallel()
-        parallel.override_permanently("test", attn_dp_size=4)
+        parallel.override_permanently(attn_dp_size=4)
         with patch.object(dp_attention, "_ATTN_DP_SIZE", 4):
             with dp_attention.disable_dp_size():
                 self.assertEqual(dp_attention.get_attention_dp_size(), 1)
@@ -1547,10 +1547,10 @@ class TestDerivedWidths(_IsolatedOverrides):
 
     def test_the_permanent_override_is_cleared_and_reset(self):
         parallel = get_parallel()
-        parallel.override_permanently("test", attn_dp_size=2)
+        parallel.override_permanently(attn_dp_size=2)
         self.assertEqual(parallel.attn_dp_size, 2)
         # Elastic scaling overrides again where it updates the live width.
-        parallel.override_permanently("test", attn_dp_size=4)
+        parallel.override_permanently(attn_dp_size=4)
         self.assertEqual(parallel.attn_dp_size, 4)
         parallel.clear_derived_widths()
         with parallel.override(tp_size=8, attn_dp_size=1):
@@ -1564,7 +1564,7 @@ class TestDerivedWidths(_IsolatedOverrides):
         topology.
         """
         parallel = get_parallel()
-        parallel.override_permanently("test", attn_tp_size=4)
+        parallel.override_permanently(attn_tp_size=4)
         self.assertEqual(parallel.attn_tp_size, 4)
         reset_context()
         self.addCleanup(reset_context)

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -1375,7 +1375,8 @@ class TestParallelLeafReads(_IsolatedServerArgs):
 
 
 class TestDerivedWidths(_IsolatedOverrides):
-    """The widths no flag sets are computed from the leaves and stamped.
+    """The widths no flag sets are computed from the leaves and permanently
+    overridable.
 
     `attn_tp_size` and its siblings used to be read back off the group
     coordinator that was built from them, which made the answer depend on
@@ -1390,7 +1391,7 @@ class TestDerivedWidths(_IsolatedOverrides):
         self.addCleanup(
             lambda: (
                 parallel.clear_derived_widths(),
-                parallel.stamp_derived_widths(**self._saved_derived),
+                parallel.override_permanently("test-restore", **self._saved_derived),
             )
         )
 
@@ -1439,13 +1440,14 @@ class TestDerivedWidths(_IsolatedOverrides):
             get_parallel().attn_tp_size
         self.assertIn("not available", str(caught.exception))
 
-    def test_a_stamp_and_a_live_group_both_win_over_the_leaves(self):
-        """Order is stamp, then live group, then the leaves. Where a group
-        exists it is the truth -- elastic scale-up moves the group without
-        restamping -- so the leaf derivation only answers where there is none.
+    def test_a_permanent_override_and_a_live_group_both_win_over_the_leaves(self):
+        """Order is permanent override, then live group, then the leaves.
+        Where a group exists it is the truth -- elastic scale-up moves the
+        group without a fresh override -- so the leaf derivation only
+        answers where there is none.
         """
         parallel = get_parallel()
-        parallel.stamp_derived_widths(attn_tp_size=7)
+        parallel.override_permanently("test", attn_tp_size=7)
         self.addCleanup(parallel.clear_derived_widths)
         with parallel.override(tp_size=8, attn_dp_size=2):
             self.assertEqual(parallel.attn_tp_size, 7)
@@ -1464,9 +1466,9 @@ class TestDerivedWidths(_IsolatedOverrides):
         self.assertEqual(widths["moe_tp_size"], 8 // 4 // 2)
         self.assertEqual(widths["attn_dcp_size"], 1)
 
-    def test_the_world_size_is_not_stamped(self):
+    def test_the_world_size_is_not_permanently_overridden(self):
         """It is not a quotient, and the live getter is right at every moment.
-        A stamp taken when the groups are built would answer with the launch
+        A value fixed when the groups are built would answer with the launch
         count after `try_admit_scale_ranks` expands WORLD, and with the joining
         cohort's own width on a scale-joiner, which lays its groups out at
         `tp * pp` while WORLD spans `ep_join_rank_offset + tp * pp`."""
@@ -1481,31 +1483,30 @@ class TestDerivedWidths(_IsolatedOverrides):
         )
         self.assertNotIn("world_size", widths)
         parallel = get_parallel()
-        parallel.stamp_derived_widths(attn_tp_size=4)
+        parallel.override_permanently("test", attn_tp_size=4)
         with patch(f"{_PS}.get_world_size", return_value=9):
             self.assertEqual(parallel.world_size, 9)
 
-    def test_a_stamped_width_is_what_the_reader_answers_with(self):
+    def test_a_permanently_overridden_width_is_what_the_reader_answers_with(self):
         parallel = get_parallel()
-        parallel.stamp_derived_widths(attn_tp_size=4, moe_tp_size=1)
+        parallel.override_permanently("test", attn_tp_size=4, moe_tp_size=1)
         with patch(
             f"{_PS}.get_attn_tensor_model_parallel_world_size",
             side_effect=AssertionError("the group must not be asked"),
         ):
             self.assertEqual(parallel.attn_tp_size, 4)
 
-    def test_an_override_still_wins_over_the_stamp(self):
+    def test_a_scoped_override_still_wins_over_the_permanent_one(self):
         parallel = get_parallel()
-        parallel.stamp_derived_widths(attn_tp_size=4)
+        parallel.override_permanently("test", attn_tp_size=4)
         with parallel.override(attn_tp_size=1):
             self.assertEqual(parallel.attn_tp_size, 1)
         self.assertEqual(parallel.attn_tp_size, 4)
 
     def test_the_group_is_never_consulted(self):
-        """There is no third source. A quotient comes from an override, a stamp
-        or the published leaf -- never from a group coordinator, which could
-        only ever agree, since `initialize_model_parallel` stamps as its last
-        statement."""
+        """There is no third source. A quotient comes from a scoped override, a
+        permanent override, or the published leaf -- never from a group
+        coordinator."""
         reset_context()
         self.addCleanup(reset_context)
         with patch(
@@ -1528,50 +1529,51 @@ class TestDerivedWidths(_IsolatedOverrides):
             with self.assertRaisesRegex(RuntimeError, r"derived parallel width"):
                 get_parallel().attn_tp_size
 
-    def test_a_temporary_disable_beats_the_stamp(self):
+    def test_a_temporary_disable_beats_the_permanent_override(self):
         """`disable_dp_size()` runs a draft scope without DP attention. It moves
         the module global the legacy getter reads, so it has to move the derived
-        width too -- the stamp wins over the live group, and a scope that left
-        it alone would answer with the target model's width for its duration."""
+        width too -- the scoped override wins over the permanent one, and a
+        scope that left it alone would answer with the target model's width
+        for its duration."""
         from sglang.srt.layers import dp_attention
 
         parallel = get_parallel()
-        parallel.stamp_derived_widths(attn_dp_size=4)
+        parallel.override_permanently("test", attn_dp_size=4)
         with patch.object(dp_attention, "_ATTN_DP_SIZE", 4):
             with dp_attention.disable_dp_size():
                 self.assertEqual(dp_attention.get_attention_dp_size(), 1)
                 self.assertEqual(parallel.attn_dp_size, 1)
             self.assertEqual(parallel.attn_dp_size, 4)
 
-    def test_the_stamp_is_cleared_and_restamped(self):
+    def test_the_permanent_override_is_cleared_and_reset(self):
         parallel = get_parallel()
-        parallel.stamp_derived_widths(attn_dp_size=2)
+        parallel.override_permanently("test", attn_dp_size=2)
         self.assertEqual(parallel.attn_dp_size, 2)
-        # Elastic scaling restamps where it updates the live width.
-        parallel.stamp_derived_widths(attn_dp_size=4)
+        # Elastic scaling overrides again where it updates the live width.
+        parallel.override_permanently("test", attn_dp_size=4)
         self.assertEqual(parallel.attn_dp_size, 4)
         parallel.clear_derived_widths()
         with parallel.override(tp_size=8, attn_dp_size=1):
             self.assertEqual(parallel.attn_dp_size, 1)
 
-    def test_reset_context_drops_the_stamp(self):
-        """The stamp belongs to the lifecycle that made it.
+    def test_reset_context_drops_the_permanent_override(self):
+        """The permanent override belongs to the lifecycle that made it.
 
-        `_derived_width` prefers the stamp over the published leaf, so a stamp
-        that outlived `reset_context()` would let the next test read the
-        previous topology.
+        `_derived_width` prefers it over the published leaf, so one that
+        outlived `reset_context()` would let the next test read the previous
+        topology.
         """
         parallel = get_parallel()
-        parallel.stamp_derived_widths(attn_tp_size=4)
+        parallel.override_permanently("test", attn_tp_size=4)
         self.assertEqual(parallel.attn_tp_size, 4)
         reset_context()
         self.addCleanup(reset_context)
         publish(ServerArgs(model_path="dummy", tp_size=1), role="test")
         self.assertEqual(get_parallel().attn_tp_size, 1)
 
-    def test_the_rank_helper_agrees_with_the_stamp(self):
+    def test_the_rank_helper_agrees_with_the_override(self):
         """`compute_dp_attention_world_info` keeps the ranks and takes the
-        widths from the same derivation the stamp uses."""
+        widths from the same derivation `override_permanently`'s callers use."""
         from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
 
         for tp_size, dp_size, attn_cp_size in ((8, 2, 1), (8, 2, 2), (16, 4, 2)):
@@ -1591,7 +1593,7 @@ class TestDerivedWidths(_IsolatedOverrides):
             self.assertEqual(attn_dp_size, widths["attn_dp_size"])
 
     def test_recomputing_from_published_leaves_matches_the_publish_bag(self):
-        """`initialize_model_parallel` no longer stamps -- see
+        """`initialize_model_parallel` no longer overrides anything -- see
         `test_initialize_model_parallel_no_longer_touches_the_bag` below --
         which makes this the load-bearing half of 16-field-registry-design.md
         §6e: every real caller must forward leaves that already match its own
@@ -1601,8 +1603,9 @@ class TestDerivedWidths(_IsolatedOverrides):
         pins that the formula they'd recompute from those leaves
         (`derive_attention_widths`, `derive_parallel_widths`, the same ones
         `publish` itself used) agrees with what's already in the bag, across
-        the widths `test_the_rank_helper_agrees_with_the_stamp` does not vary
-        -- moe_ep_size, moe_dp_size, and dcp_size -- using real `publish()`.
+        the widths `test_the_rank_helper_agrees_with_the_override` does not
+        vary -- moe_ep_size, moe_dp_size, and dcp_size -- using real
+        `publish()`.
 
         A caller that does NOT keep the two in sync is a bug in that caller,
         not something this framework silently corrects: two real ones existed
@@ -1610,7 +1613,7 @@ class TestDerivedWidths(_IsolatedOverrides):
         `test/manual/ep/test_flashinfer_dispatcher.py`, both publishing a
         placeholder config and then building real groups at a width it never
         reflected) and were fixed by publishing the actual width instead of
-        relying on a stamp to paper over the mismatch.
+        relying on a correction to paper over the mismatch.
         """
         shapes = (
             dict(tp_size=8),
@@ -1650,15 +1653,13 @@ class TestDerivedWidths(_IsolatedOverrides):
 
     def test_initialize_model_parallel_no_longer_touches_the_bag(self):
         """§6e, landed: `initialize_model_parallel` used to recompute and
-        stamp the six derived widths onto `get_parallel()` after building its
-        groups; that stamp is gone. Publish a placeholder config (tp_size
-        defaults to 1), then build real groups at a different width the same
-        way `test_initialize_model_parallel_corrects_a_stale_publish` used
-        to (that test named the OLD, now-removed behavior; this one names
-        the current, intentional one) -- the published leaf must now stay
-        exactly what it was, because nothing corrects it. This is the
-        behavior a caller relies on being told about, loudly, the first time
-        it publishes and builds inconsistently -- see
+        permanently override the six derived widths on `get_parallel()`
+        after building its groups; that call is gone. Publish a placeholder
+        config (tp_size defaults to 1), then build real groups at a
+        different width -- the published leaf must now stay exactly what it
+        was, because nothing corrects it. This is the behavior a caller
+        relies on being told about, loudly, the first time it publishes and
+        builds inconsistently -- see
         `test_recomputing_from_published_leaves_matches_the_publish_bag`
         for why every real caller must not do that.
         """

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -1591,19 +1591,26 @@ class TestDerivedWidths(_IsolatedOverrides):
             self.assertEqual(attn_dp_size, widths["attn_dp_size"])
 
     def test_recomputing_from_published_leaves_matches_the_publish_bag(self):
-        """§6e's precondition for deleting `initialize_model_parallel`'s full
-        stamp: does anything between that stamp and `publish` depend on the
-        stamp giving a *different* answer than the bag already has? It
-        cannot, for any of the three real callers -- every one of them
-        forwards leaves read off this same published bag
-        (`ps.attn_dp_size`/`ps.moe_ep_size`/etc. in `scheduler.py`, or the
-        daemon's own already-published config), through the very functions
-        (`derive_attention_widths`, `derive_parallel_widths`) the bag itself
-        was projected with. This pins that across the widths
+        """When a caller forwards leaves read off its own already-published
+        bag into `initialize_model_parallel` -- `scheduler.py`'s
+        `ps.attn_dp_size`/`ps.moe_ep_size`/etc, or the weight-cache daemon's
+        own already-published config -- the stamp it produces cannot differ
+        from what `publish` already put in the bag: same formula
+        (`derive_attention_widths`, `derive_parallel_widths`), same inputs.
+        This pins that agreement across the widths
         `test_the_rank_helper_agrees_with_the_stamp` does not vary --
-        moe_ep_size, moe_dp_size, and dcp_size -- using real `publish()`,
-        not bare integers, so a change to either the projection or a
-        caller's forwarding would surface here.
+        moe_ep_size, moe_dp_size, and dcp_size -- using real `publish()`.
+
+        This is *not* a general argument that the stamp is redundant and
+        safe to delete -- 16-field-registry-design.md §6e floated exactly
+        that, and it does not hold in general: see
+        `test_initialize_model_parallel_corrects_a_stale_publish` right
+        below, where a caller (this is the real shape of
+        `test/registered/eplb/test_lplb_distributed.py`'s harness, checked
+        on real 2-GPU hardware) publishes a placeholder config and then
+        builds real groups at a width the published bag never reflects. The
+        stamp is what makes `get_parallel().attn_tp_size` answer with the
+        width actually built in that case, not this one.
         """
         shapes = (
             dict(tp_size=8),
@@ -1640,6 +1647,68 @@ class TestDerivedWidths(_IsolatedOverrides):
                     dcp_enabled=parallel.dcp_size > 1,
                 )
                 self.assertEqual(published, recomputed)
+
+    def test_initialize_model_parallel_corrects_a_stale_publish(self):
+        """The counter-example to the test above, and to §6e's "delete the
+        full stamp" idea: publish a placeholder config (tp_size defaults to
+        1), then build real distributed groups at a width the published bag
+        never reflects -- exactly what
+        `test/registered/eplb/test_lplb_distributed.py` does, publishing
+        `ServerArgs(model_path="dummy")` and then calling
+        `initialize_model_parallel(tensor_model_parallel_size=world_size,
+        expert_model_parallel_size=world_size)`. Confirmed on real 2-GPU
+        hardware: without the stamp, `get_parallel().attn_tp_size` answers
+        1 (the stale published leaf) after building width-2 groups; with
+        it, 2 (what was actually built). Mocked here so the same guard
+        runs without GPUs.
+        """
+        from unittest.mock import Mock
+
+        from sglang.srt.distributed import parallel_state
+
+        reset_context()
+        self.addCleanup(reset_context)
+        publish(ServerArgs(model_path="dummy"), role="test")
+        self.assertEqual(get_parallel().attn_tp_size, 1)
+        self.assertEqual(get_parallel().moe_ep_size, 1)
+
+        world_size = 8
+        with (
+            patch.object(parallel_state, "_WORLD", None),
+            patch.object(parallel_state, "_TP", None),
+            patch.object(parallel_state, "_DCP", None),
+            patch.object(parallel_state, "_ATTN_CP", None),
+            patch.object(parallel_state, "_ATTN_TP", None),
+            patch.object(parallel_state, "_MOE_DP", None),
+            patch.object(parallel_state, "_MOE_EP", None),
+            patch.object(parallel_state, "_MOE_TP", None),
+            patch.object(parallel_state, "_PP", None),
+            patch.object(parallel_state, "_SELF_PP", None),
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_world_size", return_value=world_size),
+            patch("torch.distributed.get_rank", return_value=0),
+            patch("torch.distributed.get_backend", return_value="nccl"),
+            patch.object(
+                parallel_state,
+                "init_model_parallel_group",
+                return_value=Mock(device_group=Mock()),
+            ),
+            patch.object(parallel_state, "get_world_group") as mock_world_group,
+        ):
+            mock_world_group.return_value = Mock(device_group=Mock(), local_rank=0)
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size=world_size,
+                expert_model_parallel_size=world_size,
+            )
+        self.addCleanup(parallel_state.destroy_model_parallel)
+
+        self.assertEqual(
+            get_parallel().attn_tp_size,
+            world_size,
+            "the stamp should have corrected the stale published leaf to "
+            "the width actually built",
+        )
+        self.assertEqual(get_parallel().moe_ep_size, world_size)
 
 
 class TestTheDerivedHalfIsDeclared(CustomTestCase):

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -1591,26 +1591,26 @@ class TestDerivedWidths(_IsolatedOverrides):
             self.assertEqual(attn_dp_size, widths["attn_dp_size"])
 
     def test_recomputing_from_published_leaves_matches_the_publish_bag(self):
-        """When a caller forwards leaves read off its own already-published
-        bag into `initialize_model_parallel` -- `scheduler.py`'s
-        `ps.attn_dp_size`/`ps.moe_ep_size`/etc, or the weight-cache daemon's
-        own already-published config -- the stamp it produces cannot differ
-        from what `publish` already put in the bag: same formula
-        (`derive_attention_widths`, `derive_parallel_widths`), same inputs.
-        This pins that agreement across the widths
-        `test_the_rank_helper_agrees_with_the_stamp` does not vary --
-        moe_ep_size, moe_dp_size, and dcp_size -- using real `publish()`.
+        """`initialize_model_parallel` no longer stamps -- see
+        `test_initialize_model_parallel_no_longer_touches_the_bag` below --
+        which makes this the load-bearing half of 16-field-registry-design.md
+        §6e: every real caller must forward leaves that already match its own
+        published config, because nothing corrects a mismatch anymore.
+        `scheduler.py`'s `ps.attn_dp_size`/`ps.moe_ep_size`/etc, and the
+        weight-cache daemon's own already-published config, both do -- this
+        pins that the formula they'd recompute from those leaves
+        (`derive_attention_widths`, `derive_parallel_widths`, the same ones
+        `publish` itself used) agrees with what's already in the bag, across
+        the widths `test_the_rank_helper_agrees_with_the_stamp` does not vary
+        -- moe_ep_size, moe_dp_size, and dcp_size -- using real `publish()`.
 
-        This is *not* a general argument that the stamp is redundant and
-        safe to delete -- 16-field-registry-design.md §6e floated exactly
-        that, and it does not hold in general: see
-        `test_initialize_model_parallel_corrects_a_stale_publish` right
-        below, where a caller (this is the real shape of
-        `test/registered/eplb/test_lplb_distributed.py`'s harness, checked
-        on real 2-GPU hardware) publishes a placeholder config and then
-        builds real groups at a width the published bag never reflects. The
-        stamp is what makes `get_parallel().attn_tp_size` answer with the
-        width actually built in that case, not this one.
+        A caller that does NOT keep the two in sync is a bug in that caller,
+        not something this framework silently corrects: two real ones existed
+        (`test/registered/eplb/test_lplb_distributed.py` and
+        `test/manual/ep/test_flashinfer_dispatcher.py`, both publishing a
+        placeholder config and then building real groups at a width it never
+        reflected) and were fixed by publishing the actual width instead of
+        relying on a stamp to paper over the mismatch.
         """
         shapes = (
             dict(tp_size=8),
@@ -1648,19 +1648,19 @@ class TestDerivedWidths(_IsolatedOverrides):
                 )
                 self.assertEqual(published, recomputed)
 
-    def test_initialize_model_parallel_corrects_a_stale_publish(self):
-        """The counter-example to the test above, and to §6e's "delete the
-        full stamp" idea: publish a placeholder config (tp_size defaults to
-        1), then build real distributed groups at a width the published bag
-        never reflects -- exactly what
-        `test/registered/eplb/test_lplb_distributed.py` does, publishing
-        `ServerArgs(model_path="dummy")` and then calling
-        `initialize_model_parallel(tensor_model_parallel_size=world_size,
-        expert_model_parallel_size=world_size)`. Confirmed on real 2-GPU
-        hardware: without the stamp, `get_parallel().attn_tp_size` answers
-        1 (the stale published leaf) after building width-2 groups; with
-        it, 2 (what was actually built). Mocked here so the same guard
-        runs without GPUs.
+    def test_initialize_model_parallel_no_longer_touches_the_bag(self):
+        """§6e, landed: `initialize_model_parallel` used to recompute and
+        stamp the six derived widths onto `get_parallel()` after building its
+        groups; that stamp is gone. Publish a placeholder config (tp_size
+        defaults to 1), then build real groups at a different width the same
+        way `test_initialize_model_parallel_corrects_a_stale_publish` used
+        to (that test named the OLD, now-removed behavior; this one names
+        the current, intentional one) -- the published leaf must now stay
+        exactly what it was, because nothing corrects it. This is the
+        behavior a caller relies on being told about, loudly, the first time
+        it publishes and builds inconsistently -- see
+        `test_recomputing_from_published_leaves_matches_the_publish_bag`
+        for why every real caller must not do that.
         """
         from unittest.mock import Mock
 
@@ -1704,11 +1704,12 @@ class TestDerivedWidths(_IsolatedOverrides):
 
         self.assertEqual(
             get_parallel().attn_tp_size,
-            world_size,
-            "the stamp should have corrected the stale published leaf to "
-            "the width actually built",
+            1,
+            "initialize_model_parallel must not touch the published leaf -- "
+            "a caller that needs it corrected must publish a config that "
+            "already matches the width it is about to build",
         )
-        self.assertEqual(get_parallel().moe_ep_size, world_size)
+        self.assertEqual(get_parallel().moe_ep_size, 1)
 
 
 class TestTheDerivedHalfIsDeclared(CustomTestCase):


### PR DESCRIPTION
Stacked on #39137.

## Summary

`initialize_model_parallel` recomputes and stamps six parallel widths onto
`get_parallel()` (`attn_tp_size`, `attn_dp_size`, `moe_ep_size`,
`moe_tp_size`, `dcp_enabled`, `attn_dcp_size`) after building its groups. For
a normal engine these are the same values `publish()` already projected
from the resolved config -- so the stamp is redundant there, *if* every
caller's published config genuinely matches the width it builds.

**First attempt** (this PR originally): traced the three production call
sites of `initialize_model_parallel` (the scheduler/`ModelRunner` path,
`weight_cache/daemon.py`, `MMEncoder.__init__`), confirmed all three keep
publish and build width in sync, and deleted the stamp on that basis.

**That was wrong.** Real 2-GPU hardware found a live counter-example:
`test/registered/eplb/test_lplb_distributed.py` publishes a placeholder
`ServerArgs(model_path="dummy")` (`tp_size` defaults to 1) and then calls
`initialize_model_parallel(tensor_model_parallel_size=world_size, ...)`
directly, building real groups at width 2 while the published bag still
says 1. Confirmed on real hardware both ways: with the stamp,
`get_parallel().attn_tp_size` reads 2 (correct) after init; without it,
reads 1 (stale). The fix generalized "these three call sites agree" into
"the stamp is redundant everywhere," which doesn't hold -- nothing forces
every caller to keep the two in sync.

**Fixed for real**: audited every file in the tree that calls
`initialize_model_parallel` directly (~30, across `test/registered/`,
`test/manual/`, `multimodal_gen/test/`, benchmarks, examples), checking
each one's published config against the width it actually builds --
verified on real GPU hardware rather than trusting "the test passed"
(`test_lplb_distributed.py`'s own assertions never read the mismatched
leaf, which is exactly how it stayed broken under a passing test the first
time). Found exactly two real divergences, both fixed by publishing the
correct width instead of relying on the stamp to paper over it:
`test_lplb_distributed.py` and `test/manual/ep/test_flashinfer_dispatcher.py`
(the latter needed reordering too -- `init_distributed_environment` reads
no published config, so it can run before `ServerArgs` is even
constructed, letting the width be correct from a single `publish()` call
instead of publishing a placeholder and republishing). Everything else
checked out clean (production call sites; trivial `tp=1` cases; a few
tests that never publish at all, so they'd raise loudly rather than read a
stale value; one pre-existing, unrelated failure in a manual multimodal_gen
test, reproduced identically on the pre-change tree via a worktree).

Deletes the stamp call in `initialize_model_parallel` for real.

**Also in this stack**: `ParallelContext.stamp_derived_widths(**widths)` is
renamed to `override_permanently(**widths)` for the two call sites that
remain genuinely load-bearing after the deletion above --
`dp_attention.py`'s elastic `attn_dp_size` correction (a value that changes
at runtime, well after publish, for an elastic scale-up) and
`multimodal_gen`'s borrowed-TP-group sync (lending a wider group to shared
`srt` layers with no `srt` config to publish against) -- because
`stamp`/`override` were two unrelated-sounding names for the same kind of
correction, which got more confusing once "stamp" started meaning "the
thing that got deleted" as well. Confirmed the two can't simply share the
scoped `override(**kwargs)` on the same class (name collision, and scoped
semantics don't fit a permanent correction); confirmed they can't route
through the namespace-wide permanent `override(source, **fields)` either,
since that requires a published config and the `multimodal_gen` case
explicitly has none.

## Test plan

- [x] `test/registered/unit/test_runtime_context.py` (103 tests) and
  `test/registered/unit/distributed/test_parallel_state.py` (calls the real
  `initialize_model_parallel` with mocked distributed init) -- both green.
- [x] Real 2-GPU hardware (H200): `test_lplb_distributed.py` passes with
  the stamp deleted and the fix applied; a standalone probe confirms
  `get_parallel().attn_tp_size`/`moe_ep_size` read the actual built width,
  not a stale default.
- [x] `test/manual/ep/test_flashinfer_dispatcher.py` run via
  `torchrun --nproc_per_node=4` on real hardware: the reordered `setUpClass`
  (publish, MoE config init, `initialize_model_parallel`) completes cleanly
  for all four ranks; a later failure inside the dispatch test itself is
  pre-existing (reproduced identically on the pre-change tree via a
  worktree), unrelated to this change.
- [x] CPU-mocked regression guard added for the exact counter-example above
  (`test_initialize_model_parallel_no_longer_touches_the_bag`), verified by
  mutation test: re-adding the stamp made it fail with the same mismatch
  found on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34722664452](https://github.com/sgl-project/sglang/actions/runs/34722664452)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #34722664312](https://github.com/sgl-project/sglang/actions/runs/34722664312)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #34722664387](https://github.com/sgl-project/sglang/actions/runs/34722664387)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->