### PR TITLE
[OpenAI] Share PD/DP routing fields and adapter across entrypoints

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -325,7 +325,33 @@ def _migrate_deprecated_dp_rank(values: dict) -> dict:
     return values
 
 
-class CompletionRequest(BaseModel):
+class OpenAISglangRoutingFields(BaseModel):
+    bootstrap_host: Optional[Union[List[str], str]] = Field(
+        default=None,
+        description="[SGLang extension] PD disaggregation: prefill host address",
+    )
+    bootstrap_port: Optional[Union[List[Optional[int]], int]] = Field(
+        default=None, description="[SGLang extension] PD disaggregation: prefill port"
+    )
+    bootstrap_room: Optional[Union[List[int], int]] = Field(
+        default=None,
+        description="[SGLang extension] PD disaggregation: bootstrap room ID",
+    )
+    routed_dp_rank: Optional[int] = Field(
+        default=None,
+        description="[SGLang extension] DP routing: external router assigns a specific DP worker",
+    )
+    disagg_prefill_dp_rank: Optional[int] = Field(
+        default=None,
+        description="[SGLang extension] PD disaggregation: hint telling decode which prefill DP worker has the KV cache",
+    )
+    data_parallel_rank: Optional[int] = Field(
+        default=None,
+        description="[SGLang extension] Deprecated: use routed_dp_rank instead",
+    )
+
+
+class CompletionRequest(OpenAISglangRoutingFields):
     # Ordered by official OpenAI API documentation
     # https://platform.openai.com/docs/api-reference/completions/create
     model: str = Field(
@@ -377,18 +403,6 @@ class CompletionRequest(BaseModel):
     custom_logit_processor: Optional[str] = None
 
     images_config: Optional[Dict] = None
-
-    # For PD disaggregation
-    bootstrap_host: Optional[Union[List[str], str]] = None
-    bootstrap_port: Optional[Union[List[Optional[int]], int]] = None
-    bootstrap_room: Optional[Union[List[int], int]] = None
-
-    # For DP routing — external router assigns a specific DP worker
-    routed_dp_rank: Optional[int] = None
-    # For PD disagg — hint telling decode which prefill DP worker has the KV cache
-    disagg_prefill_dp_rank: Optional[int] = None
-    # Deprecated: use routed_dp_rank instead
-    data_parallel_rank: Optional[int] = None
 
     # For request id
     rid: Optional[Union[List[str], str]] = None
@@ -840,7 +854,7 @@ def _has_message_level_tools(messages: Any) -> bool:
     )
 
 
-class ChatCompletionRequest(BaseModel):
+class ChatCompletionRequest(OpenAISglangRoutingFields):
     # Ordered by official OpenAI API documentation
     # https://platform.openai.com/docs/api-reference/chat/create
     messages: List[ChatCompletionMessageParam]
@@ -956,18 +970,6 @@ class ChatCompletionRequest(BaseModel):
     cache_salt: Optional[Union[List[str], str]] = None
     # Priority for the request
     priority: Optional[int] = None
