### PR TITLE
[Rust] Build cumulative stream frames in one buffer

### DIFF
--- a/rust/sglang-server/src/api_server/frame.rs
+++ b/rust/sglang-server/src/api_server/frame.rs
@@ -254,49 +254,65 @@ pub(super) fn cumulative_frame_json(
     // quirk is reproduced instead of re-derived.
     let finish = serde_json::to_value(&o.finish_reason).ok()?.to_string();
 
-    // Alphabetical by convention only — a stable order that is easy to extend and
-    // diff.
-    let mut m = String::new();
-    let _ = write!(m, "{{\"completion_tokens\":{}", o.completion_tokens);
-    let _ = write!(m, ",\"finish_reason\":{finish}");
-    if let Some(h) = &acc.hidden_json {
-        let _ = write!(m, ",\"hidden_states\":{h}");
-    }
-    let _ = write!(m, ",\"id\":{}", serde_json::Value::String(rid.to_string()));
-    if let Some(v) = &acc.in_tid_json {
-        let _ = write!(m, ",\"input_token_ids_logprobs\":{v}");
-    }
-    // Input+output token logprobs are emitted as a PAIR whenever either side has
-    // data (empty list included), matching `frame_value` byte for byte — see the
-    // PD-router rationale there.
     let lp_pair = acc.in_lp_json.is_some() || !acc.out_lp_json.is_empty();
-    if lp_pair {
-        let v = acc.in_lp_json.as_deref().unwrap_or("[]");
-        let _ = write!(m, ",\"input_token_logprobs\":{v}");
-    }
-    if let Some(v) = &acc.in_top_json {
-        let _ = write!(m, ",\"input_top_logprobs\":{v}");
-    }
-    // The `Value` path keys these off the source columns being non-empty; an empty
-    // source renders to an empty body, so the two guards coincide.
-    if !acc.out_tid_json.is_empty() {
-        let _ = write!(m, ",\"output_token_ids_logprobs\":[{}]", acc.out_tid_json);
-    }
-    if lp_pair {
-        let _ = write!(m, ",\"output_token_logprobs\":[{}]", acc.out_lp_json);
-    }
-    if !acc.out_top_json.is_empty() {
-        let _ = write!(m, ",\"output_top_logprobs\":[{}]", acc.out_top_json);
-    }
-    let _ = write!(m, ",\"prompt_tokens\":{}}}", o.prompt_tokens);
-
-    let mut s = String::with_capacity(acc.text_json.len() + acc.ids_json.len() + m.len() + 40);
+    let optional_len = |v: &Option<String>| v.as_deref().map_or(0, str::len);
+    let mut s = String::with_capacity(
+        acc.text_json.len()
+            + acc.ids_json.len()
+            + acc.out_lp_json.len()
+            + acc.out_top_json.len()
+            + acc.out_tid_json.len()
+            + optional_len(&acc.in_lp_json)
+            + optional_len(&acc.in_top_json)
+            + optional_len(&acc.in_tid_json)
+            + optional_len(&acc.hidden_json)
+            + finish.len()
+            + rid.len()
+            + 256,
+    );
     s.push('{');
     if let Some(i) = index {
         let _ = write!(s, "\"index\":{i},");
     }
-    s.push_str("\"meta_info\":");
-    s.push_str(&m);
+
+    // Alphabetical by convention only — a stable order that is easy to extend and
+    // diff. Write directly into the final frame so large cumulative logprob metadata
+    // is not first materialized in a temporary String and then copied here.
+    let _ = write!(
+        s,
+        "\"meta_info\":{{\"completion_tokens\":{}",
+        o.completion_tokens
+    );
+    let _ = write!(s, ",\"finish_reason\":{finish}");
+    if let Some(h) = &acc.hidden_json {
+        let _ = write!(s, ",\"hidden_states\":{h}");
+    }
+    let _ = write!(s, ",\"id\":{}", serde_json::Value::String(rid.to_string()));
+    if let Some(v) = &acc.in_tid_json {
+        let _ = write!(s, ",\"input_token_ids_logprobs\":{v}");
+    }
+    // Input+output token logprobs are emitted as a PAIR whenever either side has
+    // data (empty list included), matching `frame_value` byte for byte — see the
+    // PD-router rationale there.
+    if lp_pair {
+        let v = acc.in_lp_json.as_deref().unwrap_or("[]");
+        let _ = write!(s, ",\"input_token_logprobs\":{v}");
+    }
+    if let Some(v) = &acc.in_top_json {
+        let _ = write!(s, ",\"input_top_logprobs\":{v}");
+    }
+    // The `Value` path keys these off the source columns being non-empty; an empty
+    // source renders to an empty body, so the two guards coincide.
+    if !acc.out_tid_json.is_empty() {
+        let _ = write!(s, ",\"output_token_ids_logprobs\":[{}]", acc.out_tid_json);
+    }
+    if lp_pair {
+        let _ = write!(s, ",\"output_token_logprobs\":[{}]", acc.out_lp_json);
+    }
+    if !acc.out_top_json.is_empty() {
+        let _ = write!(s, ",\"output_top_logprobs\":[{}]", acc.out_top_json);
+    }
+    let _ = write!(s, ",\"prompt_tokens\":{}}}", o.prompt_tokens);
     if !acc.ids_json.is_empty() {
         s.push_str(",\"output_ids\":[");
         s.push_str(&acc.ids_json);


### PR DESCRIPTION
## Summary

- build cumulative stream frames directly in the final `String`
- avoid materializing the potentially large `meta_info` object in a temporary `String` and copying it into the final frame
- preserve the existing field order and serialized JSON output

## Follow-up HTTP validation and scope

The actual CPU loopback `/generate` HTTP/SSE path, using a deterministic mock model producer, passed correctness in 96/96 fresh processes. Its predeclared performance qualification **did not pass**: the primary 512-step top-5 case measured 1.068x (95% CI 1.017–1.123), missing the required lower bound >1.02. An incremental control that bypasses this formatter measured 0.999x (0.969–1.029), also missing its no-regression screen; that result does not establish a regression caused by this patch.

This PR is retained as a small, localized removal of the temporary metadata buffer and copy. The component measurements below remain supporting evidence, not a production-serving or end-to-end throughput claim. The failed HTTP qualification is not reclassified as a pass.

## Performance

I measured the native Rust cumulative streaming path from Tokio channel consumption through accumulation and SSE `String` construction. Each of six shapes used 9 paired, fresh-process repeats with alternating baseline/candidate order. A separate untimed request hashed every intermediate output to verify byte-for-byte parity.

| Payload | Steps | Baseline median | Candidate median | Geometric-mean speedup | Paired bootstrap 95% CI |
| --- | ---: | ---: | ---: | ---: | ---: |
| plain ASCII | 32 | 55.48 us/stream | 46.53 us/stream | 1.114x | [1.066x, 1.159x] |
| plain ASCII | 128 | 173.11 us/stream | 146.22 us/stream | 1.181x | [1.132x, 1.243x] |
| plain ASCII | 512 | 662.65 us/stream | 555.47 us/stream | 1.236x | [1.190x, 1.282x] |
| escaped text | 128 | 161.63 us/stream | 135.25 us/stream | 1.172x | [1.156x, 1.185x] |
| top-5 text logprobs | 128 | 926.16 us/stream | 728.85 us/stream | 1.235x | [1.181x, 1.292x] |
| top-5 text logprobs | 512 | 5,303.91 us/stream | 3,700.19 us/stream | 1.433x | [1.383x, 1.493x] |

All 54 paired comparisons produced identical intermediate output bytes. Across these exact shapes, the median avoided CPU time ranges from 8.95 us to 1.604 ms per cumulative stream (about 0.21 us to 3.13 us per emitted frame). These measurements cover CPU-side native cumulative-stream formatting; they do not claim a model, GPU, network, or whole-server end-to-end speedup.

## Validation

- `cargo test --locked -p sglang-server --lib` (264 passed)
- `cargo test --locked -p sglang-server --lib cumulative_frame_json -- --nocapture` (2 passed after replay onto current `main`)
- `cargo fmt --all -- --check`
- `cargo clippy --locked -p sglang-server --all-targets -- -D warnings`

The validated `frame.rs` baseline blob remains unchanged on latest `main`; the branch has a clean merge tree despite intervening path-disjoint commits.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34699976792](https://github.com/sgl-project/sglang/actions/runs/34699976792)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34699976484](https://github.com/sgl-project/sglang/actions/runs/34699976484)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->