### PR TITLE
fix(diffusion): allow SageAttention for FLUX.2

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
@@ -1466,6 +1466,7 @@ class Flux2Transformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
     _supported_attention_backends = {
         AttentionBackendEnum.TORCH_SDPA,
         AttentionBackendEnum.FA,
+        AttentionBackendEnum.SAGE_ATTN,
         AttentionBackendEnum.AITER,
         AttentionBackendEnum.AITER_SAGE,
     }

--- a/test/registered/unit/models/test_flux2_fp8_norm_quant_gate.py
+++ b/test/registered/unit/models/test_flux2_fp8_norm_quant_gate.py
@@ -11,8 +11,10 @@ from sglang.multimodal_gen.runtime.layers.quantization.modelopt_quant import (
 )
 from sglang.multimodal_gen.runtime.models.dits.flux_2 import (
     Flux2SingleTransformerBlock,
+    Flux2Transformer2DModel,
     Flux2TransformerBlock,
 )
+from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -55,6 +57,12 @@ def _double_block(scales: tuple[float, float, float]) -> Flux2TransformerBlock:
 
 
 class TestFlux2Fp8NormQuantGate(CustomTestCase):
+    def test_sage_attention_is_supported(self) -> None:
+        self.assertIn(
+            AttentionBackendEnum.SAGE_ATTN,
+            Flux2Transformer2DModel._supported_attention_backends,
+        )
+
     def test_qkv_requires_identical_input_scales(self) -> None:
         matching = _double_block((0.25, 0.25, 0.25))
         mismatched = _double_block((0.25, 0.5, 0.25))


### PR DESCRIPTION
## Motivation

Fixes #39070.

FLUX.2 declares the attention backends available to its transformer blocks,
but the declaration omits `SAGE_ATTN`. This prevents the model capability
declaration from matching the CUDA attention backend resolver and can reject
explicit `sage_attn` configurations on model-level admission paths.

## Modifications

- Add `SAGE_ATTN` to `Flux2Transformer2DModel._supported_attention_backends`.
- Add a regression test for the FLUX.2 backend declaration.

## Accuracy Tests

- `python -m py_compile python/sglang/multimodal_gen/runtime/models/dits/flux_2.py test/registered/unit/models/test_flux2_fp8_norm_quant_gate.py`
- `pre-commit run --files python/sglang/multimodal_gen/runtime/models/dits/flux_2.py test/registered/unit/models/test_flux2_fp8_norm_quant_gate.py`


## Checklist

- [x] Format code with the repository pre-commit configuration.
- [x] Add focused regression coverage.
- [x] No documentation update is required.
- [ ] Full GPU accuracy validation; SageAttention hardware validation is left for CI/maintainer review.

AI assistance was used for investigation and implementation.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34694092476](https://github.com/sgl-project/sglang/actions/runs/34694092476)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34694092228](https://github.com/sgl-project/sglang/actions/runs/34694092228)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34694092353](https://github.com/sgl-project/sglang/actions/runs/34694092353)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->