### PR TITLE
[Spec] Budget the DFLASH draft KV pool at the attention group's width

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
+++ b/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
@@ -7,8 +7,10 @@ import msgspec
 
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.runtime_context import (
+    configured_attn_cp_size,
     configured_tp_size,
     get_model,
+    get_parallel,
     get_spec,
 )
 
@@ -238,11 +240,20 @@ def _resolve_dflash_draft_cell_size(
                 get_spec().speculative_draft_attention_backend
             ),
         )
+        # Configured sizes, not live ones: this runs before dist init. The
+        # draft pool is later built at the attention group's width (attn_tp),
+        # and under DP-attention that is narrower than the global TP group —
+        # tp_size shards the draft heads across ranks that never share them,
+        # under-counting the pool each rank actually allocates.
+        attn_dp_size = (
+            get_parallel().dp_size if get_parallel().enable_dp_attention else 1
+        )
+        attn_tp_size = configured_tp_size() // attn_dp_size // configured_attn_cp_size()
         return dflash_draft_cell_size_per_token(
             draft_model_config=draft_model_config,
             draft_num_layers=draft_num_layers,
             draft_kv_cache_dtype=draft_kv_cache_dtype,
-            tp_size=configured_tp_size(),
+            tp_size=attn_tp_size,
         )
     except Exception as e:  # noqa: BLE001
         logger.warning(

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -940,6 +940,53 @@ class TestDflashDraftKvBudget(CustomTestCase):
             0,
         )
 
+    def test_dp_attention_budgets_draft_pool_at_attention_tp(self):
+        """Under DP-attention the draft pool is budgeted at the attention
+        group's width, not the global TP group's. The global tp_size shards
+        the draft heads across ranks that never share them, so the budget
+        under-counts the pool each rank allocates and boot OOMs at
+        mem-fraction-static values the target alone fits.
+        """
+        import torch
+
+        from sglang.srt.model_executor.model_runner_components.spec_aux_hidden_state import (
+            _resolve_dflash_draft_cell_size,
+        )
+        from sglang.srt.runtime_context import get_server_args
+
+        # 8 kv heads sharded the way ModelConfig.get_num_kv_heads does.
+        draft = SimpleNamespace(
+            get_num_kv_heads=lambda tp_size, dcp_size=1: max(1, 8 // tp_size),
+            head_dim=128,
+            v_head_dim=128,
+            dtype=torch.bfloat16,
+        )
+
+        def _cell(**parallel_fields):
+            _publish_config(
+                self,
+                tp_size=8,
+                attn_cp_size=1,
+                kv_cache_dtype="auto",
+                **parallel_fields,
+            )
+            return _resolve_dflash_draft_cell_size(
+                server_args=get_server_args(),
+                draft_model_config=draft,
+                draft_num_layers=5,
+            )
+
+        # tp8/dp8: attn_tp=1, the rank keeps all 8 heads.
+        self.assertEqual(
+            _cell(dp_size=8, enable_dp_attention=True),
+            8 * (128 + 128) * 5 * KV_SIZE,
+        )
+        # Without DP-attention the attention group is the whole TP group.
+        self.assertEqual(
+            _cell(dp_size=1, enable_dp_attention=False),
+            1 * (128 + 128) * 5 * KV_SIZE,
+        )
+
     def test_dcp_replication_scales_draft_budget(self):
         """The replicated draft pool spans every DCP virtual location."""
         draft_kv_per_token = 10_240


### PR DESCRIPTION
## Motivation

The DFLASH-family (DSpark) draft KV pool **budget** cell is priced at the
global `tp_size`, but the pool each rank actually allocates is built at the
**attention group's width** (`attn_tp`). Under DP-attention these differ:

- budget: `_resolve_dflash_draft_cell_size` → `get_num_kv_heads(tp_size)` —
  shards the draft heads across the whole TP group
  (`spec_aux_hidden_state.py`, `tp_size=configured_tp_size()`)
- runtime: `kv_cache_configurator` → `get_num_kv_heads(attn_tp_size, attn_dcp_size)`

Drafts never join the TP attention group, so under DP-attention the budget
under-counts the draft term by the DP factor.

Repro (v0.5.19 image, 8×H200, GLM-5.2-W4AFP8 target + AlayaNeW/GLM-5.2-DSpark
draft, `--tp-size 8 --dp-size 8 --enable-dp-attention`):

- budget cell: 69.6 KB/token vs real 139.4 KB/token (8 KV heads × 256 B ×
  5 layers × fp8) → token count overshoot ~2×
- **before:** `CUDA OOM` at boot with `--mem-fraction-static 0.80`
  (`memory_pool.py`, draft KV buffer); `0.66` survives only by overshoot luck
  and actually pins ~90% of the card
- **after:** boots at `0.80` with a correctly-sized pool (332,864-token KV
  pool, 22.4 GB still free per rank), spec decoding healthy (accept length
  2.0–3.6), outputs byte-identical to the non-spec server (greedy verify)

TP-only serving is unaffected (`attn_tp == tp`); EAGLE/MTP drafts reuse the
target attention and are priced by layer count off the target cell, also
unaffected.

## Modifications

`_resolve_dflash_draft_cell_size` now prices the draft cell at the attention
group's width, derived from configured leaves (it runs before dist init):

```python
attn_dp_size = get_parallel().dp_size if get_parallel().enable_dp_attention else 1
attn_tp_size = configured_tp_size() // attn_dp_size // configured_attn_cp_size()
```

— the same arithmetic as `_compute_parallelism_ranks`
(`entrypoints/engine.py`). This also covers `attn_cp > 1`, where the budget
had the same under-count.

## Accuracy Tests

Pool sizing only — no model forward, kernel, or decode-path change. Outputs
are byte-identical before/after (greedy spec-verify invariant; verified in
the 8×H200 A/B above).

New unit test (fails on pre-fix code, passes after):
`test/registered/unit/model_executor/test_pool_configurator.py::TestDflashDraftKvBudget::test_dp_attention_budgets_draft_pool_at_attention_tp`
— publishes `tp_size=8, dp_size=8, enable_dp_attention=True` and asserts the
resolved cell carries all 8 KV heads per rank (plus a no-DP control case).

Full files pass locally (CPU env): 41 passed
(`test_pool_configurator.py` + `test_spec_aux_hidden_state.py`).

## Speed Tests and Profiling

No decode-path change; speed is unaffected. The effect is boot-time memory
accounting: under-counted budgets forced DP-attention DSpark users to lower
`--mem-fraction-static` blindly (or OOM at boot).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). *(no user-facing flags/behavior semantics changed — none needed)*
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). *(see Accuracy Tests — sizing-only change, output-invariance verified)*
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->