-
-    # For PD disaggregation
-    bootstrap_host: Optional[Union[List[str], str]] = None
-    bootstrap_port: Optional[Union[List[Optional[int]], int]] = None
-    bootstrap_room: Optional[Union[List[int], int]] = None
-
-    # For DP routing — external router assigns a specific DP worker
-    routed_dp_rank: Optional[int] = None
-    # For PD disagg — hint telling decode which prefill DP worker has the KV cache
-    disagg_prefill_dp_rank: Optional[int] = None
-    # Deprecated: use routed_dp_rank instead
-    data_parallel_rank: Optional[int] = None
 
     # OpenAI/SGLang default sampling parameters
     _DEFAULT_SAMPLING_PARAMS = {
@@ -1596,7 +1598,7 @@ ResponseInputOutputItem: TypeAlias = Union[
 ]
 
 
-class ResponsesRequest(BaseModel):
+class ResponsesRequest(OpenAISglangRoutingFields):
     """Request body for v1/responses endpoint."""
 
     # Core OpenAI API fields (ordered by official documentation)
@@ -1651,18 +1653,6 @@ class ResponsesRequest(BaseModel):
     cache_salt: Optional[str] = Field(
         default=None, description="Cache salt for request caching"
     )
-
-    # For PD disaggregation
-    bootstrap_host: Optional[Union[List[str], str]] = None
-    bootstrap_port: Optional[Union[List[Optional[int]], int]] = None
-    bootstrap_room: Optional[Union[List[int], int]] = None
-
-    # For DP routing — external router assigns a specific DP worker
-    routed_dp_rank: Optional[int] = None
-    # For PD disagg — hint telling decode which prefill DP worker has the KV cache
-    disagg_prefill_dp_rank: Optional[int] = None
-    # Deprecated: use routed_dp_rank instead
-    data_parallel_rank: Optional[int] = None
 
     # SGLang sampling extras. ``None`` defers to ``--preferred-sampling-params``.
     frequency_penalty: float = 0.0

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -11,7 +11,13 @@ from fastapi import HTTPException, Request
 from fastapi.responses import ORJSONResponse, StreamingResponse
 
 from sglang.srt.entrypoints.openai.encoding_dsv32 import DS32EncodingError
-from sglang.srt.entrypoints.openai.protocol import ErrorResponse, OpenAIServingRequest
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    CompletionRequest,
+    ErrorResponse,
+    OpenAIServingRequest,
+    ResponsesRequest,
+)
 from sglang.srt.managers.io_struct import EmbeddingReqInput, GenerateReqInput
 from sglang.srt.observability.req_time_stats import monotonic_time
 from sglang.srt.runtime_context import get_observability
@@ -257,6 +263,21 @@ class OpenAIServingBase(ABC):
         if raw_request is None:
             return None
         return raw_request.headers.get("x-smg-routing-key")
+
+    def _extract_generation_routing(
+        self,
+        request: Union[ChatCompletionRequest, CompletionRequest, ResponsesRequest],
+        raw_request: Optional[Request],
+    ) -> dict[str, Any]:
+        return {
+            "bootstrap_host": request.bootstrap_host,
+            "bootstrap_port": request.bootstrap_port,
+            "bootstrap_room": request.bootstrap_room,
+            "routed_dp_rank": self.extract_routed_dp_rank_from_header(
+                raw_request, request.routed_dp_rank
+            ),
+            "disagg_prefill_dp_rank": request.disagg_prefill_dp_rank,
+        }
 
     def extract_routed_dp_rank_from_header(
         self, raw_request: Request, body_routed_dp_rank: Optional[int] = None

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1138,9 +1138,7 @@ class OpenAIServingChat(OpenAIServingBase):
         custom_labels = self.extract_custom_labels(raw_request)
 
         # Extract routed_dp_rank from header (has higher priority than body)
-        effective_routed_dp_rank = self.extract_routed_dp_rank_from_header(
-            raw_request, request.routed_dp_rank
-        )
+        generation_routing = self._extract_generation_routing(request, raw_request)
 
         # Resolve LoRA adapter from model parameter or explicit lora_path
         lora_path = self._resolve_lora_path(request.model, request.lora_path)
@@ -1161,11 +1159,7 @@ class OpenAIServingChat(OpenAIServingBase):
             return_text_in_logprobs=True,
             modalities=processed_messages.modalities,
             lora_path=lora_path,
-            bootstrap_host=request.bootstrap_host,
-            bootstrap_port=request.bootstrap_port,
-            bootstrap_room=request.bootstrap_room,
-            routed_dp_rank=effective_routed_dp_rank,
-            disagg_prefill_dp_rank=request.disagg_prefill_dp_rank,
+            **generation_routing,
             return_hidden_states=request.return_hidden_states,
             return_routed_experts=request.return_routed_experts,
             routed_experts_start_len=request.routed_experts_start_len,

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -105,9 +105,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
         custom_labels = self.extract_custom_labels(raw_request)
 
         # Extract routed_dp_rank from header (has higher priority than body)
-        effective_routed_dp_rank = self.extract_routed_dp_rank_from_header(
-            raw_request, request.routed_dp_rank
-        )
+        generation_routing = self._extract_generation_routing(request, raw_request)
 
         # Resolve LoRA adapter from model parameter or explicit lora_path
         lora_path = self._resolve_lora_path(request.model, request.lora_path)
@@ -121,11 +119,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
             return_text_in_logprobs=True,
             stream=request.stream,
             lora_path=lora_path,
-            bootstrap_host=request.bootstrap_host,
-            bootstrap_port=request.bootstrap_port,
-            bootstrap_room=request.bootstrap_room,
-            routed_dp_rank=effective_routed_dp_rank,
-            disagg_prefill_dp_rank=request.disagg_prefill_dp_rank,
+            **generation_routing,
             return_hidden_states=request.return_hidden_states,
             return_routed_experts=request.return_routed_experts,
             routed_experts_start_len=request.routed_experts_start_len,

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -435,8 +435,8 @@ class OpenAIServingResponses(OpenAIServingChat):
                         else {}
                     )
 
