### PR TITLE
Fix client-disconnect CancelledError crashing the entire engine

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1749,6 +1749,49 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         state = self.rid_to_state[obj.rid]
         return self._stream_one_response(obj=obj, state=state, request=request)
 
+    async def _is_request_disconnected(self, request: fastapi.Request) -> bool:
+        """Poll whether the client is still connected, tolerating cancellation
+        of the poll itself.
+
+        ``Request.is_disconnected()`` awaits the ASGI ``receive`` channel. If
+        the transport is torn down while that await is pending (the client
+        closed its socket, a proxy reset the connection, etc.), uvicorn/h11
+        cancels the pending receive, which surfaces here as
+        ``asyncio.CancelledError``. Since Python 3.8, ``CancelledError`` is a
+        ``BaseException``, not an ``Exception``, so it silently bypasses every
+        ``except Exception`` handler in the request-handling call stack. Left
+        uncaught, it propagates out of this task and is mistaken for a fatal
+        engine error upstream, which brings down the whole process for what
+        is really just one client disconnecting.
+
+        This poll only touches the HTTP/ASGI transport layer -- it never
+        reaches the scheduler process, the KV cache, or any CUDA state (those
+        live behind an IPC boundary) -- so it's safe to treat a cancellation
+        observed here as "the client disconnected" and let the normal
+        disconnect path run. The one case we must NOT swallow is our own task
+        being cancelled on purpose, e.g. during graceful server shutdown --
+        that has to keep propagating or shutdown can hang.
+        """
+        try:
+            return await request.is_disconnected()
+        except asyncio.CancelledError:
+            current_task = asyncio.current_task()
+            if current_task is not None and hasattr(current_task, "cancelling"):
+                # Python 3.11+: Task.cancelling() tells us precisely whether
+                # *this* task has a cancellation request pending. If it does,
+                # this CancelledError is ours to honor, not the transport's.
+                if current_task.cancelling() > 0:
+                    raise
+            elif self.gracefully_exit:
+                # Python 3.10 has no Task.cancelling(); fall back to the
+                # engine's own shutdown flag as the next-best signal that
+                # this cancellation was intentional rather than transport-driven.
+                raise
+            # Otherwise, the cancellation came from the transport tearing
+            # down the connection itself -- treat it the same as a normal
+            # disconnected-client observation.
+            return True
+
     async def _stream_one_response(
         self,
         obj: Union[GenerateReqInput, EmbeddingReqInput],
@@ -1766,7 +1809,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 if (
                     request is not None
                     and not obj.background
-                    and await request.is_disconnected()
+                    and await self._is_request_disconnected(request)
                 ):
                     # Abort the request for disconnected requests (non-streaming, waiting queue)
                     self.abort_request(obj.rid)
@@ -1854,7 +1897,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 if (
                     request is not None
                     and not obj.background
-                    and await request.is_disconnected()
+                    and await self._is_request_disconnected(request)
                 ):
                     # Abort the request for disconnected requests (non-streaming, running)
                     self.abort_request(obj.rid)

--- a/test/registered/unit/managers/test_tokenizer_manager_disconnect_cancelled.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_disconnect_cancelled.py
@@ -1,0 +1,198 @@
+"""
+Regression test for TokenizerManager._is_request_disconnected.
+
+Background: TokenizerManager._stream_one_response polls
+`await request.is_disconnected()` (Starlette) every
+SGLANG_REQUEST_STATE_WAIT_TIMEOUT seconds while waiting on a request. If the
+client's TCP connection is torn down while that poll is in flight, uvicorn
+cancels the pending ASGI receive, raising asyncio.CancelledError from inside
+is_disconnected(). Since Python 3.8, CancelledError is a BaseException, not
+an Exception, so it silently bypasses the `except Exception` handlers used
+throughout the request-handling stack and propagates uncaught, which is
+mistaken for a fatal engine error upstream and brings down the whole engine
+process for what should have been a single aborted request (see #39216).
+
+_is_request_disconnected() catches only that specific CancelledError and
+distinguishes: cancellation of *our own* task (e.g. graceful shutdown, which
+must keep propagating) from cancellation caused by the transport tearing
+down the connection (which must be treated as "client disconnected" and
+handled by the engine's existing per-request abort path). This test drives
+that helper directly via mocks -- covering both the Python 3.11+
+Task.cancelling() path and the Python 3.10 gracefully_exit-flag fallback --
+plus an end-to-end check that a request whose is_disconnected() poll is hit
+by a bare CancelledError does not crash the engine and a subsequent request
+still completes normally.
+"""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.tokenizer_manager import TokenizerManager  # noqa: E402
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _bare_tokenizer_manager(gracefully_exit: bool = False) -> TokenizerManager:
+    """A TokenizerManager stand-in exposing only what
+    _is_request_disconnected reads, without running __init__ (which spins up
+    the full engine: scheduler processes, tokenizers, zmq sockets, ...)."""
+    tm = TokenizerManager.__new__(TokenizerManager)
+    tm.gracefully_exit = gracefully_exit
+    return tm
+
+
+class FakeTaskWithCancelling:
+    """Simulates a Python 3.11+ asyncio.Task exposing .cancelling()."""
+
+    def __init__(self, cancelling_count: int):
+        self._n = cancelling_count
+
+    def cancelling(self) -> int:
+        return self._n
+
+
+class FakeTaskWithoutCancelling:
+    """Simulates a Python 3.10 asyncio.Task (no .cancelling() method)."""
+
+
+class TestIsRequestDisconnectedHandlesCancelledError(CustomTestCase):
+    """Unit-level coverage of the CancelledError-vs-disconnect branching."""
+
+    def test_disconnected_client_no_cancellation(self):
+        tm = _bare_tokenizer_manager()
+        request = AsyncMock()
+        request.is_disconnected.return_value = True
+        self.assertTrue(asyncio.run(tm._is_request_disconnected(request)))
+
+    def test_connected_client_no_cancellation(self):
+        tm = _bare_tokenizer_manager()
+        request = AsyncMock()
+        request.is_disconnected.return_value = False
+        self.assertFalse(asyncio.run(tm._is_request_disconnected(request)))
+
+    def test_transport_teardown_cancelled_error_is_swallowed(self):
+        """The core bug scenario: uvicorn cancels the pending receive when
+        the client's socket closes mid-poll. Our own task was not asked to
+        cancel (Task.cancelling() == 0), so this must be treated as a normal
+        disconnect, not re-raised as an uncaught BaseException."""
+        tm = _bare_tokenizer_manager(gracefully_exit=False)
+        request = AsyncMock()
+        request.is_disconnected.side_effect = asyncio.CancelledError()
+
+        async def run():
+            with patch("asyncio.current_task", return_value=FakeTaskWithCancelling(0)):
+                return await tm._is_request_disconnected(request)
+
+        self.assertTrue(asyncio.run(run()))
+
+    def test_real_task_cancellation_still_propagates(self):
+        """When our own task has a genuine pending cancellation (e.g. server
+        shutdown), Task.cancelling() > 0 and the CancelledError must
+        propagate -- swallowing it here would risk hanging shutdown."""
+        tm = _bare_tokenizer_manager(gracefully_exit=False)
+        request = AsyncMock()
+        request.is_disconnected.side_effect = asyncio.CancelledError()
+
+        async def run():
+            with patch("asyncio.current_task", return_value=FakeTaskWithCancelling(1)):
+                await tm._is_request_disconnected(request)
+
+        with self.assertRaises(asyncio.CancelledError):
+            asyncio.run(run())
+
+    def test_py310_fallback_transport_teardown(self):
+        """Without Task.cancelling() (Python 3.10), fall back to the
+        engine's own gracefully_exit flag. Not shutting down -> disconnect."""
+        tm = _bare_tokenizer_manager(gracefully_exit=False)
+        request = AsyncMock()
+        request.is_disconnected.side_effect = asyncio.CancelledError()
+
+        async def run():
+            with patch(
+                "asyncio.current_task", return_value=FakeTaskWithoutCancelling()
+            ):
+                return await tm._is_request_disconnected(request)
+
+        self.assertTrue(asyncio.run(run()))
+
+    def test_py310_fallback_shutdown_propagates(self):
+        """Without Task.cancelling(), a gracefully_exit shutdown in progress
+        must still propagate the cancellation."""
+        tm = _bare_tokenizer_manager(gracefully_exit=True)
+        request = AsyncMock()
+        request.is_disconnected.side_effect = asyncio.CancelledError()
+
+        async def run():
+            with patch(
+                "asyncio.current_task", return_value=FakeTaskWithoutCancelling()
+            ):
+                await tm._is_request_disconnected(request)
+
+        with self.assertRaises(asyncio.CancelledError):
+            asyncio.run(run())
+
+
+class TestStreamOneResponseSurvivesDisconnectCancellation(CustomTestCase):
+    """End-to-end (still process-local, no real server/model) check that a
+    disconnect-triggered CancelledError aborts only the one request and
+    leaves the manager able to serve a following request."""
+
+    def test_one_request_aborted_next_request_unaffected(self):
+        tm = _bare_tokenizer_manager(gracefully_exit=False)
+        tm.abort_request = MagicMock()
+
+        class FakeObj:
+            rid = "req-1"
+            background = False
+
+        class FakeState:
+            def __init__(self):
+                self.event = asyncio.Event()
+                self.out_list = []
+                self.finished = False
+
+        state = FakeState()
+        request = AsyncMock()
+        request.is_disconnected.side_effect = asyncio.CancelledError()
+
+        async def drive():
+            # The real bug fires while _stream_one_response is polling via
+            # asyncio.wait_for(..., timeout=_REQUEST_STATE_WAIT_TIMEOUT)
+            # (default 4s) waiting for a long-running request. Shrink that
+            # timeout so the test hits the same code path without a real
+            # multi-second wait.
+            with (
+                patch(
+                    "sglang.srt.managers.tokenizer_manager._REQUEST_STATE_WAIT_TIMEOUT",
+                    0.01,
+                ),
+                patch("asyncio.current_task", return_value=FakeTaskWithCancelling(0)),
+            ):
+                gen = TokenizerManager._stream_one_response(
+                    tm, obj=FakeObj(), state=state, request=request
+                )
+                with self.assertRaises(ValueError):
+                    await gen.__anext__()
+
+        asyncio.run(drive())
+
+        # The single disconnected request was aborted through the engine's
+        # existing per-request cleanup path...
+        tm.abort_request.assert_called_once_with("req-1")
+
+        # ...and the manager itself is still alive: nothing here touched
+        # process state, so a subsequent, independent request's polling
+        # helper still behaves normally.
+        next_request = AsyncMock()
+        next_request.is_disconnected.return_value = False
+        self.assertFalse(asyncio.run(tm._is_request_disconnected(next_request)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Fixes #39216

When a client's connection is torn down while the server is still processing a request (for example, a client-side timeout hit during a long prefill), `TokenizerManager`'s periodic `await request.is_disconnected()` poll (in `_stream_one_response`, called roughly every `SGLANG_REQUEST_STATE_WAIT_TIMEOUT` seconds, default 4s) has its underlying ASGI `receive` await cancelled by uvicorn when the connection drops, raising `asyncio.CancelledError`.

Since Python 3.8, `CancelledError` is a `BaseException`, not an `Exception`, so it silently bypasses the many `except Exception` handlers used throughout the request-handling stack. Left uncaught, it propagates out of the request's task and is treated as a fatal engine error upstream, which kills the **entire process** — every in-flight and future request — instead of just failing the one request whose client happened to disconnect.

This is reproducible under ordinary operating conditions (any client timeout, cancellation, or network blip during an active request), not just as an edge case — I hit it on a real deployment by sending a ~200K-token prefill request with a client-side timeout shorter than the expected processing time.

## Fix

Adds `TokenizerManager._is_request_disconnected()`, which wraps the poll and distinguishes two cases when a `CancelledError` surfaces from it:

1. **Our own task is being cancelled on purpose** (e.g. graceful server shutdown) — detected via `Task.cancelling() > 0` on Python 3.11+, or via the engine's existing `gracefully_exit` flag as a fallback on 3.10 (this repo's `pyproject.toml` pins `requires-python >= 3.10`, so `Task.cancelling()` can't be relied on unconditionally). In this case the `CancelledError` **must keep propagating** — swallowing it here would risk hanging shutdown.
2. **The transport tore down the connection itself** — the actual bug scenario. Safe to treat as "client disconnected" and flow into the engine's existing per-request `abort_request()` path, unchanged.

Both call sites of `await request.is_disconnected()` in `tokenizer_manager.py` are updated to use the new helper.

### Why this specific catch is safe

`is_disconnected()` only touches the HTTP/ASGI transport layer — it never reaches the scheduler process, the KV cache, or any CUDA state, all of which live behind an IPC boundary from the tokenizer manager. So treating this particular cancellation as request-scoped does not risk continuing to serve from a corrupted GPU/scheduler state, unlike a broader "catch everything" change would.

## Testing

- Added `test/registered/unit/managers/test_tokenizer_manager_disconnect_cancelled.py`, following existing conventions in `test/registered/unit/managers/` (`CustomTestCase`, `register_cpu_ci`, `maybe_stub_sgl_kernel()`). Covers: normal connected/disconnected polls, the core bug scenario (transport-driven `CancelledError` swallowed), genuine task cancellation still propagating (both the 3.11+ `Task.cancelling()` path and the 3.10 `gracefully_exit` fallback), and an end-to-end check that one aborted request does not affect a subsequent request.
- Ran `ruff check`, `ruff format --check`, and `isort` (against this repo's pinned configs) on both changed files — clean.
- Could not run the full test suite or a live multi-GPU server in my local environment (no GPU/CUDA available here); validated the branching logic independently with a standalone script exercising all six scenarios before writing the sglang-integrated test. Happy to address anything CI surfaces.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34698042998](https://github.com/sgl-project/sglang/actions/runs/34698042998)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34698042876](https://github.com/sgl-project/sglang/actions/runs/34698042876)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34698042988](https://github.com/sgl-project/sglang/actions/runs/34698042988)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->