### PR TITLE
Force reasoning mode for GLM-5.3 chat templates

### DIFF
--- a/python/sglang/srt/parser/template_detection.py
+++ b/python/sglang/srt/parser/template_detection.py
@@ -169,6 +169,13 @@ REASONING_MODE_RULES = (
         ),
     ),
     DetectionRule(
+        name="glm53_always_think",
+        value=ReasoningToggleConfig(special_case="always"),
+        # The generation prompt opens <think> unconditionally, so output starts
+        # inside reasoning; lambda because _is_glm53 is defined below.
+        predicate=lambda ctx: _is_glm53(ctx),
+    ),
+    DetectionRule(
         name="mistral_reasoning_effort",
         value=ReasoningToggleConfig(special_case="mistral"),
         predicate=lambda ctx: (

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -42,7 +42,11 @@ from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.jinja_template_utils import (
     jinja_template_may_reorder_tool_results,
 )
-from sglang.srt.parser.template_detection import ReasoningToggleConfig
+from sglang.srt.parser.reasoning_parser import ReasoningParser
+from sglang.srt.parser.template_detection import (
+    ReasoningToggleConfig,
+    detect_reasoning_pattern,
+)
 from sglang.srt.runtime_context import get_context, publish, reset_context
 from sglang.srt.sampling.sampling_params import (
     REQUEST_REASONING_END_TOKEN_IDS_KEY,
@@ -268,6 +272,17 @@ class TestChatTemplateCache(CustomTestCase):
         )
         self.assertEqual(self.tokenizer_manager.tokenizer.encode.call_count, 2)
         self.tokenizer_manager.tokenizer.decode.assert_not_called()
+
+
+# Minimal GLM-5.3 detection signature; the absent ``enable_thinking`` toggle
+# is part of it, not an omission for brevity.
+_GLM53_TEMPLATE = (
+    "[gMASK]<sop>"
+    "<|system|>Reasoning Effort: {{ reasoning_effort | capitalize }}"
+    "{{- '<tool_call>' + tc.name -}}"
+    "<arg_key>{{ k }}</arg_key><arg_value>{{ v }}</arg_value></tool_call>"
+    "<|assistant|>{{- '<think>' -}}"
+)
 
 
 class ServingChatTestCase(unittest.TestCase):
@@ -799,6 +814,40 @@ class ServingChatTestCase(unittest.TestCase):
             processed = self.chat._process_messages(request, is_multimodal=False)
 
         self.assertTrue(processed.require_reasoning)
+
+    def test_glm53_keeps_reasoning_split_when_request_disables_thinking(self):
+        """A request that disables thinking must not un-split GLM-5.3 reasoning;
+        the template opens ``<think>`` regardless, so content would keep the
+        closing tag."""
+        force, config = detect_reasoning_pattern(_GLM53_TEMPLATE)
+        self.template_manager.force_reasoning = force
+        self.template_manager.reasoning_config = config
+        self.chat.reasoning_parser = "glm45"
+        self.chat._reasoning_detector = ReasoningParser("glm45").detector
+
+        for kwargs in (
+            {"reasoning_effort": "none"},
+            {"chat_template_kwargs": {"enable_thinking": False}},
+        ):
+            with self.subTest(**kwargs):
+                request = ChatCompletionRequest(
+                    model="x",
+                    messages=[{"role": "user", "content": "What is 17*23?"}],
+                    **kwargs,
+                )
+                require_reasoning = (
+                    self.template_manager.force_reasoning
+                    or self.chat._get_reasoning_from_request(request)
+                )
+                reasoning, content = ReasoningParser(
+                    self.chat.reasoning_parser,
+                    force_reasoning=require_reasoning,
+                    request=request,
+                ).parse_non_stream("17*23 = 391</think>391")
+
+                self.assertTrue(require_reasoning)
+                self.assertEqual(reasoning, "17*23 = 391")
+                self.assertEqual(content, "391")
 
     def test_kimi_tool_call_respects_explicit_reasoning_disable(self):
         self.template_manager.reasoning_config = ReasoningToggleConfig(

--- a/test/registered/unit/parser/test_template_manager.py
+++ b/test/registered/unit/parser/test_template_manager.py
@@ -117,10 +117,8 @@ class TestTemplateManagerReasoningDetection(unittest.TestCase):
                 )
 
     def test_glm53_effort_template_forces_reasoning(self):
-        # The GLM-5.3 generation prompt ends in ``<|assistant|><think>``, so the
-        # model only ever emits the closing ``</think>``. Without always-on
-        # reasoning the parser never opens a reasoning block and the whole
-        # completion -- stray ``</think>`` included -- lands in ``content``.
+        """GLM-5.3 templates must detect as always-on reasoning; their generation
+        prompt opens ``<think>``, so output carries only the closing tag."""
         vocab = ["<tool_call>", "<arg_key>", "<arg_value>", "<|user|>", "<|endoftext|>"]
         for concat in ("+", "~"):
             with self.subTest(concat=concat):
@@ -129,18 +127,6 @@ class TestTemplateManagerReasoningDetection(unittest.TestCase):
                 self.assertTrue(force)
                 self.assertEqual(config, ReasoningToggleConfig(special_case="always"))
                 self.assertTrue(config.always_on)
-
-    def test_glm53_reasoning_parser_splits_output_without_opening_think(self):
-        # Real GLM-5.3-Flash output for "What is 17*23?" is ``17*23 = 391</think>391``
-        # -- there is no opening ``<think>`` to key off.
-        from sglang.srt.parser.reasoning_parser import ReasoningParser
-
-        reasoning, content = ReasoningParser(
-            "glm45", force_reasoning=True
-        ).parse_non_stream("17*23 = 391</think>391")
-
-        self.assertEqual(reasoning, "17*23 = 391")
-        self.assertEqual(content, "391")
 
     def test_interns1_detects_enable_thinking_default_true(self):
         template = """

--- a/test/registered/unit/parser/test_template_manager.py
+++ b/test/registered/unit/parser/test_template_manager.py
@@ -116,6 +116,32 @@ class TestTemplateManagerReasoningDetection(unittest.TestCase):
                     "glm47",
                 )
 
+    def test_glm53_effort_template_forces_reasoning(self):
+        # The GLM-5.3 generation prompt ends in ``<|assistant|><think>``, so the
+        # model only ever emits the closing ``</think>``. Without always-on
+        # reasoning the parser never opens a reasoning block and the whole
+        # completion -- stray ``</think>`` included -- lands in ``content``.
+        vocab = ["<tool_call>", "<arg_key>", "<arg_value>", "<|user|>", "<|endoftext|>"]
+        for concat in ("+", "~"):
+            with self.subTest(concat=concat):
+                force, config, _ = self._detect(_glm53_template(concat), vocab)
+
+                self.assertTrue(force)
+                self.assertEqual(config, ReasoningToggleConfig(special_case="always"))
+                self.assertTrue(config.always_on)
+
+    def test_glm53_reasoning_parser_splits_output_without_opening_think(self):
+        # Real GLM-5.3-Flash output for "What is 17*23?" is ``17*23 = 391</think>391``
+        # -- there is no opening ``<think>`` to key off.
+        from sglang.srt.parser.reasoning_parser import ReasoningParser
+
+        reasoning, content = ReasoningParser(
+            "glm45", force_reasoning=True
+        ).parse_non_stream("17*23 = 391</think>391")
+
+        self.assertEqual(reasoning, "17*23 = 391")
+        self.assertEqual(content, "391")
+
     def test_interns1_detects_enable_thinking_default_true(self):
         template = """
         {% set default_thinking_sys %}...<think>...</think>{% endset %}


### PR DESCRIPTION
> The `glm53_always_think` rule is @b8zhong's work, and the commit keeps his authorship. This PR is
> that rule alone, rebased onto current `main` without the `--reasoning-parser=auto` default it
> originally shipped alongside, plus a regression test.

## Motivation

GLM-5.3 templates open `<think>` in the generation prompt, so the model emits only the closing tag:

```
prompt   ...<|assistant|><think>
output   </think>391            # live zai-org/GLM-5.3-Flash, "What is 17*23?"
```

No rule recognizes these templates, so `detect_reasoning_pattern` returns `(False, None)`. `Glm45Detector` opens reasoning on `_in_reasoning or "<think>" in text` — with no opening tag, the split rests entirely on `force_reasoning`:

| request | force_reasoning | reasoning_content | content |
|---|---|---|---|
| ordinary | `True` (fallback) | `17*23 = 391` | `391` |
| `reasoning_effort: "none"` | `False` | `null` | `17*23 = 391</think>391` |
| `chat_template_kwargs: {enable_thinking: false}` | `False` | `null` | `17*23 = 391</think>391` |

Ordinary requests already work: `reasoning_config is None` falls back to `Glm45Detector.reasoning_default` (`"enable_thinking"`). Both failing rows resolve to `chat_template_kwargs={'enable_thinking': False}` — a toggle GLM-5.3 removed, so the prompt opens `<think>` regardless and the parser is told not to expect it.

Observed in #38297, deferred to #37977. #37977 does not close it: its rule sets no `special_case`, so `has_toggle` is false, `reasoning_toggle_config` is `None`, and the same fallback applies.

## Modifications

`parser/template_detection.py`, one rule:

```python
DetectionRule(
    name="glm53_always_think",
    value=ReasoningToggleConfig(special_case="always"),
    predicate=lambda ctx: _is_glm53(ctx),
)
```

| | |
|---|---|
| predicate | `_is_glm53` from #38297 — requires `[gMASK]<sop>` and **no** `enable_thinking`, so GLM-4.5/4.6/4.7 keep their toggle rules |
| parser selection | unchanged; #38297 already resolves `glm45` / `glm47` |
| explicit flags | also fixed — `force_reasoning` comes from `detect_reasoning_pattern`, not the flag |
| tests | detection — `test_glm53_effort_template_forces_reasoning` goes red without the rule; the request-level gate it feeds is pinned by `test_get_reasoning_from_request_special_cases` |

### Requests that ask for thinking off

`special_case="always"` short-circuits `_get_reasoning_from_request` before any request-level
toggle, so `reasoning_effort: "none"` and `chat_template_kwargs: {enable_thinking: false}` keep
reasoning on instead of un-splitting it. On the Anthropic endpoint an explicit
`thinking: {"type": "disabled"}` now returns 400 (`always-on and cannot be disabled`) instead
of writing an `enable_thinking` kwarg the template ignores.

### Conflicts with #37977

Both rules match both shipped templates; `detect_reasoning_pattern` takes the first match.

```
RadixArk/GLM-5.3-NVFP4:  _is_glm53=True  glm53_reasoning_effort=True
zai-org/GLM-5.3-Flash:   _is_glm53=True  glm53_reasoning_effort=True
```

| | rule | index | value |
|---|---|---|---|
| this PR | `glm53_always_think` | 3 of 11 | `special_case="always"` |
| #37977 | `glm53_reasoning_effort` | last | `effort_levels` + `effort_aliases` |

Whichever merges second is dead code for GLM-5.3 — the leak reopens, or the aliasing never reaches the only model it targets. Collapse into one:

```python
ReasoningToggleConfig(
    special_case="always",
    effort_levels=("low", "high", "max"),
    effort_aliases=(("none", "low"), ("minimal", "low"), ("medium", "high"), ("xhigh", "max")),
)
```

`has_toggle` becomes true and `_get_reasoning_from_request` hits the `special_case == "always"` branch, while `toggle_param` / `effort_kwarg` stay `None` so `_apply_jinja_template`, `_get_reasoning_toggle_param` and `apply_reasoning_enabled` are unchanged. Either merge order works.

## Tests

zai-org/GLM-5.3-Flash, 4x GB300, `--tp 4 --reasoning-parser glm45 --tool-call-parser glm47`, temp 0, "What is 17*23?" — same server, rule reverted in place for the baseline:

| request | `reasoning_tokens` | `reasoning_content` | `content` |
|---|---|---|---|
| **without the rule** ||||
| ordinary | 27 | `17 * 23 = ... = 391` | `391` |
| `reasoning_effort: "none"` | 0 | `null` | `17 * 23 = ... = 391</think>391` |
| `chat_template_kwargs: {enable_thinking: false}` | 0 | `null` | `17 * 23 = ... = 391</think>391` |
| **with the rule** ||||
| all three | 27 | `17 * 23 = ... = 391` | `391` |

`reasoning_tokens: 0` is what reaches downstream consumers — sgl-eval records it as `num_reasoning_tokens` and charges the thinking tokens to `num_answer_tokens` instead.

Detection on the fixed server:

```
Auto-detected template features: reasoning_config=ReasoningToggleConfig(..., special_case='always'), reasoning_parser=glm45, tool_call_parser=glm47
```

Both models, parsers resolved to `glm45` / `glm47`:

| model | check | result |
|---|---|---|
| zai-org/GLM-5.3-Flash, RadixArk/GLM-5.3-NVFP4 | non-streaming split | `raw == reasoning + "</think>" + content`, byte-for-byte |
| zai-org/GLM-5.3-Flash | streaming vs non-streaming, temp 0 | byte-identical |
| both | tool call | `tool_calls` parsed, `finish_reason: tool_calls`, `content: ""`, no `</think>` leak |
| zai-org/GLM-5.3-Flash | multi-turn tool round-trip | tool result consumed, clean final content |

Unit: 675 passed across `test/registered/unit/parser/`, `test_serving_chat.py`, `test_serving_responses.py`, `entrypoints/anthropic/test_serving.py`. Reverting the rule fails `test_glm53_effort_template_forces_reasoning`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34864558101](https://github.com/sgl-project/sglang/actions/runs/34864558101)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #34929476813](https://github.com/sgl-project/sglang/actions/runs/34929476813)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34864558020](https://github.com/sgl-project/sglang/actions/runs/34864558020)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