-                    effective_routed_dp_rank = self.extract_routed_dp_rank_from_header(
-                        raw_request, request.routed_dp_rank
+                    generation_routing = self._extract_generation_routing(
+                        request, raw_request
                     )
 
                     adapted_request = GenerateReqInput(
@@ -468,11 +468,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                         session_id=request.session_id,
                         extra_key=request.extra_key,
                         cache_salt=request.cache_salt,
-                        bootstrap_host=request.bootstrap_host,
-                        bootstrap_port=request.bootstrap_port,
-                        bootstrap_room=request.bootstrap_room,
-                        routed_dp_rank=effective_routed_dp_rank,
-                        disagg_prefill_dp_rank=request.disagg_prefill_dp_rank,
+                        **generation_routing,
                         # background+stream streams on this connection, so don't detach.
                         background=request.background and not request.stream,
                         require_reasoning=require_reasoning,

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -2580,7 +2580,9 @@ class OpenAIServingResponses(OpenAIServingChat):
             # Render the updated conversation for the next completion
             prompt_token_ids = context.render_for_completion()
 
-            # Update the adapted request with new prompt
+            # Update the adapted request with new prompt.
+            # PD routing fields are intentionally not carried over: this continuation
+            # has no matching prefill, and bootstrap_room is a consume-once slot.
             adapted_request = GenerateReqInput(
                 input_ids=prompt_token_ids,
                 sampling_params=sampling_params,


### PR DESCRIPTION
Converge three identical PD/DP routing field declarations into OpenAISglangRoutingFields, extract a shared serving adapter, and document why builtin-tool continuation drops routing metadata.

## What

Three commits:
1. Share the request routing adapter across generation entrypoints — one `_extract_generation_routing()` helper on `OpenAIServingBase` replaces three identical five-key forwarding blocks in serving_chat / serving_completions / serving_responses. Header precedence (X-Data-Parallel-Rank) is preserved.
2. Document why builtin-tool continuation drops PD routing — a PD tool continuation has no matching prefill; upstream #39122 now rejects such continuations before side effects. The comment records the constraint.
3. Share and annotate SGLang request extension fields — the six PD/DP routing fields (bootstrap_host/port/room, routed_dp_rank, disagg_prefill_dp_rank, deprecated data_parallel_rank) move into `OpenAISglangRoutingFields`, inherited by CompletionRequest / ChatCompletionRequest / ResponsesRequest, each annotated `[SGLang extension]`. Extension fields occupy schema positions 0-5; official fields keep relative order. Types, defaults, and validators are unchanged.

## Validation (CPU, rebased on latest main)

- 334 tests passed: test_protocol (43), test_serving_chat (135+), test_serving_completions (19), test_responses_protocol (22), plus test_serving_responses / test_responses_custom_tools / test_chat_prompt_round_trip / test_serving_responses_stream
- 60 direct routing cases (header precedence, alias migration, list-valued bootstrap fields)
- Schema comparison across all three request classes: identical except the six intended descriptions and property ordering
- Pre-commit hooks pass

## Notes

- Field set is unchanged from the previous version of this PR; rebased onto latest main with one comment corrected after upstream #39122 added a PD builtin-tool admission guard.
- No GPU behavior change; distributed PD behavior not exercised (routing metadata only).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35737600640](https://github.com/sgl-project/sglang/actions/runs/35737600640)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #35737874064](https://github.com/sgl-project/sglang/actions/runs/35737874064)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35737600802](https://github.com/sgl-project/sglang/actions/runs/35737600802)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->