### PR TITLE
[MLX] Build FutureMap on the req_to_token_pool device, not the scheduler device

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1617,8 +1617,13 @@ class Scheduler(
             attn_backends = (self.tp_worker.model_runner.attn_backend,)
         needs_cpu_seq_lens = decide_needs_cpu_seq_lens(attn_backends)
         needs_confidence_relay = decide_needs_confidence_relay()
+        # FutureMap bufs are indexed by req_pool_idx and written/read with
+        # batch tensors (req_pool_indices, next_token_ids, seq_lens), which
+        # live on the req_to_token_pool's device. On CUDA that is self.device;
+        # the MLX backend keeps its pools and batches on CPU while self.device
+        # is "mps", so the relay must follow the pool, not the accelerator.
         self.future_map = self.spec_algorithm.create_future_map(
-            self.device,
+            self.req_to_token_pool.device,
             self.req_to_token_pool,
             needs_cpu_seq_lens=needs_cpu_seq_lens,
             needs_confidence_relay=needs_confidence_relay,

--- a/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
+++ b/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
@@ -14,6 +14,7 @@ register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
 
 _HAS_MLX = importlib.util.find_spec("mlx") is not None
 _SKIP_REASON = "requires mlx"
+_HAS_MPS = False
 
 if _HAS_MLX:
     import mlx.core as mx
@@ -56,6 +57,8 @@ if _HAS_MLX:
     from sglang.srt.managers.utils import GenerationBatchResult
     from sglang.srt.mem_cache.base_prefix_cache import InsertParams, InsertResult
     from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+
+    _HAS_MPS = torch.backends.mps.is_available()
 
 
 def _set_runner_cache_layout(
@@ -407,15 +410,21 @@ class TestMlxAuxiliaryStateRunnerCache(unittest.TestCase):
         self.assertEqual(calls, [(1, [[7]], ["r0"])])
         self.assertEqual(pending.lazy_tokens.tolist(), [8])
 
-    def test_mlx_scheduler_init_overlap_keeps_future_map_relay(self):
+    @staticmethod
+    def _init_overlap_mlx_scheduler(device: str):
+        """Run ``Scheduler.init_overlap`` on a bare MLX-style scheduler.
+
+        ``device`` is the scheduler's accelerator device; the MLX backend keeps
+        ``req_to_token_pool`` (and hence every ScheduleBatch tensor) on CPU
+        regardless.
+        """
         from sglang.srt.managers import scheduler as scheduler_module
-        from sglang.srt.managers.overlap_utils import RelayPayload
         from sglang.srt.managers.scheduler import Scheduler
         from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
         from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
         scheduler = object.__new__(Scheduler)
-        scheduler.device = "cpu"
+        scheduler.device = device
         scheduler.draft_worker = None
         scheduler.tp_worker = SimpleNamespace(
             model_runner=SimpleNamespace(attn_backend=None)
@@ -440,6 +449,36 @@ class TestMlxAuxiliaryStateRunnerCache(unittest.TestCase):
             Scheduler.init_overlap(scheduler)
         finally:
             scheduler_module.use_mlx = original_use_mlx
+        return scheduler
+
+    @unittest.skipUnless(_HAS_MPS, "requires the mps device")
+    def test_mlx_scheduler_future_map_follows_req_pool_device(self):
+        """``--disable-overlap-schedule`` relays ``next_token_ids`` through
+        ``FutureMap.stash`` with the batch's CPU ``req_pool_indices`` and the
+        MLX worker's CPU tokens. A FutureMap built on the scheduler's "mps"
+        device only survived that by PyTorch's one-element CPU-scalar
+        exception: the first batch with two requests raised
+        "Expected all tensors to be on the same device". The relay must live
+        on the req_to_token_pool's device.
+        """
+        from sglang.srt.managers.overlap_utils import RelayPayload
+
+        scheduler = self._init_overlap_mlx_scheduler(device="mps")
+
+        indices = torch.tensor([1, 2], dtype=torch.int64)
+        scheduler.future_map.stash(
+            indices,
+            RelayPayload(bonus_tokens=torch.tensor([7, 9], dtype=torch.int64)),
+        )
+        self.assertEqual(
+            scheduler.future_map.output_tokens_buf[indices].tolist(), [7, 9]
+        )
+        self.assertEqual(scheduler.future_map.output_tokens_buf.device.type, "cpu")
+
+    def test_mlx_scheduler_init_overlap_keeps_future_map_relay(self):
+        from sglang.srt.managers.overlap_utils import RelayPayload
+
+        scheduler = self._init_overlap_mlx_scheduler(device="cpu")
 
         self.assertIsNotNone(scheduler.future_map)
         indices = torch.tensor([1], dtype=torch.int64)


### PR DESCRIPTION
## AI Disclosure
Fable helped me track down and repro this issue. I reviewed the code myself. 

## Motivation

`--disable-overlap-schedule` is listed as a supported flag in the Apple Silicon docs, but on the MLX backend the server crashes on the first batch that contains two or more requests:

```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, mps:0 and cpu!
  File "sglang/srt/managers/scheduler.py", line 4480, in _relay_forward_payload
  File "sglang/srt/managers/overlap_utils.py", line 608, in stash
```

Repro on an M4 Pro:

```bash
SGLANG_USE_MLX=1 python -m sglang.launch_server --model-path Qwen/Qwen3-0.6B \
  --disable-cuda-graph --max-total-tokens 32768 --disable-overlap-schedule
# send the same prompt twice, or any two concurrent requests
```

**Root cause.** `Scheduler.init_overlap` creates the `FutureMap` on `self.device`, which is `"mps"` on MLX. But the MLX backend keeps `req_to_token_pool`, every `ScheduleBatch` tensor, and the worker's `next_token_ids` on CPU. `FutureMap.stash` does `output_tokens_buf[req_pool_indices] = next_token_ids` with CPU index and value tensors against an mps buffer. PyTorch tolerates a one-element CPU value there (the CPU-scalar exception), so single-request batches worked by accident, and the first two-request batch raised.

## Modifications

- `Scheduler.init_overlap`: pass `self.req_to_token_pool.device` to `create_future_map` instead of `self.device`. The `FutureMap` is indexed by `req_pool_idx` and only ever meets batch tensors, so the pool device is the correct one. On CUDA the two are the same device, so this is a no-op there.
- `test/registered/unit/hardware_backend/mlx/test_attention_patching.py`: extract the existing `init_overlap` scheduler setup into `_init_overlap_mlx_scheduler(device)` and add `test_mlx_scheduler_future_map_follows_req_pool_device`, which runs `init_overlap` with the scheduler device set to `"mps"` and stashes a two-row CPU payload. It fails with the error above without the fix and is skipped where MPS is unavailable.

## Accuracy Tests

Not applicable, no change to model forward code. Verified on M4 Pro with Qwen3-0.6B.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not needed.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35048542152](https://github.com/sgl-project/sglang/actions/runs/35048542152)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35048541981](https://github.com/sgl-project/sglang/actions/runs/35048541981)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35048542094](https://github.com/sgl-project/sglang/actions/runs/35048542094)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->
