### PR TITLE
[Performance] Batch top-logprob detokenization across positions

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2833,18 +2833,69 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         token_logprobs_idx: List[int],
         decode_to_text: bool,
     ):
-        # TODO: The current implementation only batches the detokenization for top-k tokens per single position.
-        # We should batch all top-k tokens in all positions.
-        ret = []
-        for i in range(len(token_logprobs_val)):
-            if token_logprobs_val[i]:
-                ret.append(
-                    self.detokenize_logprob_tokens(
-                        token_logprobs_val[i], token_logprobs_idx[i], decode_to_text
-                    )
+        if not decode_to_text:
+            return [
+                self.detokenize_logprob_tokens(
+                    token_logprobs_val[i], token_logprobs_idx[i], False
                 )
-            else:
-                ret.append(None)
+                if token_logprobs_val[i]
+                else None
+                for i in range(len(token_logprobs_val))
+            ]
+
+        if len(token_logprobs_val) == 1:
+            return [
+                self.detokenize_logprob_tokens(
+                    token_logprobs_val[0], token_logprobs_idx[0], True
+                )
+                if token_logprobs_val[0]
+                else None
+            ]
+
+        # Cross-position batching helps the OpenAI-compatible top-logprob range,
+        # but large flattened tokenizer batches can cost more than the calls saved.
+        if any(
+            token_logprobs and len(token_logprobs_idx[i]) > 20
+            for i, token_logprobs in enumerate(token_logprobs_val)
+        ):
+            return [
+                self.detokenize_logprob_tokens(
+                    token_logprobs_val[i], token_logprobs_idx[i], True
+                )
+                if token_logprobs_val[i]
+                else None
+                for i in range(len(token_logprobs_val))
+            ]
+
+        non_empty_rows = [
+            i for i, token_logprobs in enumerate(token_logprobs_val) if token_logprobs
+        ]
+        ret = [None] * len(token_logprobs_val)
+        if not non_empty_rows:
+            return ret
+        if len(non_empty_rows) == 1:
+            i = non_empty_rows[0]
+            ret[i] = self.detokenize_logprob_tokens(
+                token_logprobs_val[i], token_logprobs_idx[i], True
+            )
+            return ret
+
+        assert self.tokenizer is not None
+        # In transformers v5, batch_decode([1, 2, 3]) concatenates all tokens
+        # into one string. Wrap each ID in its own list so they decode separately.
+        token_texts = self.tokenizer.batch_decode(
+            [[token_id] for i in non_empty_rows for token_id in token_logprobs_idx[i]]
+        )
+        row_start = 0
+        for i in non_empty_rows:
+            token_ids = token_logprobs_idx[i]
+            ret[i] = [
+                (logprob, token_id, token_texts[row_start + j])
+                for j, (logprob, token_id) in enumerate(
+                    zip(token_logprobs_val[i], token_ids)
+                )
+            ]
+            row_start += len(token_ids)
         return ret
 
     def _calculate_spec_decoding_metrics(

--- a/test/registered/unit/managers/test_flat_raw_top_logprobs.py
+++ b/test/registered/unit/managers/test_flat_raw_top_logprobs.py
@@ -63,6 +63,16 @@ class _TokenizerManagerStub:
     detokenize_top_logprobs_tokens = TokenizerManager.detokenize_top_logprobs_tokens
 
 
+class _RecordingTokenizer:
+    def __init__(self):
+        self.calls = []
+
+    def batch_decode(self, token_ids):
+        token_ids = [list(ids) for ids in token_ids]
+        self.calls.append(token_ids)
+        return [f"token-{ids[0]}" for ids in token_ids]
+
+
 def _make_state(**obj_kwargs) -> ReqState:
     obj = GenerateReqInput(text="hello", **obj_kwargs)
     obj.normalize_batch_and_arguments()
@@ -85,6 +95,114 @@ def _add_logprob_meta_info(state: ReqState, top_logprobs_num: int = 2) -> dict:
         return_text_in_logprobs=False,
     )
     return meta_info
+
+
+class TestTopLogprobDetokenization(CustomTestCase):
+    def test_batches_all_non_empty_positions(self):
+        tokenizer = _RecordingTokenizer()
+        manager = _TokenizerManagerStub()
+        manager.tokenizer = tokenizer
+
+        result = manager.detokenize_top_logprobs_tokens(
+            [None, [-0.1, -0.2], [], [-0.3]],
+            [None, [11, 12], [], [21]],
+            decode_to_text=True,
+        )
+
+        self.assertEqual(tokenizer.calls, [[[11], [12], [21]]])
+        self.assertEqual(
+            result,
+            [
+                None,
+                [(-0.1, 11, "token-11"), (-0.2, 12, "token-12")],
+                None,
+                [(-0.3, 21, "token-21")],
+            ],
+        )
+
+    def test_no_text_does_not_access_tokenizer(self):
+        manager = _TokenizerManagerStub()
+
+        result = manager.detokenize_top_logprobs_tokens(
+            [None, [-0.1, -0.2], []],
+            [None, [11, 12], []],
+            decode_to_text=False,
+        )
+
+        self.assertEqual(result, [None, [(-0.1, 11, None), (-0.2, 12, None)], None])
+
+    def test_all_empty_rows_do_not_access_tokenizer(self):
+        manager = _TokenizerManagerStub()
+
+        result = manager.detokenize_top_logprobs_tokens(
+            [None, [], None],
+            [None, [], None],
+            decode_to_text=True,
+        )
+
+        self.assertEqual(result, [None, None, None])
+
+    def test_single_non_empty_row_uses_one_decode(self):
+        tokenizer = _RecordingTokenizer()
+        manager = _TokenizerManagerStub()
+        manager.tokenizer = tokenizer
+
+        result = manager.detokenize_top_logprobs_tokens(
+            [None, [-0.1, -0.2], []],
+            [None, [11, 12], []],
+            decode_to_text=True,
+        )
+
+        self.assertEqual(tokenizer.calls, [[[11], [12]]])
+        self.assertEqual(
+            result, [None, [(-0.1, 11, "token-11"), (-0.2, 12, "token-12")], None]
+        )
+
+        tokenizer.calls.clear()
+        result = manager.detokenize_top_logprobs_tokens(
+            [[-0.3]], [[21]], decode_to_text=True
+        )
+        self.assertEqual(tokenizer.calls, [[[21]]])
+        self.assertEqual(result, [[(-0.3, 21, "token-21")]])
+
+    def test_ragged_rows_preserve_zip_truncation(self):
+        tokenizer = _RecordingTokenizer()
+        manager = _TokenizerManagerStub()
+        manager.tokenizer = tokenizer
+
+        result = manager.detokenize_top_logprobs_tokens(
+            [[-0.1], [-0.2, -0.3], None, [-0.4]],
+            [[11, 12], [21], None, []],
+            decode_to_text=True,
+        )
+
+        self.assertEqual(tokenizer.calls, [[[11], [12], [21]]])
+        self.assertEqual(
+            result,
+            [
+                [(-0.1, 11, "token-11")],
+                [(-0.2, 21, "token-21")],
+                None,
+                [],
+            ],
+        )
+
+    def test_large_rows_remain_position_batched(self):
+        tokenizer = _RecordingTokenizer()
+        manager = _TokenizerManagerStub()
+        manager.tokenizer = tokenizer
+        values = [[-float(i) for i in range(21)] for _ in range(2)]
+        indices = [list(range(21)), list(range(100, 121))]
+
+        result = manager.detokenize_top_logprobs_tokens(
+            values, indices, decode_to_text=True
+        )
+
+        self.assertEqual(len(tokenizer.calls), 2)
+        self.assertEqual(tokenizer.calls[0], [[i] for i in range(21)])
+        self.assertEqual(tokenizer.calls[1], [[i] for i in range(100, 121)])
+        self.assertEqual(len(result[0]), 21)
+        self.assertEqual(len(result[1]), 21)
 
 
 class TestFlatRawTopLogprobsValidation(CustomTestCase):


### PR DESCRIPTION
## Motivation

When `return_text_in_logprobs` is enabled, top-logprob token text is currently
detokenized with one `batch_decode` call per non-empty output position. Responses
with several positions therefore repeat tokenizer setup and dispatch overhead.

This revives the useful direction from #24447, which was closed automatically
after 114 days without updates rather than rejected on technical grounds. The
implementation here is rebased onto current `main` and adds guards motivated by
new production-tokenizer measurements and broader semantic testing.

## Modifications

- Flatten token IDs from multiple non-empty positions into one `batch_decode`
  call, then reconstruct the existing per-position result shape.
- Preserve the existing position-wise path for a single position, a single
  non-empty row, or rows with `top_k > 20`. The last guard avoids a measured
  regression from overly large flattened tokenizer batches.
- Preserve `None`, empty-row, ragged `zip` truncation, and
  `decode_to_text=False` behavior.
- Add focused unit coverage for optimized and fallback paths in the current
  registered-test layout.

## Relationship to prior work

#24447 introduced the same core cross-position flattening idea. This Draft does
not claim that idea as new. It carries the direction forward on current main and
adds:

- a measured `top_k > 20` fallback after a `top_k=50` counterexample;
- single-position and single-nonempty-row guards;
- ragged-input and fallback-path tests;
- 50,008 baseline-equivalence cases; and
- a production Qwen2.5 tokenizer shape/performance portfolio.

If maintainers prefer reopening #24447 or preserving its authorship in another
form, I am happy to follow that direction.

## Accuracy tests

- Exact production-method tests: 6/6 passed.
- Deterministic and randomized comparison against the position-wise baseline:
  50,008/50,008 cases passed, including empty, `None`, ragged, `top_k=20`, and
  `top_k=21` cases.
- Qwen2.5-7B-Instruct production tokenizer portfolio: 20/20 output shapes were
  exactly equivalent.

The repository-registered test is included, but the local Windows Python
environment cannot collect SGLang because it lacks the POSIX `resource` module.
This Draft is intended to obtain dependency-complete upstream CPU CI as well as
maintainer feedback on the relationship to #24447.

## Speed tests and profiling

Direct CPU tokenizer attribution with the Qwen2.5 tokenizer showed:

- positions=2, top_k=5: 1.033x
- positions=8, top_k=5: 1.157x
- positions=32, top_k=5: 1.211x
- positions=128, top_k=5: 1.194x
- positions=32, top_k=20: 1.054x
- positions=128, top_k=20: 1.040x

Each listed result had a paired bootstrap 95% confidence interval above 1.0.
`top_k > 20` deliberately uses the old path after a counterexample at
`top_k=50`.

These numbers are direct CPU tokenizer attribution only. No live-server,
end-to-end latency, throughput, GPU, or whole-model performance claim is made.
A logprob-heavy server A/B remains required before this PR is marked ready.

## Checklist

- [x] Focused correctness tests added.
- [x] Ruff 0.15.1 format and focused static checks pass.
- [x] Historical exact predecessor disclosed and compared.
- [ ] Dependency-complete repository CPU test passes in upstream CI.
- [ ] Logprob-heavy live-server workload is measured.
- [ ] Documentation updated (not applicable: no public API change).

This implementation and its validation were AI-assisted. I reviewed the diff and
the evidence summarized above. The PR remains Draft until upstream CPU CI and a
representative server workload are available.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34701969463](https://github.com/sgl-project/sglang/actions/runs/34701969463)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34701969383](https://github.com/sgl-project/sglang/actions/runs/34701969383)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34701969426](https://github.com/sgl-project/sglang/actions/runs/34701969426)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->