### PR TITLE
fix(server): preserve SIGQUIT cleanup with multiple tokenizer workers

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -111,6 +111,7 @@ from sglang.srt.entrypoints.openai.serving_transcription import (
     OpenAIServingTranscription,
 )
 from sglang.srt.entrypoints.request_headers import apply_header_overrides
+from sglang.srt.entrypoints.uvicorn_utils import run_uvicorn_with_sigquit_handler
 from sglang.srt.entrypoints.warmup import execute_warmups
 from sglang.srt.environ import envs
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
@@ -2733,7 +2734,7 @@ def _setup_and_run_http_server(
                     ssl_keyfile_password=get_serving().ssl_keyfile_password,
                 )
             else:
-                uvicorn.run(
+                run_uvicorn_with_sigquit_handler(
                     "sglang.srt.entrypoints.http_server:app",
                     host=get_serving().host,
                     port=get_serving().port,

--- a/python/sglang/srt/entrypoints/uvicorn_utils.py
+++ b/python/sglang/srt/entrypoints/uvicorn_utils.py
@@ -1,0 +1,18 @@
+import signal
+
+import uvicorn
+from uvicorn.supervisors import multiprocess
+
+
+def run_uvicorn_with_sigquit_handler(*args, **kwargs) -> None:
+    """Keep SGLang's crash handler active in the multi-tokenizer parent."""
+    original_signals = multiprocess.SIGNALS
+    try:
+        # Uvicorn otherwise captures SIGQUIT without invoking SGLang's cleanup.
+        # Exclude it before the supervisor registers its signal handlers.
+        multiprocess.SIGNALS = {
+            sig: name for sig, name in original_signals.items() if sig != signal.SIGQUIT
+        }
+        uvicorn.run(*args, **kwargs)
+    finally:
+        multiprocess.SIGNALS = original_signals

--- a/test/registered/unit/utils/test_subprocess_watchdog.py
+++ b/test/registered/unit/utils/test_subprocess_watchdog.py
@@ -20,6 +20,9 @@ import threading
 import time
 import unittest.mock
 
+from uvicorn.supervisors import multiprocess
+
+from sglang.srt.entrypoints.uvicorn_utils import run_uvicorn_with_sigquit_handler
 from sglang.srt.utils.watchdog import SubprocessWatchdog
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -133,6 +136,42 @@ class TestSubprocessWatchdog(CustomTestCase):
             self.sigquit_triggered.is_set(),
             "SIGQUIT should not be triggered for normal exit (exitcode=0)",
         )
+
+    def test_uvicorn_preserves_sigquit_handler(self):
+        for sig in multiprocess.SIGNALS:
+            self.addCleanup(signal.signal, sig, signal.getsignal(sig))
+
+        # This regression needs real signal delivery through Uvicorn's handlers.
+        self._patcher.stop()
+        received_signals = []
+        signal.signal(
+            signal.SIGQUIT, lambda signum, frame: received_signals.append(signum)
+        )
+        proc = self._spawn(healthy_worker)
+
+        def run_supervisor(supervisor):
+            self._watch(proc)
+            proc.kill()
+            deadline = time.monotonic() + 5
+            while not received_signals and time.monotonic() < deadline:
+                supervisor.handle_signals()
+                time.sleep(0.01)
+            self.assertEqual(
+                received_signals,
+                [signal.SIGQUIT],
+                "Backend death must reach the original SIGQUIT handler",
+            )
+
+        with (
+            unittest.mock.patch.object(
+                multiprocess.Multiprocess,
+                "run",
+                autospec=True,
+                side_effect=run_supervisor,
+            ),
+            unittest.mock.patch("uvicorn.Config.bind_socket"),
+        ):
+            run_uvicorn_with_sigquit_handler("unused:app", workers=2, log_config=None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

With `--tokenizer-worker-num > 1`, Uvicorn's multiprocess supervisor overwrites SGLang's `SIGQUIT` handler and queues the signal without invoking SGLang's cleanup. A scheduler exception, abnormal backend exit, or hard watchdog timeout can therefore leave the parent and remaining inference processes running after requesting process-tree cleanup.

Preserve SGLang's existing fatal-error handler so that these failures terminate the inference process tree.

## Modifications

- Exclude `SIGQUIT` from Uvicorn's signal registrations before the multiprocess supervisor initializes, preserving the existing SGLang or custom handler.
- Scope this change to `uvicorn.run` and restore Uvicorn's internal `SIGNALS` mapping in `finally`.
- Add one regression to the existing `test_subprocess_watchdog.py`: after Uvicorn initializes its supervisor, killing a backend must still deliver the watchdog's `SIGQUIT` to the original handler.

## Accuracy Tests

Model accuracy evaluation is not applicable: no model forward, kernel, sampling, or output-format code changes.

All **7 tests** in `test_subprocess_watchdog.py` passed: the 6 existing tests and 1 new regression. The new regression fails when using the original `uvicorn.run` instead of the wrapper.

```bash
python test/registered/unit/utils/test_subprocess_watchdog.py -f
```

The regression uses a real subprocess and POSIX signal delivery; HTTP worker startup and socket binding are stubbed. Local validation used macOS/Python 3.14 with import-time Torch compile/MPS shims. GPU inference and deployment-platform restart behavior were not exercised.

## Speed Tests and Profiling

Not applicable: the wrapper runs during HTTP supervisor setup and does not modify inference request or model execution paths.

## Checklist

- [x] Format code with pre-commit. Changed-file checks and `pre-commit run --all-files` passed.
- [x] Add focused regression coverage using `CustomTestCase`, CPU CI registration, and a standard test entry point.
- [x] Documentation assessed: no new public option or API; internal behavior is documented in code and this description.
- [x] Accuracy and speed benchmarks assessed: not applicable; CPU correctness results are provided above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34822584217](https://github.com/sgl-project/sglang/actions/runs/34822584217)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34822583867](https://github.com/sgl-project/sglang/actions/runs/34822583867)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34822584185](https://github.com/sgl-project/sglang/actions/runs/34822584185)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->