### PR TITLE
[Spec] Stabilize the DP adaptive tier vote: shared EMA + min dwell

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2134,6 +2134,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     is_extend_in_batch: bool = False
     can_run_dp_cuda_graph: bool = False
     can_run_dp_breakable_cuda_graph: bool = False
+    # DP-consensus adaptive speculative num_steps (min across ranks); None when
+    # adaptive spec is off or no rank expressed a tier this round.
+    adaptive_consensus_steps: Optional[int] = None
     tbo_split_seq_index: Optional[int] = None
     # Rank-consistent forward mode for the recv skipper, derived from the MLP
     # sync all-gather (the TBO-only `global_forward_mode` is None without TBO).

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -76,6 +76,11 @@ def _resolve_elastic_world_dp_size(
     return live_dp_size
 
 
+# Sentinel emitted by ranks that are idle or not running adaptive spec, so a
+# `.min()` reduce never lets them force everyone to a lower speculative tier.
+ADAPTIVE_STEPS_SENTINEL = 2**31 - 1
+
+
 @dataclass
 class MLPSyncBatchInfo:
     dp_size: int
@@ -89,9 +94,15 @@ class MLPSyncBatchInfo:
     is_extend_in_batch: bool
     local_can_run_tbo: bool
     local_forward_mode: int
+    # Locally-desired adaptive speculative num_steps for this rank's batch.
+    # Gathered and min-reduced so every DP rank runs the same tier (equal
+    # draft-token shapes → no NCCL buffer mismatch). Sentinel = no preference.
+    local_adaptive_steps: int = ADAPTIVE_STEPS_SENTINEL
 
     # some gathered elements
     tp0_info_cpu: torch.Tensor = None
+    # min-reduced consensus tier across DP ranks; sentinel if none expressed.
+    consensus_adaptive_steps: int = ADAPTIVE_STEPS_SENTINEL
     global_num_tokens: list[int] = None
     global_num_tokens_for_logprob: list[int] = None
     tbo_split_seq_index: torch.Tensor = None
@@ -108,6 +119,7 @@ class MLPSyncBatchInfo:
                 int(self.local_can_run_tbo),
                 self.local_forward_mode,
                 int(self.can_run_prefill_cuda_graph),
+                self.local_adaptive_steps,
             ],
             device=device,
             dtype=dtype,
@@ -123,6 +135,7 @@ class MLPSyncBatchInfo:
                 1,  # local_can_run_tbo
                 ForwardMode.IDLE.value,  # local_forward_mode
                 0,  # can_run_prefill_cuda_graph
+                ADAPTIVE_STEPS_SENTINEL,  # local_adaptive_steps (idle: no vote)
             ],
             device=device,
             dtype=dtype,
@@ -194,6 +207,9 @@ class MLPSyncBatchInfo:
         self.can_run_decode_cuda_graph = bool(tp0_info_cpu[:, 2].min())
         self.is_extend_in_batch = bool(tp0_info_cpu[:, 3].max())
         self.can_run_prefill_cuda_graph = bool(tp0_info_cpu[:, 6].min())
