### PR TITLE
[Performance] Speed up streaming function-call common-prefix detection

### DIFF
--- a/python/sglang/srt/function_call/utils.py
+++ b/python/sglang/srt/function_call/utils.py
@@ -175,14 +175,19 @@ def normalize_json_schema_types(schema: Any) -> None:
 
 
 def _find_common_prefix(s1: str, s2: str) -> str:
-    prefix = ""
     min_length = min(len(s1), len(s2))
-    for i in range(0, min_length):
-        if s1[i] == s2[i]:
-            prefix += s1[i]
-        else:
-            break
-    return prefix
+
+    if len(s1) <= len(s2):
+        if s2.startswith(s1):
+            return s1
+    elif s1.startswith(s2):
+        return s2
+
+    for i in range(min_length):
+        if s1[i] != s2[i]:
+            return s1[:i]
+
+    return s1[:min_length]
 
 
 def _partial_json_loads(input_str: str, flags: Allow) -> Tuple[Any, int]:

--- a/test/registered/unit/function_call/test_utils_common_prefix.py
+++ b/test/registered/unit/function_call/test_utils_common_prefix.py
@@ -1,0 +1,71 @@
+import itertools
+import random
+import unittest
+
+from sglang.srt.function_call.utils import _find_common_prefix
+
+
+def _reference_common_prefix(left: str, right: str) -> str:
+    length = 0
+    for left_char, right_char in zip(left, right):
+        if left_char != right_char:
+            break
+        length += 1
+    return left[:length]
+
+
+class TestFindCommonPrefix(unittest.TestCase):
+    def test_edge_cases(self):
+        cases = [
+            ("", ""),
+            ("", "abc"),
+            ("abc", ""),
+            ("abc", "abc"),
+            ("abc", "abcdef"),
+            ("abcdef", "abc"),
+            ("abc", "xyz"),
+            ("abx", "aby"),
+            ('{"city": "San', '{"city": "San Francisco"}'),
+            ("你好，世界", "你好，工具调用"),
+            ("😀tool", "😀token"),
+        ]
+
+        for left, right in cases:
+            with self.subTest(left=left, right=right):
+                expected = _reference_common_prefix(left, right)
+                self.assertEqual(_find_common_prefix(left, right), expected)
+                self.assertEqual(_find_common_prefix(right, left), expected)
+
+    def test_exhaustive_short_strings(self):
+        values = [
+            "".join(chars)
+            for length in range(5)
+            for chars in itertools.product("ab", repeat=length)
+        ]
+
+        for left in values:
+            for right in values:
+                self.assertEqual(
+                    _find_common_prefix(left, right),
+                    _reference_common_prefix(left, right),
+                )
+
+    def test_random_strings(self):
+        random_generator = random.Random(0)
+        alphabet = "ab<>｜{}😀"
+
+        for _ in range(1000):
+            left = "".join(
+                random_generator.choices(alphabet, k=random_generator.randrange(128))
+            )
+            right = "".join(
+                random_generator.choices(alphabet, k=random_generator.randrange(128))
+            )
+            self.assertEqual(
+                _find_common_prefix(left, right),
+                _reference_common_prefix(left, right),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/function_call/test_utils_common_prefix.py
+++ b/test/registered/unit/function_call/test_utils_common_prefix.py
@@ -5,7 +5,6 @@ import unittest
 from sglang.srt.function_call.utils import _find_common_prefix
 from sglang.test.ci.ci_register import register_cpu_ci
 
-
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 

--- a/test/registered/unit/function_call/test_utils_common_prefix.py
+++ b/test/registered/unit/function_call/test_utils_common_prefix.py
@@ -3,6 +3,10 @@ import random
 import unittest
 
 from sglang.srt.function_call.utils import _find_common_prefix
+from sglang.test.ci.ci_register import register_cpu_ci
+
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
 def _reference_common_prefix(left: str, right: str) -> str:


### PR DESCRIPTION
## Summary

- speed up `_find_common_prefix` for streaming tool arguments by handling the usual prefix-growth case with `str.startswith`
- replace per-character immutable string construction with a single slice for mismatching inputs
- add focused edge, exhaustive short-string, and deterministic randomized Unicode tests

This is a focused follow-up to the helper optimization attempted in the closed #20883. That PR mixed parser state, JSON serialization, decoder, and serving changes and was closed after going stale. This slice keeps the existing helper API and all parser/serialization behavior unchanged.

## Why

`BaseFormatDetector` and `DeepSeekV32Detector` use this helper while stabilizing partial JSON arguments. The old implementation builds the common prefix one character at a time in Python. During long streaming tool calls, the stable prefix usually grows with every chunk, so the helper repeatedly reconstructs an increasingly large string.

## Performance

CPU-only DeepSeekV32 direct-JSON streaming parser benchmark, 21 alternating fresh-process AB/BA pairs, paired bootstrap 95% CI:

| Argument / chunk shape | Geomean speedup | 95% CI |
|---|---:|---:|
| 4 KiB / 16 chars | 3.27x | [3.09x, 3.47x] |
| 4 KiB / 64 chars | 3.19x | [3.00x, 3.40x] |
| 16 KiB / 16 chars | 3.52x | [3.31x, 3.73x] |
| 16 KiB / 64 chars | 3.45x | [3.24x, 3.64x] |

The claim is limited to this CPU parser micro-workload. It is not a server throughput, model, GPU, or end-to-end result.

## Test plan

- `python -m pytest -q test/registered/unit/function_call` (`543 passed`, `32 subtests passed`) on the prior base with the identical patch
- focused utility test on a later same-patch replay (`3 passed`, `11 subtests passed`)
- Ruff 0.15.1 check and format on both changed files
- `git diff HEAD^ --check`

The fork branch remains at the tested candidate commit. A read-only freshness check against current `main` found no changes to either touched path and a clean merge-tree; an independently created later replay preserves the exact stable patch-id. The full function-call suite passed on the prior base; on this host, collecting that full suite in the current official image is blocked by an architecture-specific `sgl_kernel` SIGILL. The focused tests and fresh parser benchmark above pass on the same patch lineage.

This contribution was prepared with AI assistance. Before this Draft is marked ready, the submitting human will review every changed line, rerun the relevant tests, and be prepared to defend the implementation and claim boundary.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34689404039](https://github.com/sgl-project/sglang/actions/runs/34689404039)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34689403949](https://github.com/sgl-project/sglang/actions/runs/34689403949)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34689404005](https://github.com/sgl-project/sglang/actions/runs/34689404005)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->