### PR TITLE
[NPU] [bugfix] Fix mamba state-tracking chunk size with NPU kernel grid

### DIFF
--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -33,9 +33,15 @@ from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.model_executor.model_runner import ModelRunner
-from sglang.srt.runtime_context import get_exec, get_memory, get_spec
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_memory,
+    get_spec,
+    mamba_cache_chunk_size,
+)
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.spec_info import SpecInput
+from sglang.srt.utils.common import is_npu
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.verify_mask import VerifyMask
@@ -379,7 +385,11 @@ class MambaAttnBackendBase(AttentionBackend):
         chunk boundary. Also returns ``track_ssm_h_batch_src``: the batch rows of
         the unaligned tracked seqs, used to integer-index the fp32 snapshot
         buffer on the KDA path so the copy stays free of GPU syncs."""
-        state_chunk_size = self.mamba_chunk_size
+        state_chunk_size = (
+            self.mamba_chunk_size
+            if not is_npu()
+            else mamba_cache_chunk_size()
+        )
         # CPU to avoid kernel launches for the masking ops
         mamba_track_mask = forward_batch.mamba_track_mask.cpu()
         extend_seq_lens = forward_batch.extend_seq_lens.cpu()

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -17,6 +17,7 @@ from sglang.srt.utils.common import (
     Range,
     ceil_align,
     flatten_arrays_to_pinned_cpu,
+    is_npu,
     is_pin_memory_available,
 )
 from sglang.srt.utils.weight_versions import (
@@ -2839,8 +2840,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         req: Req,
     ) -> _MambaRadixCacheV2TrackEntry:
         cache_chunk_size = mamba_cache_chunk_size()
-        state_chunk_size = getattr(
-            self.model_config.hf_text_config, "mamba_chunk_size", 64
+        state_chunk_size = (
+            getattr(self.model_config.hf_text_config, "mamba_chunk_size", 64)
+            if not is_npu()
+            else cache_chunk_size
         )
         # Donated depth must land on the actual DCP-widened radix page, while
         # kernel snapshots stay on the cache chunk grid.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When running `Qwen3-Next-80B-A3B-Instruct` on NPU with `--tp-size 4 --mamba-track-interval 128 --page-size 128` , enabling `ASCEND_USE_FIA=1` and `GDN_USE_MEGA_GDN=1` triggers the following error: the NPU kernel reports Index out of range in dimension 0: index value 12 exceeds bounds 8 .

The problem was introduced by #33561, which changed the mamba chunk size from the global value to the model config value (the default num is 64).

The NPU GDN kernel `sgl_kernel_npu/fla/mega_chunk_gdn.py` uses a fixed grid, allocating with a chunk size of 128, while the sglang side computes with 64.

## Modifications

1. python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
   - NPU: restore to `mamba_cache_chunk_size()`
   - Non-NPU: keep #33561 logic
2. python/sglang/srt/managers/schedule_batch.py
   - NPU: `state_chunk_size` and `cache_chunk_size` both using `mamba_cache_chunk_size()`
   - Non-NPU: keep #33561 logic

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34687468378](https://github.com/sgl-project/sglang/actions/runs/34687468378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34687468113](https://github.com/sgl-project/sglang/actions/runs/34687468113)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34687468339](https://github.com/sgl-project/sglang/actions/runs/34687468339)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->