### PR TITLE
[Kernel] Reject unsupported FlashAttention versions

### DIFF
--- a/python/sglang/kernels/aot/python/sgl_kernel/flash_attn.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/flash_attn.py
@@ -152,6 +152,7 @@ def flash_attn_with_kvcache(
         return_softmax_lse: bool. Whether to return the logsumexp of the attention scores.
         score_mod [optional]: A callable that takes the attention scores and applies a modification.
         aux_tensors [optional]: Some score_mods will want to read from global aux_tensors. This is how we thread them through to the inner kernel.
+        ver: FlashAttention implementation version. Only 3 is supported by this module.
 
     Return:
         out: (batch_size, seqlen, nheads, headdim).
@@ -159,6 +160,9 @@ def flash_attn_with_kvcache(
             logsumexp of each row of the matrix QK^T * scaling (e.g., log of the softmax
             normalization factor).
     """
+
+    if ver != 3:
+        raise ValueError(f"sgl_kernel.flash_attn only supports ver=3, got {ver!r}")
 
     if v_cache is None:
         raise ValueError("v_cache must be provided")
@@ -302,6 +306,10 @@ def flash_attn_varlen_func(
     ver=3,
     out=None,
 ):
+    """Variable-length FlashAttention-3; other ``ver`` values are unsupported."""
+
+    if ver != 3:
+        raise ValueError(f"sgl_kernel.flash_attn only supports ver=3, got {ver!r}")
 
     if not is_fa3_supported():
         raise NotImplementedError(

--- a/test/registered/unit/kernels/test_flash_attention_version.py
+++ b/test/registered/unit/kernels/test_flash_attention_version.py
@@ -1,0 +1,75 @@
+"""Validate the FA3 wrapper contract without loading CUDA extensions."""
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class TestFlashAttentionVersion(CustomTestCase):
+    def setUp(self):
+        package = types.ModuleType("sgl_kernel")
+        source_dir = (
+            Path(__file__).resolve().parents[4]
+            / "python/sglang/kernels/aot/python/sgl_kernel"
+        )
+        package.__path__ = [str(source_dir)]
+        native = types.ModuleType("sgl_kernel.flash_ops")
+        imports = patch.dict(
+            sys.modules, {"sgl_kernel": package, "sgl_kernel.flash_ops": native}
+        )
+        imports.start()
+        self.addCleanup(imports.stop)
+        spec = importlib.util.spec_from_file_location(
+            "_flash_attention_version_test", source_dir / "flash_attn.py"
+        )
+        self.module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.module)
+
+    def test_unsupported_versions_fail_before_tensor_or_device_access(self):
+        for version in (0, 2, 4):
+            for name, args in (
+                ("flash_attn_with_kvcache", (None, None, None)),
+                ("flash_attn_varlen_func", (None, None, None, None, None)),
+            ):
+                with self.subTest(version=version, function=name):
+                    with self.assertRaisesRegex(ValueError, "only supports ver=3"):
+                        getattr(self.module, name)(*args, ver=version)
+
+    def test_default_and_explicit_fa3_dispatch(self):
+        q = torch.zeros(1, 1, 2, 64)
+        kv = torch.zeros(1, 8, 2, 64)
+        expected = torch.ones_like(q)
+        for kwargs in ({}, {"ver": 3}):
+            for name, args, extra in (
+                ("flash_attn_with_kvcache", (q, kv, kv), {}),
+                (
+                    "flash_attn_varlen_func",
+                    (q[0], kv[0], kv[0], None, None),
+                    {"max_seqlen_q": 1, "max_seqlen_k": 8},
+                ),
+            ):
+                with self.subTest(function=name, kwargs=kwargs):
+                    with (
+                        patch.object(
+                            self.module, "is_fa3_supported", return_value=True
+                        ),
+                        patch.object(torch.ops.sgl_kernel, "fwd", create=True) as fwd,
+                    ):
+                        fwd.default.return_value = (expected, None)
+                        result = getattr(self.module, name)(*args, **extra, **kwargs)
+                        self.assertIs(result, expected)
+                        fwd.default.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The `sgl_kernel.flash_attn` wrappers accept `ver=2` or `ver=4` but always dispatch through the FA3 `sgl_kernel::fwd` operation. Downstream callers can therefore believe they selected another implementation while executing FA3.

Reject unsupported versions with a clear `ValueError` before tensor processing or device checks. Keep the default and explicit `ver=3` calls unchanged, and document the supported version.

Related to #38980. The SM89 shared-memory launch failure and the local KV-coordinate issue are addressed in [sgl-flash-attn#50](https://github.com/sgl-project/sgl-flash-attn/pull/50).

## Validation

- Registered CPU tests import the actual Python wrapper with only its native-extension import stubbed. Unsupported versions `0`, `2`, and `4` are rejected by both entry points before tensor/device access; default and explicit `3` retain dispatch and return values.
- `PYTHONPATH=python python -m pytest test/registered/unit/kernels/test_flash_attention_version.py -q`: 2 passed, 10 subtests passed.
- The CI-style `python test/registered/unit/kernels/test_flash_attention_version.py -f` entry point passes.
- On an RTX 4090D (SM89), PyTorch 2.11.0+cu130 and the installed `sglang-kernel` 0.4.5 binaries: the changed source wrapper rejects all six invalid-version cases, and four real CUDA calls (both APIs, default/explicit `3`) match a PyTorch attention reference.
- Applicable changed-file pre-commit hooks and `git diff --check` pass.

No kernel is rebuilt or modified by this PR. Runtime version validation is a Python wrapper check before generation.
