### PR TITLE
[Perf] trtllm_mla: reuse the fused fp8 KV/Q prepare on target verify

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -1483,14 +1483,29 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
 
         # TODO refactor to avoid code duplication
         merge_query = q_rope is not None
+        fused_fp8_query = None
         if (
             self.data_type == torch.float8_e4m3fn
         ) and forward_batch.forward_mode.is_target_verify():
             assert q_rope is not None and k_rope is not None
             if cos_sin_cache is None:
-                q, k, k_rope = mla_quantize_without_rope_for_fp8(
-                    q, q_rope, k.squeeze(1), k_rope.squeeze(1)
-                )
+                if save_kv_cache and self._fused_set_kv_concat_q_fp8:
+                    loc = self._resolve_fused_write_loc(forward_batch)
+                    if loc is not None:
+                        # Fused: bf16->fp8 quantize + KV scatter + q concat
+                        # in one launch; None when not covered.
+                        fused_fp8_query = self._set_kv_and_concat_q_fp8_fused(
+                            layer=layer,
+                            loc=loc,
+                            q=q,
+                            q_rope=q_rope,
+                            k=k,
+                            k_rope=k_rope,
+                        )
+                if fused_fp8_query is None:
+                    q, k, k_rope = mla_quantize_without_rope_for_fp8(
+                        q, q_rope, k.squeeze(1), k_rope.squeeze(1)
+                    )
             else:
                 q, k, k_rope = mla_quantize_and_rope_for_fp8(
                     q,
@@ -1505,8 +1520,8 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 )
             merge_query = False
 
-        # Save KV cache if requested
-        if save_kv_cache:
+        # Save KV cache if requested (the fused fp8 path already wrote it)
+        if save_kv_cache and fused_fp8_query is None:
             assert k is not None and k_rope is not None, (
                 "For populating trtllm_mla kv cache, both k_nope and k_rope should be not None."
             )
@@ -1520,8 +1535,11 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 )
 
         # TODO refactor to avoid code duplication
-        # Prepare query tensor inline
-        if merge_query:
+        # Prepare query tensor inline (already built when the fused fp8 path
+        # ran)
+        if fused_fp8_query is not None:
+            q = fused_fp8_query
+        elif merge_query:
             # For FP16 path, we merge the query and rope parts into a single tensor
             q_nope = q.view(-1, layer.tp_q_head_num, layer.v_head_dim)
             q_rope_reshaped = q_rope.view(


### PR DESCRIPTION
## Motivation

Closes #39107.

`TRTLLMMLABackend.forward_decode` already fuses the fp8 no-RoPE preparation (bf16 -> fp8 quantize + KV scatter + `[q_nope | q_rope]` concat) into one `set_mla_kv_concat_q_fp8` launch. Target verify dispatches through `forward_extend`, which on the same inputs still ran the unfused chain unconditionally: `concat_mla_absorb_q` + three aten fp8 casts + the pool's Triton scatter, i.e. five launches per MLA layer instead of one. This is the `cos_sin_cache is None` case, hit by MLA models with no RoPE on the absorbed path (Kimi K3, `skip_rope=True`); RoPE models take the flashinfer `mla_rope_quantize_fp8` path and are unaffected.

Nothing about the fused kernel is decode-specific: it is per-token / per-(token, head), its q/k row strides are runtime parameters, and the capture-stable write loc (`_decode_kernel_loc`) is already filled for `TARGET_VERIFY` under the unified pool. `CuteDslMLABackend` and `TokenspeedMLABackend` inherit `forward_extend`, so their verify takes the same path (including Kimi K3's default DCP config, which routes verify to cutedsl_mla via `speculative_attention_mode="decode"`).

## Modifications

- `forward_extend`, fp8 + `is_target_verify()` + `cos_sin_cache is None`: try the same guarded fused prepare as decode (`save_kv_cache` and `_fused_set_kv_concat_q_fp8` on, `_resolve_fused_write_loc` yields a loc, `covered_fp8` accepts). On success the pool write and the concat are skipped; otherwise the existing `mla_quantize_without_rope_for_fp8` + `set_mla_kv_buffer` chain runs unchanged. No new kernel and no change to the static gate: this is the dispatch fix from the issue, on the existing CUDA JIT kernel.
- New `test/registered/kernel/attention/test_trtllm_mla_fp8_prepare.py`, on the same bare-backend fixture as `TestFusedFp8WriteGate`: `forward_extend` in `TARGET_VERIFY` takes the fused prepare, writes at the capture-stable loc under a translating pool, and keeps the unfused chain with the gate off, pinned to the aten fp8 reference for the pool rows and the query. The pool's writer is a stand-in that refuses on the fused branch and writes on the fallback.

## Accuracy Tests

The fused kernel produces byte-identical rows and query to the aten chain (`test_kimi_k3_prerequisite_ops` already pins that at batch 64); the new test pins the same contract on the verify path. Draft: the GPU tests have not been run locally yet, and a Kimi K3 + trtllm_mla + fp8 KV + MTP accuracy run is still pending.

## Speed Tests and Profiling

Launch count on the verify prepare drops from 5 to 1 per MLA layer. #39107 reports about 1.8% TPOT on a B300 TP8 dummy Kimi K3 with MTP1 for the same dispatch change; real-weight numbers to follow.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (n/a)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (pending)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34722808673](https://github.com/sgl-project/sglang/actions/runs/34722808673)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34722808589](https://github.com/sgl-project/sglang/actions/runs/34722808589)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34722808693](https://github.com/sgl-project/sglang/actions/runs/34722808693)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->