+        # Smaller tier is always a valid shape for every rank; larger is not.
+        # Idle/non-adaptive ranks emit the sentinel and never win the min.
+        self.consensus_adaptive_steps = int(tp0_info_cpu[:, 7].min())
         if _ENABLE_METRICS_DP_ATTENTION:
             self.dp_cooperation_info = DPCooperationInfo.create(
                 tp0_info_cpu[:, 5].tolist()
@@ -321,6 +337,19 @@ def prepare_mlp_sync_batch_raw(
         group = tp_group.cpu_group
         device = "cpu"
 
+    # Each rank votes its locally-desired adaptive tier; min-reduced below so
+    # all ranks run identical draft-token shapes (no NCCL buffer mismatch).
+    local_adaptive_steps = ADAPTIVE_STEPS_SENTINEL
+    adaptive_params = getattr(model_runner, "adaptive_spec_params", None)
+    if (
+        adaptive_params is not None
+        and local_batch is not None
+        and local_batch.forward_mode.is_decode()
+    ):
+        local_adaptive_steps = adaptive_params.get_steps_for_batch(
+            local_batch.batch_size()
+        )
+
     local_can_run_tbo, local_forward_mode = tbo_preparer.prepare_all_gather(local_batch)
     if use_world_group:
         dp_size = _resolve_elastic_world_dp_size(
@@ -341,6 +370,7 @@ def prepare_mlp_sync_batch_raw(
         is_extend_in_batch=is_extend_in_batch,
         local_can_run_tbo=local_can_run_tbo,
         local_forward_mode=local_forward_mode,
+        local_adaptive_steps=local_adaptive_steps,
     )
 
     if not skip_all_gather:
@@ -376,13 +406,26 @@ def prepare_mlp_sync_batch_raw(
             batch_to_gather, mlp_sync_info, require_mlp_tp_gather, skip_all_gather
         )
 
-    # Set on `local_batch`, not `batch_to_gather`: for PREBUILT batches the
-    # scheduler's `last_batch` is the prebuilt batch, not its inner idle batch.
+    # recv_skipper is read by the scheduler from `last_batch`, which for a
+    # PREBUILT batch is the prebuilt batch itself (not its inner idle batch) —
+    # so this field must live on `local_batch`.
     if local_batch is not None and not skip_all_gather:
         local_batch.recv_skipper_forward_mode = (
             SchedulerRecvSkipper.derive_forward_mode(
                 mlp_sync_info.tp0_info_cpu[:, 5].tolist()
             )
+        )
+
+    # DP-consensus adaptive tier for this round; None when no rank expressed one
+    # (all sentinel) → worker falls back to local batch-size routing. This is
+    # read by the worker from the batch it actually forwards, so it must live on
+    # `batch_to_gather` — for a PREBUILT batch that is the inner idle batch, not
+    # `local_batch`. Writing it to `local_batch` would leave the forwarded idle
+    # batch at None and let ranks diverge on num_draft_tokens (NCCL hang).
+    if batch_to_gather is not None and not skip_all_gather:
+        consensus = mlp_sync_info.consensus_adaptive_steps
+        batch_to_gather.adaptive_consensus_steps = (
+            consensus if consensus < ADAPTIVE_STEPS_SENTINEL else None
         )
 
     if _ENABLE_METRICS_DP_ATTENTION and local_batch is not None:

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -98,11 +98,19 @@ class MLPSyncBatchInfo:
     # Gathered and min-reduced so every DP rank runs the same tier (equal
     # draft-token shapes → no NCCL buffer mismatch). Sentinel = no preference.
     local_adaptive_steps: int = ADAPTIVE_STEPS_SENTINEL
+    # Config key of the adaptive BS slot this rank's batch routes to, and that
+    # slot's EMA as int(ema * 1000) fixed point (-1 = no contribution, e.g.
+    # idle / not decoding). Gathered so every rank can fold the cross-rank
+    # per-slot mean into its slot — the shared-EMA vote (see fresh_vote()).
+    local_adaptive_slot_bs: int = -1
+    local_adaptive_ema_fp: int = -1
 
     # some gathered elements
     tp0_info_cpu: torch.Tensor = None
     # min-reduced consensus tier across DP ranks; sentinel if none expressed.
     consensus_adaptive_steps: int = ADAPTIVE_STEPS_SENTINEL
+    # per-slot cross-rank mean EMA (slot config key → ema) for the fold.
+    adaptive_shared_ema: dict[int, float] = None
     global_num_tokens: list[int] = None
     global_num_tokens_for_logprob: list[int] = None
     tbo_split_seq_index: torch.Tensor = None
@@ -120,6 +128,8 @@ class MLPSyncBatchInfo:
                 self.local_forward_mode,
                 int(self.can_run_prefill_cuda_graph),
                 self.local_adaptive_steps,
+                self.local_adaptive_slot_bs,
+                self.local_adaptive_ema_fp,
             ],
             device=device,
             dtype=dtype,
@@ -136,6 +146,8 @@ class MLPSyncBatchInfo:
                 ForwardMode.IDLE.value,  # local_forward_mode
                 0,  # can_run_prefill_cuda_graph
                 ADAPTIVE_STEPS_SENTINEL,  # local_adaptive_steps (idle: no vote)
+                -1,  # local_adaptive_slot_bs (idle: no EMA contribution)
+                -1,  # local_adaptive_ema_fp
             ],
             device=device,
             dtype=dtype,
@@ -210,6 +222,18 @@ class MLPSyncBatchInfo:
         # Smaller tier is always a valid shape for every rank; larger is not.
         # Idle/non-adaptive ranks emit the sentinel and never win the min.
         self.consensus_adaptive_steps = int(tp0_info_cpu[:, 7].min())
+        # Shared-EMA fold input: per-slot mean of the gathered fixed-point
+        # EMAs, computed identically on every rank. Rows with slot key -1
+        # (idle / not decoding / not adaptive) contribute nothing.
+        per_slot_fp: dict[int, list[int]] = {}
+        for slot_bs, ema_fp in zip(
+            tp0_info_cpu[:, -2].tolist(), tp0_info_cpu[:, -1].tolist()
+        ):
+            if slot_bs >= 0:
+                per_slot_fp.setdefault(int(slot_bs), []).append(int(ema_fp))
+        self.adaptive_shared_ema = {
+            bs: sum(fps) / len(fps) / 1000.0 for bs, fps in per_slot_fp.items()
+        }
         if _ENABLE_METRICS_DP_ATTENTION:
             self.dp_cooperation_info = DPCooperationInfo.create(
                 tp0_info_cpu[:, 5].tolist()
@@ -337,18 +361,26 @@ def prepare_mlp_sync_batch_raw(
         group = tp_group.cpu_group
         device = "cpu"
 
-    # Each rank votes its locally-desired adaptive tier; min-reduced below so
+    # Each rank votes the tier a pure threshold walk over the DP-shared EMA
+    # selects right now (see AdaptiveStepSlot.fresh_vote); min-reduced below so
     # all ranks run identical draft-token shapes (no NCCL buffer mismatch).
+    # The vote is evaluated fresh every round, never read off a locally
+    # recomputed current_steps, so per-rank update_interval timing cannot
+    # diverge the votes. The slot key + EMA ride the same gather so every rank
+    # can fold the cross-rank mean EMA into its slot.
     local_adaptive_steps = ADAPTIVE_STEPS_SENTINEL
+    local_adaptive_slot_bs = -1
+    local_adaptive_ema_fp = -1
     adaptive_params = getattr(model_runner, "adaptive_spec_params", None)
     if (
         adaptive_params is not None
         and local_batch is not None
         and local_batch.forward_mode.is_decode()
     ):
-        local_adaptive_steps = adaptive_params.get_steps_for_batch(
-            local_batch.batch_size()
-        )
+        bs = local_batch.batch_size()
+        local_adaptive_steps = adaptive_params.fresh_steps_for_batch(bs)
+        local_adaptive_slot_bs = adaptive_params.slot_key_for_batch(bs)
+        local_adaptive_ema_fp = int(adaptive_params.get_ema_for_batch(bs) * 1000)
 
     local_can_run_tbo, local_forward_mode = tbo_preparer.prepare_all_gather(local_batch)
     if use_world_group:
@@ -371,6 +403,8 @@ def prepare_mlp_sync_batch_raw(
         local_can_run_tbo=local_can_run_tbo,
         local_forward_mode=local_forward_mode,
         local_adaptive_steps=local_adaptive_steps,
+        local_adaptive_slot_bs=local_adaptive_slot_bs,
+        local_adaptive_ema_fp=local_adaptive_ema_fp,
     )
 
     if not skip_all_gather:
@@ -427,6 +461,11 @@ def prepare_mlp_sync_batch_raw(
         batch_to_gather.adaptive_consensus_steps = (
             consensus if consensus < ADAPTIVE_STEPS_SENTINEL else None
         )
+        # Shared-EMA fold: every rank adopts the same per-slot mean EMA, so
+        # the next round's fresh vote is identical on every rank and the
+        # min() consensus degenerates to a no-op safety net.
+        if mlp_sync_info.adaptive_shared_ema and adaptive_params is not None:
+            adaptive_params.fold_shared_ema(mlp_sync_info.adaptive_shared_ema)
 
     if _ENABLE_METRICS_DP_ATTENTION and local_batch is not None:
         local_batch.dp_cooperation_info = mlp_sync_info.dp_cooperation_info

--- a/python/sglang/srt/speculative/adaptive_runtime_state.py
+++ b/python/sglang/srt/speculative/adaptive_runtime_state.py
@@ -71,13 +71,22 @@ class AdaptiveController:
       2. Call on_verify_complete(num_correct_drafts_per_req) after each decode verify.
     """
 
-    def __init__(self, worker: AdaptiveSpecWorker, config_path: str | None = None):
+    def __init__(
+        self,
+        worker: AdaptiveSpecWorker,
+        config_path: str | None = None,
+        sync_across_dp: bool = False,
+    ):
         self.worker = worker
         self.params = AdaptiveSpeculativeParams(
             initial_steps=worker.speculative_num_steps,
             cfg_path=config_path,
         )
         self._states: dict[int, SpecRuntimeState] = {}
+        # Under DP attention the tier swap is driven by a cross-rank consensus
+        # (dp_attn min-reduce) so all ranks keep equal draft-token shapes. The
+        # local EMA path must then only *update* params, never swap directly.
+        self.sync_across_dp = sync_across_dp
 
     @property
     def candidate_steps(self) -> list[int]:
@@ -115,14 +124,25 @@ class AdaptiveController:
         if target != self.worker.speculative_num_steps:
             self._activate(target)
 
+    def activate_step(self, speculative_num_steps: int) -> None:
+        """Activate an externally-decided tier (e.g. the DP-consensus step)."""
+        if speculative_num_steps != self.worker.speculative_num_steps:
+            self._activate(speculative_num_steps)
+
     def on_verify_complete(
         self, num_correct_drafts_per_req: list[int], batch_size: int
     ) -> None:
-        """Feed verify results; switch runtime state if EMA warrants it."""
+        """Feed verify results; switch runtime state if EMA warrants it.
+
+        Under DP attention only the EMA is updated here — the actual tier swap
+        is deferred to the next round's cross-rank consensus, so a rank never
+        swaps out of lockstep with its peers (which would mismatch draft-token
+        shapes and hang the DP collective).
+        """
         new_step = self.params.on_verify_complete(
             num_correct_drafts_per_req, batch_size
         )
-        if new_step is not None:
+        if new_step is not None and not self.sync_across_dp:
             self._activate(new_step)
 
     def _activate(self, speculative_num_steps: int) -> None:

--- a/python/sglang/srt/speculative/adaptive_runtime_state.py
+++ b/python/sglang/srt/speculative/adaptive_runtime_state.py
@@ -1,7 +1,11 @@
+import logging
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
 from sglang.srt.speculative.adaptive_spec_params import AdaptiveSpeculativeParams
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -87,6 +91,15 @@ class AdaptiveController:
         # (dp_attn min-reduce) so all ranks keep equal draft-token shapes. The
         # local EMA path must then only *update* params, never swap directly.
         self.sync_across_dp = sync_across_dp
+        if sync_across_dp and os.environ.get(
+            "SGLANG_SCHEDULER_SKIP_ALL_GATHER", ""
+        ) == "1":
+            logger.warning(
+                "SGLANG_SCHEDULER_SKIP_ALL_GATHER=1 disables the DP MLP-sync "
+                "all_gather that carries the adaptive tier consensus — ranks "
+                "will diverge on num_draft_tokens (NCCL shape mismatch / hang). "
+                "Do not combine with --speculative-adaptive under dp-attention."
+            )
 
     @property
     def candidate_steps(self) -> list[int]:
@@ -124,8 +137,17 @@ class AdaptiveController:
         if target != self.worker.speculative_num_steps:
             self._activate(target)
 
-    def activate_step(self, speculative_num_steps: int) -> None:
-        """Activate an externally-decided tier (e.g. the DP-consensus step)."""
+    def activate_step(
+        self, speculative_num_steps: int, batch_size: int | None = None
+    ) -> None:
+        """Activate an externally-decided tier (e.g. the DP-consensus step).
+
+        Under DP the slot's tier mirrors the consensus activation — never a
+        local recompute — and a tier change re-arms min-dwell so the
+        shared-EMA vote cannot flip the tier again within the dwell window.
+        """
+        if batch_size is not None:
+            self.params.apply_consensus(batch_size, speculative_num_steps)
         if speculative_num_steps != self.worker.speculative_num_steps:
             self._activate(speculative_num_steps)
 
@@ -134,15 +156,19 @@ class AdaptiveController:
     ) -> None:
         """Feed verify results; switch runtime state if EMA warrants it.
 
-        Under DP attention only the EMA is updated here — the actual tier swap
-        is deferred to the next round's cross-rank consensus, so a rank never
-        swaps out of lockstep with its peers (which would mismatch draft-token
-        shapes and hang the DP collective).
+        Under DP attention only the EMA is updated here — the tier is decided
+        by the fresh shared-EMA vote in every round's MLP-sync consensus, so a
+        rank never swaps out of lockstep with its peers (which would mismatch
+        draft-token shapes and hang the DP collective), and a local
+        recompute can never desync per-rank ``current_steps``.
         """
+        if self.sync_across_dp:
+            self.params.update_ema_only(num_correct_drafts_per_req, batch_size)
+            return
         new_step = self.params.on_verify_complete(
             num_correct_drafts_per_req, batch_size
         )
-        if new_step is not None and not self.sync_across_dp:
+        if new_step is not None:
             self._activate(new_step)
 
     def _activate(self, speculative_num_steps: int) -> None:

--- a/python/sglang/srt/speculative/adaptive_runtime_state.py
+++ b/python/sglang/srt/speculative/adaptive_runtime_state.py
@@ -91,9 +91,10 @@ class AdaptiveController:
         # (dp_attn min-reduce) so all ranks keep equal draft-token shapes. The
         # local EMA path must then only *update* params, never swap directly.
         self.sync_across_dp = sync_across_dp
-        if sync_across_dp and os.environ.get(
-            "SGLANG_SCHEDULER_SKIP_ALL_GATHER", ""
-        ) == "1":
+        if (
+            sync_across_dp
+            and os.environ.get("SGLANG_SCHEDULER_SKIP_ALL_GATHER", "") == "1"
+        ):
             logger.warning(
                 "SGLANG_SCHEDULER_SKIP_ALL_GATHER=1 disables the DP MLP-sync "
                 "all_gather that carries the adaptive tier consensus — ranks "

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -64,11 +64,10 @@ def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
             f"speculative_eagle_topk={server_args.speculative_eagle_topk} "
             "(only topk=1 is supported)"
         )
-    if resolved_view(server_args).enable_dp_attention:
-        return (
-            "enable_dp_attention=True is not supported "
-            "(adaptive tier decisions are not synchronized across DP ranks)"
-        )
+    # enable_dp_attention IS supported: tier decisions are synchronized across
+    # DP ranks via a min-reduce in the scheduler's MLP-sync all_gather
+    # (dp_attn.MLPSyncBatchInfo.local_adaptive_steps), so all ranks run equal
+    # draft-token shapes. See AdaptiveController(sync_across_dp=...).
     if resolved_view(server_args).enable_multi_layer_eagle:
         return (
             "enable_multi_layer_eagle=True is not supported "

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -160,6 +160,10 @@ class AdaptiveStepSlot:
         self.down_hysteresis = cfg.get("down_hysteresis", -0.25)
         self.up_hysteresis = cfg.get("up_hysteresis", 0.0)
         self.ceiling_coeff = cfg.get("ceiling_coeff", 0)
+        # Min-dwell: after a tier change, hold the new tier for this many
+        # verify rounds before another change is allowed (0 = off). Damps
+        # threshold-straddling oscillation, both TP-local and DP-shared.
+        self.min_dwell_batches = cfg.get("min_dwell_batches", 0)
 
         if initial_steps in self.candidate_steps:
             self.current_steps = initial_steps
@@ -169,6 +173,23 @@ class AdaptiveStepSlot:
         # Initialize EMA at current steps - 1 (neutral starting point)
         self.ema_accept_len = float(self.current_steps - 1)
         self._batch_count = 0
+        self._dwell_remaining = 0
+        # Cross-rank (mean) EMA folded in from the DP MLP-sync all_gather.
+        # The DP vote is a pure function of this + current_steps, so every
+        # rank computes an identical vote (None until the first fold).
+        self.shared_ema_accept_len: float | None = None
+
+    def update_ema(self, num_correct_drafts_per_req: list[int]) -> None:
+        """Fold one verify round into the EMA. No tier decision."""
+        if not num_correct_drafts_per_req:
+            return
+        if self.current_steps > 0:
+            batch_avg = sum(num_correct_drafts_per_req) / len(
+                num_correct_drafts_per_req
+            )
+            self.ema_accept_len = (
+                1 - self.ema_alpha
+            ) * self.ema_accept_len + self.ema_alpha * batch_avg
 
     def update(self, num_correct_drafts_per_req: list[int]) -> bool:
         """Update EMA with observed accept lengths. Returns True if params changed.
@@ -179,13 +200,7 @@ class AdaptiveStepSlot:
         if not num_correct_drafts_per_req:
             return False
 
-        if self.current_steps > 0:
-            batch_avg = sum(num_correct_drafts_per_req) / len(
-                num_correct_drafts_per_req
-            )
-            self.ema_accept_len = (
-                1 - self.ema_alpha
-            ) * self.ema_accept_len + self.ema_alpha * batch_avg
+        self.update_ema(num_correct_drafts_per_req)
 
         self._batch_count += 1
         if self._batch_count <= self.warmup_batches:
@@ -194,16 +209,82 @@ class AdaptiveStepSlot:
         if (self._batch_count - self.warmup_batches) % self.update_interval != 0:
             return False
 
+        if self._dwell_remaining > 0:
+            self._dwell_remaining -= 1
+            return False
+
         return self._recompute_params()
+
+    def fresh_vote(self) -> int:
+        """Tier a pure threshold walk over the EMA selects right now.
+
+        Under DP attention the gathered vote must be a deterministic function
+        of state every rank already shares — the folded cross-rank EMA and the
+        consensus-activated tier — never of when each rank's local
+        `update_interval` last fired, or per-rank timing diverges the votes.
+        """
+        if self._dwell_remaining > 0:
+            return self.current_steps
+        ema = (
+            self.shared_ema_accept_len
+            if self.shared_ema_accept_len is not None
+            else self.ema_accept_len
+        )
+        return self.candidate_steps[self._walk_target_idx(ema)]
+
+    def apply_consensus(self, steps: int) -> None:
+        """Mirror the DP-consensus activation into the slot; re-arm min-dwell."""
+        if steps != self.current_steps:
+            self.current_steps = steps
+            self._dwell_remaining = self.min_dwell_batches
+
+    def fold_shared_ema(self, ema: float) -> None:
+        """Adopt the cross-rank (mean) EMA carried by the MLP-sync all_gather."""
+        self.shared_ema_accept_len = ema
+
+    def _walk_target_idx(self, ema: float) -> int:
+        """Pure threshold walk: candidate idx *ema* selects (no mutation)."""
+        old_idx = self.candidate_steps.index(self.current_steps)
+        current_idx = old_idx
+
+        while current_idx > 0:
+            prev_step = self.candidate_steps[current_idx - 1]
+            # A zero-step candidate disables drafting. Treat zero accepted drafts
+            # as low enough to reach it when it is the floor candidate.
+            drop_threshold = 0.5 if prev_step == 0 else prev_step - 0.5
+            drop_threshold += self.down_hysteresis
+            if ema <= drop_threshold:
+                current_idx -= 1
+            else:
+                break
+
+        if current_idx >= old_idx:
+            while current_idx < len(self.candidate_steps) - 1:
+                current_step = self.candidate_steps[current_idx]
+                rise_threshold = current_step - 0.5 + self.up_hysteresis
+                if ema > rise_threshold:
+                    current_idx += 1
+                else:
+                    break
+
+        # EMA ceiling: only caps downward — never blocks step-ups, so the
+        # system can explore higher steps and let the EMA catch up.
+        if self.ceiling_coeff > 0:
+            ceiling = max(1, math.ceil(ema * self.ceiling_coeff))
+            target = self.candidate_steps[current_idx]
+            if target > ceiling and target <= self.candidate_steps[old_idx]:
+                while current_idx > 0 and self.candidate_steps[current_idx] > ceiling:
+                    current_idx -= 1
+
+        return current_idx
 
     def _recompute_params(self) -> bool:
         """Recompute steps from EMA. Returns True if params changed."""
         old_steps = self.current_steps
-        current_idx = self.candidate_steps.index(old_steps)
-        old_idx = current_idx
 
         # Probe the smallest positive step after a zero-step nospec interval.
         if old_steps == 0:
+            current_idx = self.candidate_steps.index(old_steps)
             current_idx = min(current_idx + 1, len(self.candidate_steps) - 1)
             target = self.candidate_steps[current_idx]
             if target > 0 and self.ema_accept_len < 0:
@@ -213,42 +294,13 @@ class AdaptiveStepSlot:
             return self._apply_target_steps(old_steps, target)
 
         # TODO: Consider limiting step changes to avoid overshooting.
-        while current_idx > 0:
-            prev_step = self.candidate_steps[current_idx - 1]
-            # A zero-step candidate disables drafting. Treat zero accepted drafts
-            # as low enough to reach it when it is the floor candidate.
-            drop_threshold = 0.5 if prev_step == 0 else prev_step - 0.5
-            drop_threshold += self.down_hysteresis
-            if self.ema_accept_len <= drop_threshold:
-                current_idx -= 1
-            else:
-                break
-
-        moved_down = current_idx < old_idx
-        if not moved_down:
-            while current_idx < len(self.candidate_steps) - 1:
-                current_step = self.candidate_steps[current_idx]
-                rise_threshold = current_step - 0.5 + self.up_hysteresis
-                if self.ema_accept_len > rise_threshold:
-                    current_idx += 1
-                else:
-                    break
-
-        target = self.candidate_steps[current_idx]
-        # EMA ceiling: only caps downward — never blocks step-ups, so the
-        # system can explore higher steps and let the EMA catch up.
-        if self.ceiling_coeff > 0:
-            ceiling = max(1, math.ceil(self.ema_accept_len * self.ceiling_coeff))
-            if target > ceiling and target <= old_steps:
-                while current_idx > 0 and self.candidate_steps[current_idx] > ceiling:
-                    current_idx -= 1
-                target = self.candidate_steps[current_idx]
-
+        target = self.candidate_steps[self._walk_target_idx(self.ema_accept_len)]
         return self._apply_target_steps(old_steps, target)
 
     def _apply_target_steps(self, old_steps: int, target: int) -> bool:
         if target != old_steps:
             self.current_steps = target
+            self._dwell_remaining = self.min_dwell_batches
             log_info_on_rank0(
                 logger,
                 f"Adaptive spec params updated: steps {old_steps} -> {target} "
@@ -298,6 +350,35 @@ class AdaptiveSpeculativeParams:
 
     def get_steps_for_batch(self, batch_size: int) -> int:
         return self._route(batch_size).current_steps
+
+    def fresh_steps_for_batch(self, batch_size: int) -> int:
+        """DP vote: tier the pure shared-EMA threshold walk selects now."""
+        return self._route(batch_size).fresh_vote()
+
+    def slot_key_for_batch(self, batch_size: int) -> int:
+        """Config key of the slot *batch_size* routes to (DP EMA-fold key)."""
+        return self._find_closest_bs(self._pad_to_cuda_graph_bs(batch_size))
+
+    def get_ema_for_batch(self, batch_size: int) -> float:
+        """Live EMA of the routed slot (contributed to the DP gather)."""
+        return self._route(batch_size).ema_accept_len
+
+    def update_ema_only(
+        self, num_correct_drafts_per_req: list[int], batch_size: int
+    ) -> None:
+        """DP mode: feed verify results to the EMA, no local tier decision."""
+        self._route(batch_size).update_ema(num_correct_drafts_per_req)
+
+    def fold_shared_ema(self, per_slot_ema: dict[int, float]) -> None:
+        """Adopt per-slot cross-rank mean EMAs gathered over DP."""
+        for bs, ema in per_slot_ema.items():
+            slot = self._slots.get(bs)
+            if slot is not None:
+                slot.fold_shared_ema(ema)
+
+    def apply_consensus(self, batch_size: int, steps: int) -> None:
+        """Sync the routed slot's tier to the DP-consensus activation."""
+        self._route(batch_size).apply_consensus(steps)
 
     def on_verify_complete(
         self, num_correct_drafts_per_req: list[int], batch_size: int

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1047,6 +1047,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             self.adaptive_controller = AdaptiveController(
                 self,
                 config_path=server_args.speculative_adaptive_config,
+                sync_across_dp=server_args.enable_dp_attention,
             )
 
         # Some dummy tensors
@@ -1104,6 +1105,12 @@ class EAGLEWorkerV2(BaseSpecWorker):
                         else get_exec().graph.cuda_graph_bs_decode
                     ),
                 )
+            # Expose the (live, EMA-updated) router on the target model_runner so
+            # the scheduler's DP MLP-sync can gather each rank's desired tier and
+            # min-reduce it into a cross-rank consensus (see dp_attn.py).
+            self._target_worker.model_runner.adaptive_spec_params = (
+                self.adaptive_controller.params
+            )
 
     def forward_batch_generation(
         self, batch: ScheduleBatch, on_publish=None, grammar_barrier=None
@@ -1145,7 +1152,13 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 )
                 return batch_output
         else:
-            self.activate_step_by_batch(batch.seq_lens.shape[0])
+            # Under DP attention the tier was agreed across ranks during the
+            # scheduler's MLP-sync all_gather; honor that consensus so every
+            # rank runs identical draft-token shapes. Otherwise route locally.
+            if batch.adaptive_consensus_steps is not None:
+                self.activate_step(batch.adaptive_consensus_steps)
+            else:
+                self.activate_step_by_batch(batch.seq_lens.shape[0])
 
             if batch.spec_info is None:
                 capture_mode = (
@@ -1298,6 +1311,10 @@ class EAGLEWorkerV2(BaseSpecWorker):
     def activate_step_by_batch(self, batch_size: int) -> None:
         if self.adaptive_controller is not None:
             self.adaptive_controller.activate_step_by_batch(batch_size)
+
+    def activate_step(self, speculative_num_steps: int) -> None:
+        if self.adaptive_controller is not None:
+            self.adaptive_controller.activate_step(speculative_num_steps)
 
     # -- Adaptive speculative decoding protocol --
 

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1156,7 +1156,10 @@ class EAGLEWorkerV2(BaseSpecWorker):
             # scheduler's MLP-sync all_gather; honor that consensus so every
             # rank runs identical draft-token shapes. Otherwise route locally.
             if batch.adaptive_consensus_steps is not None:
-                self.activate_step(batch.adaptive_consensus_steps)
+                self.activate_step(
+                    batch.adaptive_consensus_steps,
+                    batch_size=int(batch.seq_lens.shape[0]),
+                )
             else:
                 self.activate_step_by_batch(batch.seq_lens.shape[0])
 
@@ -1312,9 +1315,13 @@ class EAGLEWorkerV2(BaseSpecWorker):
         if self.adaptive_controller is not None:
             self.adaptive_controller.activate_step_by_batch(batch_size)
 
-    def activate_step(self, speculative_num_steps: int) -> None:
+    def activate_step(
+        self, speculative_num_steps: int, batch_size: int | None = None
+    ) -> None:
         if self.adaptive_controller is not None:
-            self.adaptive_controller.activate_step(speculative_num_steps)
+            self.adaptive_controller.activate_step(
+                speculative_num_steps, batch_size=batch_size
+            )
 
     # -- Adaptive speculative decoding protocol --
 

--- a/test/registered/spec/eagle/test_adaptive_speculative_dp_attention.py
+++ b/test/registered/spec/eagle/test_adaptive_speculative_dp_attention.py
@@ -1,0 +1,187 @@
+"""Adaptive speculative decoding under data-parallel attention (multi-GPU).
+
+Regression guard for the DP-attention consensus path: when --enable-dp-attention
+is set, each DP rank must activate the *same* adaptive tier every decode step.
+A divergent tier means a divergent num_draft_tokens -> divergent
+global_dp_buffer_len -> mismatched NCCL collective shapes -> hang. The consensus
+(min over per-rank desired tiers, carried on the existing MLP-sync all_gather)
+keeps every rank in lockstep, so a tier switch that changes the draft-token width
+mid-flight must still complete rather than deadlock.
+
+Topology: --tp 2 --dp 2 --enable-dp-attention -> 2 GPUs, 2 DP-attention groups.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_DRAFT_MODEL_EAGLE,
+    DEFAULT_TARGET_MODEL_EAGLE,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=300, stage="extra-a", runner_config="2-gpu-large")
+register_amd_ci(est_time=360, stage="extra-a", runner_config="2-gpu-large-amd")
+
+# A batch big enough that, split across 2 DP ranks by the auto load balancer,
+# every rank still lands at BS >= 8 (the high-load tier's routing key).
+HIGH_LOAD_BATCH = 24
+
+
+class TestAdaptiveSpeculativeDPAttentionServer(CustomTestCase):
+    """Adaptive tier switching stays lockstep across DP ranks (no deadlock).
+
+    Config routes BS<8 -> steps=3 (draft width 4) and BS>=8 -> steps=1 (draft
+    width 2), so a rising/falling load forces a *shape-changing* tier switch.
+    Under --enable-dp-attention this only completes if the two ranks agree on
+    the tier; otherwise the verify collective deadlocks.
+    """
+
+    model = DEFAULT_TARGET_MODEL_EAGLE
+    draft_model = DEFAULT_DRAFT_MODEL_EAGLE
+    base_url = DEFAULT_URL_FOR_TEST
+
+    COUNT_PROMPT = "Count from 1 to 400, separated by commas. Output only the numbers."
+
+    @classmethod
+    def setUpClass(cls):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(
+                {
+                    "1": {"candidate_steps": [3], "warmup_batches": 0},
+                    "8": {"candidate_steps": [1], "warmup_batches": 0},
+                },
+                f,
+            )
+            cls.adaptive_config_path = f.name
+
+        try:
+            cls.process = popen_launch_server(
+                cls.model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=[
+                    "--trust-remote-code",
+                    "--attention-backend",
+                    "triton",
+                    "--tp",
+                    "2",
+                    "--dp",
+                    "2",
+                    "--enable-dp-attention",
+                    "--speculative-algorithm",
+                    "EAGLE",
+                    "--speculative-draft-model-path",
+                    cls.draft_model,
+                    "--speculative-num-steps",
+                    "3",
+                    "--speculative-eagle-topk",
+                    "1",
+                    "--speculative-num-draft-tokens",
+                    "4",
+                    "--speculative-adaptive",
+                    "--speculative-adaptive-config",
+                    cls.adaptive_config_path,
+                    "--max-running-requests",
+                    "64",
+                    "--skip-server-warmup",
+                    "--mem-fraction-static",
+                    "0.7",
+                ],
+            )
+        except Exception:
+            os.unlink(cls.adaptive_config_path)
+            raise
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process"):
+            kill_process_tree(cls.process.pid)
+        if os.path.exists(cls.adaptive_config_path):
+            os.unlink(cls.adaptive_config_path)
+
+    def _steps(self) -> int:
+        r = requests.get(self.base_url + "/server_info", timeout=30)
+        self.assertEqual(r.status_code, 200, r.text)
+        return r.json()["internal_states"][0]["speculative_num_steps"]
+
+    def _generate_single(self) -> dict:
+        one = {"temperature": 0, "max_new_tokens": 64, "ignore_eos": True}
+        r = requests.post(
+            self.base_url + "/generate",
+            json={"text": self.COUNT_PROMPT, "sampling_params": one},
+            timeout=600,
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        return r.json()["meta_info"]
+
+    def test_dp_tier_switch_no_deadlock(self):
+        """BS=1 -> steps=3 -> shape-changing switch to steps=1 under load -> back.
+
+        Each phase completing (not timing out) is the deadlock check: a broken
+        consensus lets the ranks diverge on num_draft_tokens and the verify
+        collective hangs. The accept-rate assertions additionally prove drafting
+        actually runs under DP, not just that the server didn't crash.
+        """
+        # Phase 1: BS=1 -> steps=3, drafting active on the serving rank.
+        m1 = self._generate_single()
+        self.assertEqual(self._steps(), 3, "expected steps=3 at BS=1")
+        self.assertGreater(
+            m1["spec_accept_rate"], 0.8, f"not drafting at steps=3 under DP: {m1}"
+        )
+
+        # Phase 2: a 24-way batch splits ~12 per DP rank (>= 8) -> steps=1. Both
+        # ranks must switch to the narrower draft width together, mid-flight.
+        full = {"temperature": 0, "max_new_tokens": 128, "ignore_eos": True}
+        r = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": [self.COUNT_PROMPT] * HIGH_LOAD_BATCH,
+                "sampling_params": [full] * HIGH_LOAD_BATCH,
+            },
+            timeout=600,
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(self._steps(), 1, "BS>=8 did not switch to steps=1 under DP")
+
+        # Phase 3: BS=1 -> steps=3 again, drafting restored (shape widened back).
+        m3 = self._generate_single()
+        self.assertEqual(self._steps(), 3, "did not reopen to steps=3 under DP")
+        self.assertGreater(
+            m3["spec_accept_rate"], 0.8, f"drafting not restored under DP: {m3}"
+        )
+
+    def test_gsm8k_accuracy_under_dp(self):
+        """Correctness is preserved through the adaptive+DP path (no regression),
+        and the lifetime accept-length is reported for the PR evidence trail."""
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=100,
+            num_threads=64,
+        )
+        metrics = run_eval(args)
+        print(f"GSM8K under adaptive+dp-attention: {metrics}")
+        self.assertGreater(metrics["score"], 0.20)
+
+        server_info = requests.get(self.base_url + "/server_info").json()
+        avg_accept_len = server_info["internal_states"][0]["avg_spec_accept_length"]
+        print(f"avg_spec_accept_length (dp)={avg_accept_len:.4f}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_adaptive_spec_params.py
+++ b/test/registered/unit/spec/test_adaptive_spec_params.py
@@ -244,6 +244,103 @@ class TestAdaptiveStepSlot(unittest.TestCase):
         self.assertEqual(params.ceiling_coeff, 0)
 
 
+class TestMinDwellAndSharedEMA(unittest.TestCase):
+    """Stability regressions for the DP-attention consensus path.
+
+    At-scale evidence (GLM-5.2, tp8/dp8, 8k-in/1k-out): the min-reduce
+    consensus thrashed at ~1100 tier switches/h at dp-rank BS~1 because (a)
+    every rank voted from its own noisy EMA and (b) nothing stopped the vote
+    from flipping every update interval. The fix: a shared EMA folded into
+    every rank (votes become an identical pure function of it) plus a
+    per-slot minimum dwell between tier changes.
+    """
+
+    CFG = {
+        "candidate_steps": [1, 3, 7],
+        "ema_alpha": 1.0,
+        "warmup_batches": 0,
+        "update_interval": 1,
+        "up_hysteresis": 0.0,
+        "down_hysteresis": -0.25,
+        "min_dwell_batches": 5,
+    }
+
+    def _slot(self, initial_steps: int) -> AdaptiveStepSlot:
+        return AdaptiveStepSlot(initial_steps=initial_steps, cfg=dict(self.CFG))
+
+    def test_min_dwell_holds_tier_then_expires(self):
+        slot = self._slot(7)
+        # EMA lands between the 1 and 3 tiers: drops 7 -> 3 and arms the
+        # dwell...
+        self.assertTrue(slot.update([2, 2]))
+        self.assertEqual(slot.current_steps, 3)
+        self.assertEqual(slot._dwell_remaining, 5)
+        # ...and holds 3 for the whole dwell even as the EMA keeps falling
+        # past the floor threshold.
+        for _ in range(5):
+            self.assertFalse(slot.update([0, 0]))
+        self.assertEqual(slot.current_steps, 3)
+        # Dwell expired: the vote may continue down to 1.
+        self.assertTrue(slot.update([0, 0]))
+        self.assertEqual(slot.current_steps, 1)
+
+    def test_min_dwell_bounds_switches_under_alternating_load(self):
+        # The thrash regime: accept-length oscillating across the tier
+        # boundary every update. Without dwell this flips ~every update; with
+        # dwell=50 (the production tuning) the same 200 updates produce at
+        # most a handful of switches.
+        cfg = dict(self.CFG)
+        cfg["min_dwell_batches"] = 50
+        slot = AdaptiveStepSlot(initial_steps=3, cfg=cfg)
+        switches = 0
+        for i in range(200):
+            accept = [2, 2] if i % 2 == 0 else [0, 0]
+            if slot.update(accept):
+                switches += 1
+        self.assertLessEqual(switches, 5, f"dwell failed to bound switches: {switches}")
+
+    def test_fresh_vote_uses_shared_ema_not_live_ema(self):
+        slot = self._slot(7)
+        slot.fold_shared_ema(2.0)
+        slot.ema_accept_len = 6.0  # the live per-rank EMA would vote 7
+        self.assertEqual(slot.fresh_vote(), 3)
+        slot.fold_shared_ema(4.8)
+        self.assertEqual(slot.fresh_vote(), 7)
+
+    def test_fresh_vote_is_pinned_by_dwell(self):
+        slot = self._slot(7)
+        slot.apply_consensus(3)
+        slot.fold_shared_ema(5.0)  # would vote 7 again immediately
+        self.assertEqual(slot.fresh_vote(), 3)  # dwell pins the consensus tier
+
+    def test_apply_consensus_mirrors_tier_and_re_arms_dwell(self):
+        slot = self._slot(7)
+        slot.apply_consensus(3)
+        self.assertEqual(slot.current_steps, 3)
+        self.assertEqual(slot._dwell_remaining, 5)
+
+    def test_divergent_rank_emas_fold_to_identical_votes(self):
+        # 8 DP ranks with EMAs spread 1.0..8.0 (the min-of-8 thrash regime):
+        # after folding the same shared mean, every rank must vote identically,
+        # so the min-reduce consensus degenerates to a no-op safety net.
+        ranks = [self._slot(7) for _ in range(8)]
+        for i, rank in enumerate(ranks):
+            rank.ema_accept_len = 1.0 + i
+        mean = sum(rank.ema_accept_len for rank in ranks) / len(ranks)
+        for rank in ranks:
+            rank.fold_shared_ema(mean)
+        votes = {rank.fresh_vote() for rank in ranks}
+        self.assertEqual(len(votes), 1, f"ranks diverged on the vote: {votes}")
+
+    def test_update_ema_only_updates_signal_without_changing_tier(self):
+        # The sync_across_dp path: the local rank only feeds the shared EMA;
+        # the tier moves exclusively via apply_consensus.
+        slot = self._slot(3)
+        slot.update_ema([0] * 4)
+        self.assertEqual(slot.ema_accept_len, 0.0)
+        self.assertEqual(slot.current_steps, 3)
+
+
 class TestAdaptiveSpeculativeParams(unittest.TestCase):
     def test_default_config_loads(self):
         params = AdaptiveSpeculativeParams(initial_steps=3)
@@ -337,6 +434,31 @@ class TestAdaptiveSpeculativeParams(unittest.TestCase):
             f.flush()
             params = AdaptiveSpeculativeParams(initial_steps=3, cfg_path=f.name)
         self.assertEqual(params._slots[1].up_hysteresis, 0.1)
+
+    def test_shared_ema_and_consensus_plumbing(self):
+        # The dp_attn flow per sync round: every rank folds the same per-slot
+        # shared EMA, votes fresh from it, then mirrors the consensus tier
+        # back into the slot (re-arming its dwell).
+        with tempfile.NamedTemporaryFile("w", suffix=".json") as f:
+            json.dump(
+                {"1": {"candidate_steps": [1, 3, 7], "min_dwell_batches": 5}},
+                f,
+            )
+            f.flush()
+            params = AdaptiveSpeculativeParams(initial_steps=7, cfg_path=f.name)
+        self.assertEqual(params.slot_key_for_batch(5), 1)
+        # Boot tier 7; a mid-scale shared EMA votes 3.
+        params.fold_shared_ema({1: 2.0})
+        self.assertEqual(params.fresh_steps_for_batch(5), 3)
+        # The consensus (3) mirrors into the slot and is what the batch sees.
+        params.apply_consensus(batch_size=5, steps=3)
+        self.assertEqual(params.get_steps_for_batch(5), 3)
+        # update_ema_only feeds the signal but never moves the tier by itself.
+        # The live EMA starts at initial_steps-1 = 6.0 and decays toward the
+        # observed 0 accept rate with the default alpha 0.2 -> 4.8.
+        params.update_ema_only([0] * 4, batch_size=5)
+        self.assertEqual(params.get_steps_for_batch(5), 3)
+        self.assertAlmostEqual(params.get_ema_for_batch(5), 4.8)
 
 
 class TestBatchSizeRouting(unittest.TestCase):


### PR DESCRIPTION
# Stabilize the DP adaptive tier vote: shared EMA + min dwell

> **Stacked on #35898** (enablement, still open). Only the last two commits are
> this PR's payload; merge #35898 first and this diff shrinks to them.

## Problem

`--speculative-adaptive` under `--enable-dp-attention` (min-reduce consensus over
the MLP-sync all_gather) ties the fixed config on throughput, but the tier vote
**thrashes**. GLM-5.2 W4AFP8, tp8/dp8/ep8, 8k-in/1k-out offline bench, sglang
v0.5.18 + #35898:

| dp-rank BS~1 (c8) | c16 | c24 |
|---|---|---|
| **~1100 tier switches/h** (perfect 7→3→7→3 alternation) | 298/h | 56/h |

c16 ITL p95 +14% vs fixed. Root causes (all in the pre-fix path):

1. **Asymmetric thresholds × min-of-8**: downshift needs ONE rank below the drop
   threshold, upshift needs ALL ranks above the rise threshold. `min()` over 8
   noisy per-rank EMAs sits below the mean at dp-rank BS~1, so alternating is the
   *steady state*, not an accident.
2. **No dwell**: the vote can flip every `update_interval` (5) batches.
3. **Signal not shared**: only the final vote crosses ranks; the EMA (the actual
   signal) stays per-rank.

## Fix

- **Shared EMA on the existing collective**: `MLPSyncBatchInfo` all_gather gains
  two int columns (`slot_bs`, `int(ema_accept_len * 1000)`); after the gather each
  rank folds the per-slot mean into its slot. No new collective, no dtype change.
- **Vote = pure function of shared state**: every round each rank computes the
  vote fresh from `f(shared_ema, current_steps)` — per-rank update-timing
  differences can no longer produce transiently divergent votes, so `min()`
  degenerates to a no-op safety net. Under `sync_across_dp` the local path only
  feeds the EMA (`update_ema_only`), never recomputes the tier.
- **Min dwell** (`min_dwell_batches` per-slot config knob, default 0 = off):
  after a tier change (local or consensus), further changes are suppressed for N
  batches. Generic — also stabilizes TP-only mode.
- `activate_step` mirrors the consensus tier back into the slot and re-arms its
  dwell, so the runtime state and the vote can't drift apart.
- Warn when `SGLANG_SCHEDULER_SKIP_ALL_GATHER=1` is combined with the DP sync
  path (previously silently divergent).

## Evidence (same box, same workload, both arms mem-fraction 0.75)

Baseline = fixed EAGLE 3/1/4. Adaptive = boot 7/8, candidates [1,3,7],
`min_dwell_batches=50`, 8k1k (R=0.8), CCU ladder, fresh boot each arm:

| CCU | tput tok/s (adaptive vs fixed) | Δ | ITL p50 ms | TTFT p50 ms |
|---|---|---|---|---|
| 8 | 476 vs 482 | −1.2% | 29.6 vs 29.7 | 2104 vs 2083 |
| 16 | 744 vs 749 | −0.7% | 33.3 vs 33.2 | 2335 vs 2322 |
| 24 | 992 vs 964 | **+2.9%** | 35.8 vs 35.8 | 2667 vs 2564 |

**Tier switches over the whole ladder: 1** (7→3 on first traffic; the ladder then
runs entirely at 3/4) — vs 1100/h at c8 pre-fix, ~3 orders of magnitude. Zero
`Missing adaptive runtime state`, zero deadlocks, zero fallback warnings.

Known tail note: c24 ITL p99 +12% in this single run (TPOT p99 and TTFT p99 are
both *better*; no switch occurred during the run to blame) — within single-run
tail variance on 240 samples.

## Tests

`test/registered/unit/spec/test_adaptive_spec_params.py` gains
`TestMinDwellAndSharedEMA` + a params-level plumbing test: dwell hold/expiry,
bounded switches under alternating load, fresh vote from shared (not live) EMA,
consensus mirror + dwell re-arm, **8 slots with EMAs spread 1.0–8.0 folding the
same mean → identical votes** (the exact min-of-8 thrash regime), and
`update_ema_only` never moving the tier. 37/37 pass.

Multi-GPU lockstep coverage stays in #35898's
`test_adaptive_speculative_dp_attention.py`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->