### PR TITLE
feat(minimax): integrate VibeCUDA MSA on Blackwell

### DIFF
--- a/benchmark/minimax_m3/README.md
+++ b/benchmark/minimax_m3/README.md
@@ -1,0 +1,212 @@
+# MiniMax-M3 FlashInfer MSA end-to-end gate
+
+This gate compares SGLang's standalone `fmha_sm100` path with FlashInfer's
+source-distributed MSA path on the same host, model, software environment, and
+GPU clocks. It also records the Triton fallback as an optional diagnostic.
+
+Use a 4x GB300 node with enough memory for the selected checkpoint. The formal
+setup is `MiniMaxAI/MiniMax-M3-MXFP8` at TP4 with BF16 KV cache,
+`--attention-backend fa4`, page size 128, CUDA Graph enabled, and no speculative
+decoding. The FlashInfer checkout must contain the public
+`flashinfer.msa_ops.{msa_sparse_attention,msa_sparse_decode_attention,msa_topk_select}`
+API and its source files; install it into the same environment as SGLang. Do not
+install a prebuilt JIT cache when validating a source export.
+
+At TP4 the released model supplies the public API with these exact shapes:
+
+- prefill: Q `[total_q, 16, 128]`, K/V `[num_pages, 1, 128, 128]`, sparse
+  indices `[1, total_q, 16]`, cumulative Q lengths `[batch + 1]`, and page
+  table `[batch, max_pages]`;
+- decode: Q `[batch, 16, 128]`, the same paged K/V layout, sparse indices
+  `[1, batch, 16]`, page table `[batch, max_pages]`, sequence lengths `[batch]`,
+  and `seqlen_q=1`.
+
+The public source implementation is selected only for top-k 16, the released
+MiniMax-M3 value. Each sparse layer receives a distinct persistent public
+workspace for each CUDA Graph capture. Q, sparse indices, and length metadata
+are copied into capture-stable buffers; the page table is refreshed in place.
+The warmup stream is synchronized before capture, and replay invokes no Python
+planning API or private plan tuple. Explicit provider selection fails closed on
+a runtime rejection, so an A/B run cannot silently turn into a Triton fallback.
+
+Run the two servers sequentially on the same idle node. Keep every launch flag
+identical except the provider. The compatibility baseline needs its existing
+decode-under-graph opt-in; setting it for both launches keeps the comparison
+explicit and symmetric. This gate disables the dynamic-request prefill BCG so
+both providers exercise their own eager prefill while decode remains captured:
+
+```bash
+COMMON_ARGS=(
+  --model-path MiniMaxAI/MiniMax-M3-MXFP8
+  --trust-remote-code
+  --reasoning-parser auto
+  --tool-call-parser auto
+  --tp 4
+  --attention-backend fa4
+  --page-size 128
+  --moe-runner-backend deep_gemm
+  --chunked-prefill-size 8192
+  --mem-fraction-static 0.75
+  --disable-prefill-cuda-graph
+)
+
+# baseline
+SGLANG_OPT_USE_MSA_DECODE_UNDER_GRAPH=1 \
+SGLANG_MINIMAX_MSA_BACKEND=fmha_sm100 \
+  python -m sglang.launch_server "${COMMON_ARGS[@]}"
+
+# candidate
+SGLANG_OPT_USE_MSA_DECODE_UNDER_GRAPH=1 \
+SGLANG_MINIMAX_MSA_BACKEND=flashinfer \
+  python -m sglang.launch_server "${COMMON_ARGS[@]}"
+
+# optional fallback reference
+SGLANG_DISABLE_MSA=1 python -m sglang.launch_server "${COMMON_ARGS[@]}"
+```
+
+Before any measured run, freeze both accuracy inputs. Download GPQA-Diamond
+once, then build the LongBench subset with the candidate model's tokenizer:
+
+```bash
+curl -fL \
+  https://openaipublic.blob.core.windows.net/simple-evals/gpqa_diamond.csv \
+  -o /shared/eval/gpqa_diamond.csv
+
+python benchmark/minimax_m3/build_longbench_subset.py \
+  --model MiniMaxAI/MiniMax-M3-MXFP8 \
+  --num-examples 100 --min-tokens 32768 --max-tokens 524288 \
+  --output /shared/eval/longbench_v2_m3_100_min32k.json
+```
+
+The builder maps LongBench-v2's six human-readable `domain` labels to the
+canonical SGLang task-category names before balancing the subset. The manifest
+records that mapping, the per-category counts, and the tokenizer-observed
+minimum and maximum prompt lengths.
+
+The preflight is offline and fail-closed. When `--output` is omitted it writes
+no evidence file, although the real plan-ABI probe may populate the configured
+session JIT cache. It resolves
+the model from the local Hugging Face cache (or a local path), checks every
+indexed weight shard, loads the tokenizer locally, verifies both dataset hashes
+and row counts, checks the exact clean FlashInfer source HEAD and installed
+public API, checks the standalone baseline import, verifies this SGLang checkout
+is the one Python imports, executes the baseline's real decode-plan ABI, and
+requires exactly four visible compute-capability 10.3 GPUs. The compatibility
+image carries `apache-tvm-ffi==0.1.9`; preserve that runtime for the A/B instead
+of shadowing it with a second FFI DSO in the session environment:
+
+```bash
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+python benchmark/minimax_m3/probe_msa_e2e_dependencies.py \
+  --model MiniMaxAI/MiniMax-M3-MXFP8 \
+  --longbench-subset /shared/eval/longbench_v2_m3_100_min32k.json \
+  --gpqa-dataset /shared/eval/gpqa_diamond.csv \
+  --flashinfer-source-dir "${FLASHINFER_SOURCE_DIR}" \
+  --expected-flashinfer-head "${FLASHINFER_HEAD}" \
+  --expected-tvm-ffi-version 0.1.9
+```
+
+These smaller probes are also useful before requesting the allocation; none
+downloads or modifies a cache:
+
+```bash
+git -C "${FLASHINFER_SOURCE_DIR}" rev-parse HEAD
+git -C "${FLASHINFER_SOURCE_DIR}" status --short
+test -r /shared/eval/gpqa_diamond.csv
+test -r /shared/eval/longbench_v2_m3_100_min32k.json
+test -r /shared/eval/longbench_v2_m3_100_min32k.json.manifest.json
+```
+
+For publishable evidence, use the one canonical driver inside a fresh,
+exclusive 4x GB300 allocation. Freeze the SGLang and FlashInfer commit and tree,
+the full checkpoint file manifest and aggregate (with the config hash as an
+additional fast check), and both evaluation inputs before starting. The three modes
+must use distinct output and cache roots:
+
+```bash
+COMMON=(
+  --model /model
+  --gpqa-dataset /shared/eval/gpqa_diamond.csv
+  --longbench-subset /shared/eval/longbench_v2_m3_100_min32k.json
+  --flashinfer-source-dir /workspace/flashinfer
+  --expected-flashinfer-head "${FLASHINFER_HEAD}"
+  --expected-flashinfer-tree "${FLASHINFER_TREE}"
+  --sglang-source-dir /workspace/sglang
+  --expected-sglang-head "${SGLANG_HEAD}"
+  --expected-sglang-tree "${SGLANG_TREE}"
+  --expected-model-config-sha256 "${MODEL_CONFIG_SHA256}"
+  --model-manifest /shared/input/model-checkpoint-manifest.json
+  --expected-model-manifest-sha256 "${MODEL_MANIFEST_SHA256}"
+  --expected-model-aggregate-sha256 "${MODEL_AGGREGATE_SHA256}"
+  --expected-gpqa-sha256 "${GPQA_SHA256}"
+  --expected-longbench-sha256 "${LONGBENCH_SHA256}"
+  --expected-longbench-manifest-sha256 "${LONGBENCH_MANIFEST_SHA256}"
+  --server-timeout 7200
+)
+
+python benchmark/minimax_m3/run_msa_formal_v2.py \
+  "${COMMON[@]}" --mode accuracy \
+  --output-root /shared/results/msa_accuracy \
+  --cache-root /workspace/cache/msa_accuracy
+
+python benchmark/minimax_m3/run_msa_formal_v2.py \
+  "${COMMON[@]}" --mode external-speed \
+  --output-root /shared/results/msa_external_speed \
+  --cache-root /workspace/cache/msa_external_speed \
+  --min-median-throughput-gain 0
+
+python benchmark/minimax_m3/run_msa_formal_v2.py \
+  "${COMMON[@]}" --mode triton-speed \
+  --output-root /shared/results/msa_triton_speed \
+  --cache-root /workspace/cache/msa_triton_speed \
+  --min-median-throughput-gain 0
+```
+
+Accuracy runs exactly three fresh, alternating pairs in the order
+`external,flashinfer`, `flashinfer,external`, `external,flashinfer`. Each speed
+mode runs exactly one fresh pair: `external,flashinfer` for external speed and
+`triton,flashinfer` for the Triton reference. There are no `rep02` or `rep03`
+speed runs. Every arm gets a new server and isolated JIT/cache directories. The
+driver verifies the selected route, sends one unmeasured fixed-seed 8K/1K
+warmup, brackets the measured server log by byte offset, and rejects port reuse,
+JIT activity, errors, retries, timeouts, client exhaustion, thermal throttling,
+or an unexpected count of successful requests. It never resumes into an
+existing result root.
+For the loopback OpenAI-compatible evaluator client, the runner supplies the
+non-secret dummy key `EMPTY` only when `OPENAI_API_KEY` is absent; an explicitly
+provided value is preserved.
+Before launching a server, every allocation re-hashes the complete checkpoint,
+requires its exact file set, and compares every file plus the aggregate against
+the frozen manifest; a config hash alone is not a checkpoint identity.
+
+Build the Python environment once as an immutable input, not independently in
+the three formal allocations. Resolve the complete transitive wheel closure for
+the target Python ABI and platform into a session-local wheelhouse, record the
+exact filename, size, and SHA-256 of every wheel plus an aggregate, and reject
+missing or extra files. Each allocation must verify that manifest, install only
+those explicit wheel paths with `PIP_NO_INDEX=1`, `--no-index`, and `--no-deps`,
+then run the dependency/import preflight. Do not use a network package index in
+a formal allocation.
+
+Accuracy and speed are separate experiments. Accuracy runs exact visible-answer
+probes at short, 32K, and 64K lengths, all 198 GPQA-Diamond questions at one
+client thread, and the deterministic 100-example LongBench-v2 subset at one
+thread. Both every pair and the three-run aggregate must stay within one GPQA
+question and 0.02 LongBench score. Private GPQA responses are mode `0600`;
+public per-example evidence contains hashes rather than response text. GPQA is
+materially harder than saturated GSM8K, while LongBench directly exercises
+long-context page selection and decode replay.
+
+The two speed modes send no accuracy requests. Each arm runs exactly 256 native
+SGLang `/generate` requests at concurrency 1, 8, 32, and 128, with fixed-seed
+`random-ids`, 8192 input tokens, 1024 output tokens, range ratio 1, and implicit
+benchmark warmups disabled. The consumer rejects duplicate JSONL records,
+partial or failed request counts, workload drift, non-finite values, and a
+negative median output-throughput gain at any concurrency. Keep clocks and
+power limits fixed and retain the complete receipts and logs for review.
+
+Run the executable fail-closed contract without a GPU with:
+
+```bash
+python benchmark/minimax_m3/run_msa_formal_v2.py --test-only
+```

--- a/benchmark/minimax_m3/README.md
+++ b/benchmark/minimax_m3/README.md
@@ -156,6 +156,12 @@ python benchmark/minimax_m3/run_msa_formal_v2.py \
   --min-median-throughput-gain 0
 
 python benchmark/minimax_m3/run_msa_formal_v2.py \
+  "${COMMON[@]}" --mode cake-speed \
+  --output-root /shared/results/msa_cake_speed \
+  --cache-root /workspace/cache/msa_cake_speed \
+  --min-median-throughput-gain 0
+
+python benchmark/minimax_m3/run_msa_formal_v2.py \
   "${COMMON[@]}" --mode triton-speed \
   --output-root /shared/results/msa_triton_speed \
   --cache-root /workspace/cache/msa_triton_speed \
@@ -164,7 +170,8 @@ python benchmark/minimax_m3/run_msa_formal_v2.py \
 
 Accuracy runs exactly three fresh, alternating pairs in the order
 `external,flashinfer`, `flashinfer,external`, `external,flashinfer`. Each speed
-mode runs exactly one fresh pair: `external,flashinfer` for external speed and
+mode runs exactly one fresh pair: `external,flashinfer` for external speed,
+`cake,vibecuda` for direct CAKE-source versus VibeCUDA-export speed, and
 `triton,flashinfer` for the Triton reference. There are no `rep02` or `rep03`
 speed runs. Every arm gets a new server and isolated JIT/cache directories. The
 driver verifies the selected route, sends one unmeasured fixed-seed 8K/1K

--- a/benchmark/minimax_m3/build_longbench_subset.py
+++ b/benchmark/minimax_m3/build_longbench_subset.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Build a deterministic, category-balanced long-context LongBench-v2 slice."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from datasets import load_dataset
+from transformers import AutoTokenizer
+
+from sglang.test.simple_eval_longbench_v2 import (
+    TASK_CATEGORIES,
+    format_longbench_v2_question,
+)
+
+DOMAIN_TO_CATEGORY = {
+    "Single-Document QA": "single_document_qa",
+    "Multi-Document QA": "multi_document_qa",
+    "Long In-context Learning": "long_in_context_learning",
+    "Long-dialogue History Understanding": "long_dialogue_history",
+    "Code Repository Understanding": "code_repo_understanding",
+    "Long Structured Data Understanding": "long_structured_data",
+}
+
+
+def canonical_category(example: dict) -> str | None:
+    value = example.get("category", example.get("domain"))
+    if value in TASK_CATEGORIES:
+        return value
+    return DOMAIN_TO_CATEGORY.get(value)
+
+
+def stable_key(example: dict) -> str:
+    identity = json.dumps(
+        {
+            "context": example.get("context", ""),
+            "question": example.get("question", ""),
+            "answer": example.get("answer", ""),
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return hashlib.sha256(identity.encode()).hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--dataset", default="THUDM/LongBench-v2")
+    parser.add_argument("--split", default="train")
+    parser.add_argument("--num-examples", type=int, default=100)
+    parser.add_argument("--min-tokens", type=int, default=32768)
+    parser.add_argument("--max-tokens", type=int, default=524288)
+    args = parser.parse_args()
+    if args.max_tokens < args.min_tokens:
+        raise SystemExit("--max-tokens must be at least --min-tokens")
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    rows = [dict(row) for row in load_dataset(args.dataset, split=args.split)]
+    eligible: dict[str, list[dict]] = defaultdict(list)
+    token_lengths: dict[str, int] = {}
+    for row in rows:
+        category = canonical_category(row)
+        if category is None:
+            continue
+        key = stable_key(row)
+        num_tokens = len(
+            tokenizer.encode(
+                format_longbench_v2_question(row), add_special_tokens=False
+            )
+        )
+        if args.min_tokens <= num_tokens <= args.max_tokens:
+            eligible[category].append(row)
+            token_lengths[key] = num_tokens
+
+    categories = sorted(TASK_CATEGORIES)
+    base, remainder = divmod(args.num_examples, len(categories))
+    selected: list[dict] = []
+    for index, category in enumerate(categories):
+        quota = base + (index < remainder)
+        ranked = sorted(eligible[category], key=stable_key)
+        if len(ranked) < quota:
+            raise RuntimeError(
+                f"category {category!r} has only {len(ranked)} eligible examples, "
+                f"but its balanced quota is {quota}"
+            )
+        for row in ranked[:quota]:
+            selected.append(row)
+    if len(selected) != args.num_examples:
+        raise RuntimeError("balanced category selection cardinality drifted")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(selected, ensure_ascii=False, indent=2) + "\n")
+    lengths = [token_lengths[stable_key(row)] for row in selected]
+    manifest = {
+        "dataset": args.dataset,
+        "split": args.split,
+        "model": args.model,
+        "minimum_tokens": args.min_tokens,
+        "maximum_tokens": args.max_tokens,
+        "num_examples": len(selected),
+        "category_counts": Counter(canonical_category(row) for row in selected),
+        "domain_to_category": DOMAIN_TO_CATEGORY,
+        "minimum_observed_tokens": min(lengths),
+        "maximum_observed_tokens": max(lengths),
+        "subset_sha256": hashlib.sha256(args.output.read_bytes()).hexdigest(),
+    }
+    manifest_path = args.output.with_suffix(args.output.suffix + ".manifest.json")
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/minimax_m3/precompile_fmha_sm100.py
+++ b/benchmark/minimax_m3/precompile_fmha_sm100.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Serially compile the fmha_sm100 variants used by the TP4 MSA A/B gate."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def runtime_variants(dtype_code: int) -> list[tuple]:
+    """Return the BF16 sparse-paged variants reachable by this TP4 gate."""
+
+    variants = []
+    for single_wg in (True, False):
+        for split_kv in (False, True):
+            for pack_factor in (1, 16):
+                variants.append(
+                    (dtype_code, 128, single_wg, 0, 128, split_kv, pack_factor)
+                )
+    variants.append((dtype_code, 256, False, 0, 128, False, 1))
+    return variants
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cache-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    cache_dir = args.cache_dir.resolve()
+    output = args.output.resolve()
+    if output.exists():
+        raise SystemExit(f"refusing to overwrite precompile receipt: {output}")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    os.environ["MINFER_FMHA_CACHE_DIR"] = str(cache_dir)
+
+    import fmha_sm100
+    import fmha_sm100.jit as jit
+    import tvm_ffi
+
+    if Path(jit.CACHE_BASE).resolve() != cache_dir:
+        raise RuntimeError(
+            f"fmha_sm100 ignored MINFER_FMHA_CACHE_DIR: {jit.CACHE_BASE}"
+        )
+
+    artifacts = []
+    for runtime_args in runtime_variants(jit._BFLOAT16_CODE):
+        variant_name, params = jit._variant_key_from_runtime(*runtime_args)
+        jit._variant_manager._compile_only(variant_name, params)
+        so_path = cache_dir / variant_name / f"{variant_name}.so"
+        module = tvm_ffi.load_module(str(so_path))
+        function = f"run_{variant_name}"
+        getattr(module, function)
+        artifacts.append(
+            {
+                "kind": "variant",
+                "name": variant_name,
+                "function": function,
+                "runtime_args": list(runtime_args),
+                "path": str(so_path),
+                "sha256": sha256(so_path),
+            }
+        )
+
+    auxiliary = (
+        ("plan", jit._compile_plan_only, "plan/fmha_sm100_plan.so", "plan"),
+        (
+            "reduction",
+            jit._do_compile_reduction,
+            "reduction/fmha_sm100_reduction.so",
+            "reduction",
+        ),
+        (
+            "sparse_topk",
+            jit._do_compile_sparse_topk,
+            "sparse_topk/sparse_topk_select.so",
+            "sparse_topk_select",
+        ),
+    )
+    for name, compile_fn, relative_path, function in auxiliary:
+        compile_fn()
+        so_path = cache_dir / relative_path
+        module = tvm_ffi.load_module(str(so_path))
+        getattr(module, function)
+        artifacts.append(
+            {
+                "kind": "auxiliary",
+                "name": name,
+                "function": function,
+                "path": str(so_path),
+                "sha256": sha256(so_path),
+            }
+        )
+
+    payload = {
+        "schema_version": 1,
+        "status": "passed",
+        "cache_dir": str(cache_dir),
+        "fmha_sm100_path": str(Path(fmha_sm100.__file__).resolve()),
+        "tvm_ffi_version": getattr(tvm_ffi, "__version__", "unknown"),
+        "artifacts": artifacts,
+    }
+    with output.open("x", encoding="utf-8") as destination:
+        json.dump(payload, destination, indent=2, sort_keys=True)
+        destination.write("\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/minimax_m3/probe_msa_e2e_dependencies.py
+++ b/benchmark/minimax_m3/probe_msa_e2e_dependencies.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""Read-only, offline preflight for the MiniMax-M3 TP4 MSA gate."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import importlib
+import inspect
+import json
+import os
+import re
+import subprocess
+from importlib import metadata
+from pathlib import Path
+
+REQUIRED_GPQA_COLUMNS = {
+    "Question",
+    "Correct Answer",
+    "Incorrect Answer 1",
+    "Incorrect Answer 2",
+    "Incorrect Answer 3",
+}
+REQUIRED_TP4_SM103_ROUTES = {
+    "topk_select.topk16": {"topk"},
+    "long_bf16_reverse_prefill.paged_gqa16_sm103": {
+        "long_prefill_paged_bf16_gqa16_sm103",
+        "long_prefill_reduce_paged_bf16_gqa16",
+    },
+    "direct_m16_decode.bf16_paged": {"decode_m16_bf16_paged"},
+}
+REQUIRED_SGLANG_KERNEL_VERSION = "0.4.6.post1"
+REQUIRED_TORCH_VERSION = "2.13.0"
+REQUIRED_DEEP_GEMM_VERSION = "0.1.5.post3"
+REQUIRED_TVM_FFI_VERSION = "0.1.11"
+REQUIRED_LONGBENCH_MIN_TOKENS = 32768
+REQUIRED_LONGBENCH_MAX_TOKENS = 524288
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def git(source: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(source), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def resolve_checkpoint(model: str) -> Path:
+    local_path = Path(model).expanduser()
+    if local_path.is_dir():
+        return local_path.resolve()
+
+    from huggingface_hub import snapshot_download
+
+    return Path(snapshot_download(repo_id=model, local_files_only=True)).resolve()
+
+
+def probe_checkpoint(model: str) -> dict:
+    checkpoint = resolve_checkpoint(model)
+    config = checkpoint / "config.json"
+    if not config.is_file():
+        raise RuntimeError(f"checkpoint has no readable config.json: {checkpoint}")
+
+    indexes = sorted(checkpoint.glob("*.safetensors.index.json"))
+    shards: set[str] = set()
+    for index in indexes:
+        weight_map = json.loads(index.read_text()).get("weight_map", {})
+        shards.update(str(value) for value in weight_map.values())
+    if shards:
+        missing = sorted(
+            shard for shard in shards if not (checkpoint / shard).is_file()
+        )
+        if missing:
+            raise RuntimeError(
+                f"checkpoint is missing {len(missing)} indexed weight shards; "
+                f"first missing shard: {missing[0]}"
+            )
+    else:
+        standalone_weights = list(checkpoint.glob("*.safetensors")) + list(
+            checkpoint.glob("pytorch_model*.bin")
+        )
+        if not standalone_weights:
+            raise RuntimeError(
+                f"checkpoint contains no locally cached weights: {checkpoint}"
+            )
+        shards = {path.name for path in standalone_weights}
+
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        checkpoint, local_files_only=True, trust_remote_code=True
+    )
+    return {
+        "requested_model": model,
+        "resolved_path": str(checkpoint),
+        "config_sha256": sha256(config),
+        "num_weight_shards": len(shards),
+        "tokenizer_class": type(tokenizer).__name__,
+    }
+
+
+def probe_datasets(longbench_subset: Path, gpqa_dataset: Path) -> dict:
+    manifest_path = Path(str(longbench_subset) + ".manifest.json")
+    if not longbench_subset.is_file() or not manifest_path.is_file():
+        raise RuntimeError("LongBench-v2 subset and manifest must both be readable")
+    manifest = json.loads(manifest_path.read_text())
+    observed_subset_sha = sha256(longbench_subset)
+    if manifest.get("subset_sha256") != observed_subset_sha:
+        raise RuntimeError("LongBench-v2 subset SHA-256 does not match its manifest")
+    if int(manifest.get("num_examples", 0)) != 100:
+        raise RuntimeError("LongBench-v2 subset must contain exactly 100 examples")
+    if int(manifest.get("minimum_tokens", 0)) != REQUIRED_LONGBENCH_MIN_TOKENS:
+        raise RuntimeError("LongBench-v2 subset minimum-token policy drifted")
+    if int(manifest.get("maximum_tokens", 0)) != REQUIRED_LONGBENCH_MAX_TOKENS:
+        raise RuntimeError("LongBench-v2 subset maximum-token policy drifted")
+    if int(manifest.get("minimum_observed_tokens", 0)) < REQUIRED_LONGBENCH_MIN_TOKENS:
+        raise RuntimeError("LongBench-v2 subset contains a prompt shorter than 32K")
+    if int(manifest.get("maximum_observed_tokens", 0)) > REQUIRED_LONGBENCH_MAX_TOKENS:
+        raise RuntimeError("LongBench-v2 subset contains a prompt longer than 512K")
+    category_counts = manifest.get("category_counts", {})
+    if len(category_counts) != 6 or sorted(category_counts.values()) != [
+        16,
+        16,
+        17,
+        17,
+        17,
+        17,
+    ]:
+        raise RuntimeError("LongBench-v2 subset is not balanced across six categories")
+
+    with gpqa_dataset.open(newline="") as source:
+        reader = csv.DictReader(source)
+        rows = list(reader)
+        columns = set(reader.fieldnames or ())
+    missing_columns = REQUIRED_GPQA_COLUMNS - columns
+    if missing_columns:
+        raise RuntimeError(f"GPQA-Diamond CSV is missing columns: {missing_columns}")
+    if len(rows) != 198:
+        raise RuntimeError(f"GPQA-Diamond CSV contains {len(rows)} rows, expected 198")
+    return {
+        "longbench_v2": {
+            "path": str(longbench_subset.resolve()),
+            "sha256": observed_subset_sha,
+            "num_examples": 100,
+            "minimum_observed_tokens": manifest["minimum_observed_tokens"],
+            "maximum_observed_tokens": manifest["maximum_observed_tokens"],
+        },
+        "gpqa_diamond": {
+            "path": str(gpqa_dataset.resolve()),
+            "sha256": sha256(gpqa_dataset),
+            "num_examples": len(rows),
+        },
+    }
+
+
+def probe_flashinfer(source: Path, expected_head: str) -> dict:
+    source = source.resolve()
+    head = git(source, "rev-parse", "HEAD")
+    if head != expected_head:
+        raise RuntimeError(f"FlashInfer HEAD is {head}, expected {expected_head}")
+    dirty = git(source, "status", "--short", "--untracked-files=no")
+    if dirty:
+        raise RuntimeError(
+            "FlashInfer tracked source differs from HEAD; evidence needs exact source"
+        )
+    public_module = source / "flashinfer" / "msa_ops" / "__init__.py"
+    if not public_module.is_file():
+        raise RuntimeError(f"FlashInfer source API is missing: {public_module}")
+
+    flashinfer = importlib.import_module("flashinfer")
+    msa_ops = importlib.import_module("flashinfer.msa_ops")
+    installed_path = Path(inspect.getfile(msa_ops)).resolve()
+    expected_package = (source / "flashinfer" / "msa_ops").resolve()
+    if not installed_path.is_relative_to(expected_package):
+        raise RuntimeError(
+            f"imported flashinfer.msa_ops from {installed_path}, expected {expected_package}"
+        )
+    required = {
+        "msa_sparse_attention",
+        "msa_sparse_decode_attention",
+        "msa_topk_select",
+        "MSASparseAttentionWorkspace",
+    }
+    missing = sorted(
+        name for name in required if not callable(getattr(msa_ops, name, None))
+    )
+    if missing:
+        raise RuntimeError(
+            f"installed flashinfer.msa_ops is missing callables: {missing}"
+        )
+    route_manifest = probe_blackwell_msa_route_manifest(source)
+    return {
+        "source_path": str(source),
+        "source_head": head,
+        "installed_path": str(installed_path),
+        "version": getattr(flashinfer, "__version__", None),
+        "prefill_signature": str(inspect.signature(msa_ops.msa_sparse_attention)),
+        "decode_signature": str(inspect.signature(msa_ops.msa_sparse_decode_attention)),
+        "route_manifest": route_manifest,
+    }
+
+
+def probe_blackwell_msa_route_manifest(source: Path) -> dict:
+    """Verify the generated-source routes exercised by the GB300 TP4 gate."""
+
+    manifest_path = source / "csrc" / "blackwell_msa" / "route_manifest.json"
+    if not manifest_path.is_file():
+        raise RuntimeError(f"FlashInfer MSA route manifest is missing: {manifest_path}")
+    manifest = json.loads(manifest_path.read_text())
+    routes = manifest.get("reachable_specializations", [])
+    if manifest.get("operation") != "blackwell_msa":
+        raise RuntimeError("FlashInfer route manifest has the wrong operation")
+    if int(manifest.get("attention_topk", 0)) != 16:
+        raise RuntimeError(
+            "FlashInfer route manifest does not freeze attention top-k 16"
+        )
+    if int(manifest.get("reachable_specialization_count", -1)) != len(routes):
+        raise RuntimeError("FlashInfer route manifest specialization count is stale")
+
+    routes_by_id = {route.get("id"): route for route in routes}
+    missing_routes = sorted(set(REQUIRED_TP4_SM103_ROUTES) - set(routes_by_id))
+    if missing_routes:
+        raise RuntimeError(
+            f"FlashInfer route manifest is missing TP4 routes: {missing_routes}"
+        )
+
+    required_units: set[str] = set()
+    for route_id, source_units in REQUIRED_TP4_SM103_ROUTES.items():
+        route = routes_by_id[route_id]
+        if "sm103" not in route.get("architectures", []):
+            raise RuntimeError(f"FlashInfer route {route_id} does not support sm103")
+        observed_units = set(route.get("source_units", []))
+        if not source_units.issubset(observed_units):
+            missing_units = sorted(source_units - observed_units)
+            raise RuntimeError(
+                f"FlashInfer route {route_id} is missing source units: {missing_units}"
+            )
+        required_units.update(source_units)
+
+    inventory = manifest.get("source_inventory", {}).get("entries", [])
+    inventory_by_unit = {
+        entry.get("source_unit"): entry
+        for entry in inventory
+        if entry.get("target") == "sm103a"
+    }
+    missing_inventory = sorted(required_units - set(inventory_by_unit))
+    if missing_inventory:
+        raise RuntimeError(
+            "FlashInfer route inventory is missing sm103a source units: "
+            f"{missing_inventory}"
+        )
+    for source_unit in sorted(required_units):
+        entry = inventory_by_unit[source_unit]
+        for field in (
+            "generated_input_sha256",
+            "vendored_sha256",
+            "binding_sha256",
+            "arg_plan_sha256",
+        ):
+            value = entry.get(field, "")
+            if re.fullmatch(r"[0-9a-f]{64}", value) is None:
+                raise RuntimeError(
+                    f"FlashInfer {source_unit} has invalid {field}: {value!r}"
+                )
+    return {
+        "path": str(manifest_path.resolve()),
+        "sha256": sha256(manifest_path),
+        "required_routes": sorted(REQUIRED_TP4_SM103_ROUTES),
+        "required_sm103a_source_units": sorted(required_units),
+    }
+
+
+def probe_fmha_sm100() -> dict:
+    module = importlib.import_module("fmha_sm100")
+    for name in ("fmha_sm100", "fmha_sm100_plan"):
+        if not callable(getattr(module, name, None)):
+            raise RuntimeError(f"fmha_sm100 installation has no callable {name}")
+    import torch
+
+    device = torch.device("cuda:0")
+    qo = torch.ones(1, dtype=torch.int32)
+    kv = torch.full((1,), 16 * 128, dtype=torch.int32)
+    plan = module.fmha_sm100_plan(
+        qo,
+        kv,
+        16,
+        num_kv_heads=1,
+        page_size=128,
+        kv_block_num=16,
+        causal=False,
+        qo_offset=kv - 1,
+        device=device,
+        use_fp8_kvcache=False,
+    )
+    required_metadata = {
+        "kv_segment_lens",
+        "kv_segment_offsets",
+        "kv_page_indptr",
+        "qo_offset",
+    }
+    if not (isinstance(plan, tuple) and len(plan) > 3 and isinstance(plan[3], dict)):
+        raise RuntimeError("fmha_sm100_plan returned an incompatible plan layout")
+    missing = sorted(
+        name for name in required_metadata if not torch.is_tensor(plan[3].get(name))
+    )
+    if missing:
+        raise RuntimeError(f"fmha_sm100_plan is missing metadata tensors: {missing}")
+    return {
+        "installed_path": str(Path(inspect.getfile(module)).resolve()),
+        "plan_length": len(plan),
+        "plan_metadata_tensors": sorted(required_metadata),
+    }
+
+
+def probe_sglang(repo: Path, expected_tvm_ffi_version: str) -> dict:
+    module = importlib.import_module("sglang")
+    installed_path = Path(inspect.getfile(module)).resolve()
+    expected_package = (repo / "python" / "sglang").resolve()
+    if not installed_path.is_relative_to(expected_package):
+        raise RuntimeError(
+            f"Python imports SGLang from {installed_path}, not this checkout "
+            f"({expected_package})"
+        )
+    kernel_version = metadata.version("sglang-kernel")
+    if kernel_version != REQUIRED_SGLANG_KERNEL_VERSION:
+        raise RuntimeError(
+            f"sglang-kernel is {kernel_version}, expected "
+            f"{REQUIRED_SGLANG_KERNEL_VERSION}"
+        )
+    torch = importlib.import_module("torch")
+    torch_version = torch.__version__.split("+", 1)[0]
+    if torch_version != REQUIRED_TORCH_VERSION:
+        raise RuntimeError(
+            f"torch is {torch.__version__}, expected {REQUIRED_TORCH_VERSION}"
+        )
+    sgl_kernel = importlib.import_module("sgl_kernel")
+    deep_gemm_version = metadata.version("sgl-deep-gemm")
+    if deep_gemm_version != REQUIRED_DEEP_GEMM_VERSION:
+        raise RuntimeError(
+            f"sgl-deep-gemm is {deep_gemm_version}, expected "
+            f"{REQUIRED_DEEP_GEMM_VERSION}"
+        )
+    tvm_ffi_version = metadata.version("apache-tvm-ffi")
+    if tvm_ffi_version != expected_tvm_ffi_version:
+        raise RuntimeError(
+            f"apache-tvm-ffi is {tvm_ffi_version}, expected {expected_tvm_ffi_version}"
+        )
+    tvm_ffi = importlib.import_module("tvm_ffi")
+    deep_gemm = importlib.import_module("deep_gemm")
+    scale = torch.ones((4, 4), dtype=torch.float32, device="cuda")
+    packed_scale = deep_gemm.utils.layout.get_mn_major_tma_aligned_packed_ue8m0_tensor(
+        scale
+    )
+    if packed_scale.shape != (4, 1) or packed_scale.dtype != torch.int32:
+        raise RuntimeError(
+            f"sgl-deep-gemm ABI probe returned {packed_scale.shape}/{packed_scale.dtype}"
+        )
+    return {
+        "repo": str(repo.resolve()),
+        "head": git(repo, "rev-parse", "HEAD"),
+        "installed_path": str(installed_path),
+        "sglang_kernel_version": kernel_version,
+        "sglang_kernel_path": str(Path(inspect.getfile(sgl_kernel)).resolve()),
+        "torch_version": torch.__version__,
+        "deep_gemm_version": deep_gemm_version,
+        "deep_gemm_path": str(Path(inspect.getfile(deep_gemm)).resolve()),
+        "tvm_ffi_version": tvm_ffi_version,
+        "tvm_ffi_path": str(Path(inspect.getfile(tvm_ffi)).resolve()),
+    }
+
+
+def probe_gpus(expected_gpus: int, expected_capability: tuple[int, int]) -> dict:
+    import torch
+
+    count = torch.cuda.device_count()
+    if count != expected_gpus:
+        raise RuntimeError(
+            f"{count} CUDA devices are visible, expected {expected_gpus}"
+        )
+    devices = []
+    for index in range(count):
+        capability = torch.cuda.get_device_capability(index)
+        if capability != expected_capability:
+            raise RuntimeError(
+                f"GPU {index} capability is {capability}, expected {expected_capability}"
+            )
+        devices.append(
+            {
+                "index": index,
+                "name": torch.cuda.get_device_name(index),
+                "capability": list(capability),
+            }
+        )
+    nvidia_smi = subprocess.run(
+        [
+            "nvidia-smi",
+            "--query-gpu=index,name,uuid,compute_cap,memory.total,driver_version",
+            "--format=csv,noheader,nounits",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    return {
+        "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+        "torch_version": torch.__version__,
+        "torch_cuda_version": torch.version.cuda,
+        "devices": devices,
+        "nvidia_smi": nvidia_smi,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--longbench-subset", type=Path, required=True)
+    parser.add_argument("--gpqa-dataset", type=Path, required=True)
+    parser.add_argument("--flashinfer-source-dir", type=Path, required=True)
+    parser.add_argument("--expected-flashinfer-head", required=True)
+    parser.add_argument("--expected-gpus", type=int, default=4)
+    parser.add_argument("--expected-capability", default="10.3")
+    parser.add_argument("--expected-tvm-ffi-version", default=REQUIRED_TVM_FFI_VERSION)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    os.environ["HF_HUB_OFFLINE"] = "1"
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+    capability_parts = tuple(
+        int(value) for value in args.expected_capability.split(".")
+    )
+    if len(capability_parts) != 2:
+        raise SystemExit("--expected-capability must look like 10.3")
+    repo = Path(__file__).resolve().parents[2]
+    report = {
+        "offline": True,
+        "sglang": probe_sglang(repo, args.expected_tvm_ffi_version),
+        "flashinfer": probe_flashinfer(
+            args.flashinfer_source_dir, args.expected_flashinfer_head
+        ),
+        "fmha_sm100": probe_fmha_sm100(),
+        "checkpoint": probe_checkpoint(args.model),
+        "datasets": probe_datasets(args.longbench_subset, args.gpqa_dataset),
+        "gpu": probe_gpus(args.expected_gpus, capability_parts),
+    }
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/minimax_m3/record_fixed_parity.py
+++ b/benchmark/minimax_m3/record_fixed_parity.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Record deterministic short and long-context MiniMax-M3 responses."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import urllib.request
+from pathlib import Path
+
+from transformers import AutoTokenizer
+
+
+def _render_long_prompt(repetitions: int, target_tokens: int) -> tuple[str, str]:
+    marker = f"MSA-{target_tokens}-C7F29A"
+    sentence = "Archive row 314159 contains ordinary calibration material. "
+    filler = sentence * repetitions
+    insert_at = len(filler) * 2 // 3
+    context = filler[:insert_at] + f"\nSECRET CODE: {marker}\n" + filler[insert_at:]
+    prompt = (
+        "Read the archive and return only the exact SECRET CODE, with no explanation.\n"
+        f"<archive>\n{context}\n</archive>"
+    )
+    return prompt, marker
+
+
+def long_prompt(tokenizer, target_tokens: int) -> tuple[str, str, int]:
+    """Build a prompt whose measured tokenizer length reaches ``target_tokens``."""
+
+    low, high = 0, max(1, target_tokens // 8)
+    while True:
+        prompt, _ = _render_long_prompt(high, target_tokens)
+        if len(tokenizer.encode(prompt, add_special_tokens=False)) >= target_tokens:
+            break
+        high *= 2
+    while low + 1 < high:
+        middle = (low + high) // 2
+        prompt, _ = _render_long_prompt(middle, target_tokens)
+        if len(tokenizer.encode(prompt, add_special_tokens=False)) >= target_tokens:
+            high = middle
+        else:
+            low = middle
+    prompt, marker = _render_long_prompt(high, target_tokens)
+    measured_tokens = len(tokenizer.encode(prompt, add_special_tokens=False))
+    if measured_tokens < target_tokens:
+        raise RuntimeError(
+            f"failed to construct a {target_tokens}-token prompt: {measured_tokens}"
+        )
+    return prompt, marker, measured_tokens
+
+
+def post_json(url: str, payload: dict) -> dict:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer EMPTY"},
+    )
+    with urllib.request.urlopen(request, timeout=1800) as response:
+        return json.load(response)
+
+
+def response_record(body: dict) -> tuple[str, str, str]:
+    message = body["choices"][0]["message"]
+    reasoning = str(message.get("reasoning_content") or "").strip()
+    content = str(message.get("content") or "").strip()
+    canonical = json.dumps(
+        {"reasoning_content": reasoning, "content": content},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return reasoning, content, canonical
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--long-tokens", type=int, nargs="+", default=[32768, 65536])
+    args = parser.parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    short_prompt = "Return only the string MSA-SHORT-4B19. Do not add punctuation."
+    cases = [
+        (
+            "short",
+            short_prompt,
+            "MSA-SHORT-4B19",
+            len(tokenizer.encode(short_prompt, add_special_tokens=False)),
+        )
+    ]
+    cases.extend(
+        (f"long_{tokens}", *long_prompt(tokenizer, tokens))
+        for tokens in args.long_tokens
+    )
+    records = []
+    for name, prompt, expected, prompt_tokens in cases:
+        body = post_json(
+            args.base_url.rstrip("/") + "/v1/chat/completions",
+            {
+                "model": args.model,
+                "messages": [{"role": "user", "content": prompt}],
+                "temperature": 0,
+                "top_p": 1,
+                "max_tokens": 512,
+            },
+        )
+        reasoning, content, canonical = response_record(body)
+        records.append(
+            {
+                "name": name,
+                "expected": expected,
+                "exact_expected": content == expected,
+                "prompt_tokens": prompt_tokens,
+                "reasoning_content": reasoning,
+                "content": content,
+                "response_sha256": hashlib.sha256(canonical.encode()).hexdigest(),
+                "usage": body.get("usage", {}),
+            }
+        )
+    payload = {"label": args.label, "model": args.model, "records": records}
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    if not all(record["exact_expected"] for record in records):
+        raise SystemExit("one or more fixed-answer probes failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/minimax_m3/run_msa_formal_v2.py
+++ b/benchmark/minimax_m3/run_msa_formal_v2.py
@@ -1,0 +1,2455 @@
+#!/usr/bin/env python3
+"""Public, fail-closed MiniMax-M3 accuracy and serving-speed validation runner."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import http.client
+import json
+import math
+import os
+import re
+import shlex
+import shutil
+import signal
+import statistics
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+CONCURRENCIES = (1, 8, 32, 128)
+NUM_PROMPTS = 256
+SEED = 20260819
+GPQA_TOTAL = 198
+LONGBENCH_TOTAL = 100
+GPQA_MARGIN_QUESTIONS = 1
+LONGBENCH_MARGIN = 0.02
+THERMAL_QUERY = (
+    "timestamp,index,temperature.gpu,power.draw,clocks.current.sm,clocks.max.sm,"
+    "clocks_throttle_reasons.sw_thermal_slowdown,"
+    "clocks_throttle_reasons.hw_thermal_slowdown"
+)
+FAILURE_PATTERNS = {
+    "errors": re.compile(
+        r"Traceback \(most recent call last\)|CUDA error|RuntimeError:|Exception:|"
+        r"(?:^|[\s:\[])FATAL(?:[\s:\]]|$)|(?:^|[\s:\[])ERROR(?:[\s:\]]|$)|"
+        r"Segmentation fault|illegal memory|NCCL[^\n]*(?:error|abort)|"
+        r"request[^\n]*(?:failed|failure)",
+        re.IGNORECASE,
+    ),
+    "retries": re.compile(r"\bretr(?:y|ies|ied|ying)\b", re.IGNORECASE),
+    "jit_or_compilation": re.compile(
+        r"\b(?:JIT|NVRTC|ninja|compil(?:e|ed|ing|ation))\b", re.IGNORECASE
+    ),
+}
+CLIENT_FAILURE_PATTERNS = {
+    "errors": re.compile(
+        r"Traceback \(most recent call last\)|\b(?:CUDA )?error\b|RuntimeError:|"
+        r"\bException\b|Segmentation fault|illegal memory|NCCL[^\n]*(?:error|abort)|"
+        r"\b(?:failed|failure|exhausted)\b|connection (?:reset|refused)",
+        re.IGNORECASE,
+    ),
+    "retries": re.compile(r"\bretr(?:y|ies|ied|ying)\b", re.IGNORECASE),
+    "timeouts": re.compile(r"\b(?:timed out|timeouts?)\b", re.IGNORECASE),
+}
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def require_sha256(path: Path, expected: str, label: str) -> None:
+    actual = sha256(path)
+    if actual != expected:
+        raise RuntimeError(f"{label} SHA-256 mismatch: {actual} != {expected}")
+
+
+def verify_file_manifest(
+    root: Path,
+    manifest_path: Path,
+    expected_manifest_sha256: str,
+    expected_aggregate_sha256: str,
+    label: str,
+) -> dict:
+    """Re-hash an immutable directory against an exact file manifest."""
+    require_sha256(manifest_path, expected_manifest_sha256, f"{label} manifest")
+    manifest = json.loads(manifest_path.read_text())
+    if manifest.get("schema_version") != 1 or manifest.get("status") != "pass":
+        raise RuntimeError(f"invalid {label} manifest header: {manifest}")
+    if manifest.get("aggregate_sha256") != expected_aggregate_sha256:
+        raise RuntimeError(
+            f"{label} manifest aggregate mismatch: "
+            f"{manifest.get('aggregate_sha256')!r} != {expected_aggregate_sha256!r}"
+        )
+    expected_rows = manifest.get("files")
+    if not isinstance(expected_rows, list) or not expected_rows:
+        raise RuntimeError(f"{label} manifest contains no files")
+    expected: dict[str, dict] = {}
+    for row in expected_rows:
+        relative = row.get("path") if isinstance(row, dict) else None
+        if (
+            not isinstance(relative, str)
+            or not relative
+            or Path(relative).is_absolute()
+            or ".." in Path(relative).parts
+            or relative in expected
+            or not isinstance(row.get("size"), int)
+            or row["size"] < 0
+            or re.fullmatch(r"[0-9a-f]{64}", str(row.get("sha256", ""))) is None
+        ):
+            raise RuntimeError(f"invalid {label} manifest row: {row!r}")
+        expected[relative] = row
+    actual_paths = {
+        path.relative_to(root).as_posix(): path
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+    if set(actual_paths) != set(expected):
+        raise RuntimeError(
+            f"{label} file-set mismatch: missing={sorted(set(expected) - set(actual_paths))}, "
+            f"unexpected={sorted(set(actual_paths) - set(expected))}"
+        )
+    aggregate = hashlib.sha256()
+    total_bytes = 0
+    for relative in sorted(expected):
+        path = actual_paths[relative]
+        size = path.stat().st_size
+        digest = sha256(path)
+        row = expected[relative]
+        if size != row["size"] or digest != row["sha256"]:
+            raise RuntimeError(
+                f"{label} file mismatch for {relative}: "
+                f"size={size}/{row['size']} sha256={digest}/{row['sha256']}"
+            )
+        aggregate.update(
+            relative.encode()
+            + b"\0"
+            + str(size).encode()
+            + b"\0"
+            + digest.encode()
+            + b"\n"
+        )
+        total_bytes += size
+    actual_aggregate = aggregate.hexdigest()
+    if actual_aggregate != expected_aggregate_sha256:
+        raise RuntimeError(
+            f"{label} runtime aggregate mismatch: "
+            f"{actual_aggregate} != {expected_aggregate_sha256}"
+        )
+    if (
+        manifest.get("file_count") != len(expected)
+        or manifest.get("total_bytes") != total_bytes
+    ):
+        raise RuntimeError(f"{label} manifest count/size metadata mismatch")
+    return {
+        "schema_version": 1,
+        "status": "pass",
+        "label": label,
+        "runtime_root": str(root.resolve()),
+        "manifest_path": str(manifest_path.resolve()),
+        "manifest_sha256": expected_manifest_sha256,
+        "aggregate_sha256": actual_aggregate,
+        "file_count": len(expected),
+        "total_bytes": total_bytes,
+    }
+
+
+def command_text(command: list[str]) -> str:
+    return shlex.join(command)
+
+
+def loopback_environment(base: dict[str, str]) -> dict[str, str]:
+    result = dict(base)
+    result.setdefault("OPENAI_API_KEY", "EMPTY")
+    return result
+
+
+def roles_for_mode(mode: str) -> tuple[str, str]:
+    if mode in ("accuracy", "external-speed"):
+        return ("external", "flashinfer")
+    if mode == "triton-speed":
+        return ("triton", "flashinfer")
+    raise ValueError(f"unsupported mode: {mode}")
+
+
+def repetitions_for_mode(mode: str) -> int:
+    roles_for_mode(mode)
+    return 3 if mode == "accuracy" else 1
+
+
+def expected_order(mode: str, repetition: int) -> list[str]:
+    left, right = roles_for_mode(mode)
+    return [left, right] if repetition % 2 else [right, left]
+
+
+def validate_order(mode: str, repetition: int, observed: list[str]) -> None:
+    expected = expected_order(mode, repetition)
+    if observed != expected:
+        raise RuntimeError(
+            f"wrong {mode} rep{repetition:02d} order: {observed} != {expected}"
+        )
+
+
+def fixed_parity_required(mode: str) -> bool:
+    return mode == "accuracy"
+
+
+def within_noninferiority_margin(delta: float, margin: float) -> bool:
+    return delta >= -margin or math.isclose(delta, -margin, rel_tol=0.0, abs_tol=1e-12)
+
+
+def route_fragments(role: str) -> tuple[str, ...]:
+    if role == "external":
+        return (
+            "main_attn=fmha_sm100",
+            "msa_decode=True",
+            "msa_owns_decode=True",
+            "decode_cuda_graph=True",
+        )
+    if role in ("cake", "vibecuda"):
+        provider = "vibecuda" if role == "vibecuda" else "auto"
+        return (
+            "main_attn=flashinfer",
+            f"flashinfer_provider={provider}",
+            "msa_decode=True",
+            "msa_owns_decode=True",
+            "decode_cuda_graph=True",
+        )
+    if role == "flashinfer":
+        return (
+            "main_attn=flashinfer",
+            "msa_decode=True",
+            "msa_owns_decode=True",
+            "decode_cuda_graph=True",
+        )
+    if role == "triton":
+        return (
+            "main_attn=triton",
+            "msa_decode=False",
+            "msa_owns_decode=False",
+            "decode_cuda_graph=True",
+        )
+    raise ValueError(f"unsupported role: {role}")
+
+
+def role_environment(base: dict[str, str], role: str) -> dict[str, str]:
+    result = dict(base)
+    for name in (
+        "SGLANG_DISABLE_MSA",
+        "SGLANG_MINIMAX_MSA_BACKEND",
+        "SGLANG_MINIMAX_MSA_FLASHINFER_BACKEND",
+        "SGLANG_OPT_USE_MSA_DECODE_UNDER_GRAPH",
+    ):
+        result.pop(name, None)
+    if role == "external":
+        result.update(
+            {
+                "SGLANG_MINIMAX_MSA_BACKEND": "fmha_sm100",
+                "SGLANG_OPT_USE_MSA_DECODE_UNDER_GRAPH": "1",
+            }
+        )
+    elif role in ("flashinfer", "cake", "vibecuda"):
+        result.update(
+            {
+                "SGLANG_MINIMAX_MSA_BACKEND": "flashinfer",
+                "SGLANG_MINIMAX_MSA_FLASHINFER_BACKEND": (
+                    "vibecuda" if role == "vibecuda" else "auto"
+                ),
+                "SGLANG_OPT_USE_MSA_DECODE_UNDER_GRAPH": "1",
+            }
+        )
+    elif role == "triton":
+        result["SGLANG_DISABLE_MSA"] = "1"
+    else:
+        raise ValueError(f"unsupported role: {role}")
+    return result
+
+
+def server_command(args: argparse.Namespace) -> list[str]:
+    return [
+        args.python,
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        args.model,
+        "--trust-remote-code",
+        "--reasoning-parser",
+        "auto",
+        "--tool-call-parser",
+        "auto",
+        "--tp",
+        "4",
+        "--attention-backend",
+        "fa4",
+        "--page-size",
+        "128",
+        "--moe-runner-backend",
+        "deep_gemm",
+        "--chunked-prefill-size",
+        "8192",
+        "--mem-fraction-static",
+        "0.75",
+        "--disable-prefill-cuda-graph",
+        "--random-seed",
+        str(SEED),
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+    ]
+
+
+def server_healthy(base_url: str, timeout: float = 2.0) -> bool:
+    try:
+        with urllib.request.urlopen(
+            base_url.rstrip("/") + "/health_generate", timeout=timeout
+        ) as response:
+            return response.status == 200
+    except (OSError, urllib.error.URLError, http.client.HTTPException):
+        return False
+
+
+def tail(path: Path, lines: int = 120) -> str:
+    if not path.exists():
+        return "<server log does not exist>"
+    return "\n".join(path.read_text(errors="replace").splitlines()[-lines:])
+
+
+def wait_for_server(
+    process: subprocess.Popen, base_url: str, log_path: Path, timeout: int
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        return_code = process.poll()
+        if return_code is not None:
+            raise RuntimeError(
+                f"server exited with status {return_code} before readiness:\n"
+                + tail(log_path)
+            )
+        if server_healthy(base_url, timeout=5):
+            return
+        time.sleep(5)
+    raise TimeoutError(f"server was not ready after {timeout}s:\n" + tail(log_path))
+
+
+def stop_server(process: subprocess.Popen, base_url: str) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        process.wait(timeout=120)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait(timeout=30)
+    deadline = time.monotonic() + 120
+    while time.monotonic() < deadline:
+        if not server_healthy(base_url):
+            return
+        time.sleep(2)
+    raise RuntimeError(f"server still answers at {base_url} after shutdown")
+
+
+def validate_route(log_path: Path, role: str) -> str:
+    wanted = route_fragments(role)
+    for line in log_path.read_text(errors="replace").splitlines():
+        if all(fragment in line for fragment in wanted):
+            return line
+    raise RuntimeError(
+        f"server did not confirm {role} route {wanted}:\n{tail(log_path)}"
+    )
+
+
+def run_checked(command: list[str], *, cwd: Path, env: dict[str, str]) -> None:
+    print(f"+ {command_text(command)}", flush=True)
+    subprocess.run(command, cwd=cwd, env=env, check=True)
+
+
+def run_checked_log(
+    command: list[str], *, cwd: Path, env: dict[str, str], output: Path
+) -> None:
+    print(f"+ {command_text(command)} > {output}", flush=True)
+    with output.open("x") as destination:
+        subprocess.run(
+            command,
+            cwd=cwd,
+            env=env,
+            check=True,
+            stdout=destination,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+
+class ThermalSampler:
+    def __init__(self, output: Path, interval_seconds: float = 10.0):
+        self.output = output
+        self.interval_seconds = interval_seconds
+        self.stop_event = threading.Event()
+        self.errors: list[str] = []
+        self.thread = threading.Thread(target=self._run, daemon=True)
+
+    def _sample(self, handle) -> None:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                f"--query-gpu={THERMAL_QUERY}",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+            capture_output=True,
+        )
+        if result.returncode:
+            self.errors.append(
+                result.stderr.strip() or f"nvidia-smi={result.returncode}"
+            )
+        else:
+            handle.write(result.stdout)
+            handle.flush()
+
+    def _run(self) -> None:
+        with self.output.open("x") as handle:
+            handle.write(
+                "timestamp,index,temperature_gpu_c,power_draw_w,clocks_current_sm_mhz,"
+                "clocks_max_sm_mhz,sw_thermal_slowdown,hw_thermal_slowdown\n"
+            )
+            self._sample(handle)
+            while not self.stop_event.wait(self.interval_seconds):
+                self._sample(handle)
+
+    def start(self) -> None:
+        self.thread.start()
+
+    def stop(self) -> None:
+        self.stop_event.set()
+        self.thread.join(timeout=30)
+        if self.thread.is_alive():
+            self.errors.append("thermal sampler thread did not stop")
+        with self.output.open("a") as handle:
+            self._sample(handle)
+
+
+def thermal_failures(
+    path: Path, sampler_errors: list[str]
+) -> tuple[dict[str, int], list[str]]:
+    with path.open() as source:
+        rows = list(csv.DictReader(source))
+    counts = {str(index): 0 for index in range(4)}
+    failures = list(sampler_errors)
+    for row in rows:
+        index = row.get("index", "").strip()
+        if index not in counts:
+            failures.append(f"unexpected GPU index {index!r}")
+            continue
+        counts[index] += 1
+        for key in ("sw_thermal_slowdown", "hw_thermal_slowdown"):
+            if row.get(key, "").strip().lower() != "not active":
+                failures.append(f"GPU {index} {key}={row.get(key)!r}")
+    if any(count < 2 for count in counts.values()):
+        failures.append(f"insufficient thermal samples: {counts}")
+    return counts, failures
+
+
+def log_segment(path: Path, start: int, end: int) -> tuple[bytes, dict[str, list[str]]]:
+    if end < start:
+        raise ValueError("server log shrank during measured window")
+    with path.open("rb") as source:
+        source.seek(start)
+        data = source.read(end - start)
+    text = data.decode(errors="replace")
+    matches = {
+        name: sorted(set(pattern.findall(text)))
+        for name, pattern in FAILURE_PATTERNS.items()
+    }
+    return data, matches
+
+
+def measured_audit(
+    *,
+    role_dir: Path,
+    log_path: Path,
+    start: int,
+    end: int,
+    sampler: ThermalSampler,
+    expected_posts: int,
+    expected_endpoint: str,
+) -> dict:
+    data, matches = log_segment(log_path, start, end)
+    text = data.decode(errors="replace")
+    posts = len(
+        re.findall(rf'POST {re.escape(expected_endpoint)} HTTP/1\.1" 200 OK', text)
+    )
+    counts, thermals = thermal_failures(role_dir / "thermal.csv", sampler.errors)
+    failures: list[str] = []
+    for category, found in matches.items():
+        if found:
+            failures.append(f"{category}: {found}")
+    failures.extend(thermals)
+    if posts != expected_posts:
+        failures.append(
+            f"successful {expected_endpoint} posts {posts}/{expected_posts}"
+        )
+    payload = {
+        "status": "pass" if not failures else "fail",
+        "server_log_start_offset": start,
+        "server_log_end_offset": end,
+        "server_log_segment_bytes": len(data),
+        "server_log_segment_sha256": hashlib.sha256(data).hexdigest(),
+        "log_pattern_matches": matches,
+        "successful_posts": posts,
+        "expected_posts": expected_posts,
+        "expected_endpoint": expected_endpoint,
+        "thermal_sample_counts": counts,
+        "thermal_failures": thermals,
+        "failures": failures,
+    }
+    (role_dir / "measured_window_audit.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    )
+    if failures:
+        raise RuntimeError("measured-window audit failed: " + "; ".join(failures))
+    return payload
+
+
+def startup_audit(log_path: Path, end: int, output: Path) -> dict:
+    data, matches = log_segment(log_path, 0, end)
+    failures = []
+    for category in ("errors", "retries"):
+        if matches[category]:
+            failures.append(f"{category}: {matches[category]}")
+    payload = {
+        "status": "pass" if not failures else "fail",
+        "server_log_end_offset": end,
+        "server_log_segment_sha256": hashlib.sha256(data).hexdigest(),
+        "jit_or_compilation_matches": matches["jit_or_compilation"],
+        "errors": matches["errors"],
+        "retries": matches["retries"],
+        "failures": failures,
+    }
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    if failures:
+        raise RuntimeError("startup audit failed: " + "; ".join(failures))
+    return payload
+
+
+def client_log_audit(log_path: Path, output: Path) -> dict:
+    """Reject any client-visible error, retry, exhaustion, or timeout."""
+    data = log_path.read_bytes()
+    text = data.decode(errors="replace")
+    matches = {
+        name: sorted(set(pattern.findall(text)))
+        for name, pattern in CLIENT_FAILURE_PATTERNS.items()
+    }
+    failures = [f"{name}: {found}" for name, found in matches.items() if found]
+    payload = {
+        "schema_version": 1,
+        "status": "pass" if not failures else "fail",
+        "client_log_path": str(log_path),
+        "client_log_bytes": len(data),
+        "client_log_sha256": hashlib.sha256(data).hexdigest(),
+        "pattern_matches": matches,
+        "failures": failures,
+    }
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    if failures:
+        raise RuntimeError("client-log audit failed: " + "; ".join(failures))
+    return payload
+
+
+def last_jsonl(path: Path) -> dict:
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line]
+    if len(rows) != 1:
+        raise ValueError(
+            f"expected exactly one benchmark record in {path}, observed {len(rows)}"
+        )
+    return rows[0]
+
+
+def fixed_parity_rows(payload: dict | list) -> list:
+    return payload.get("records", []) if isinstance(payload, dict) else []
+
+
+def validate_fixed_parity_payload(payload: dict, role: str, model: str) -> None:
+    rows = fixed_parity_rows(payload)
+    names = ["short", "long_32768", "long_65536"]
+    valid = (
+        isinstance(payload, dict)
+        and payload.get("label") == role
+        and payload.get("model") == model
+        and len(rows) == 3
+        and [row.get("name") for row in rows] == names
+        and all(row.get("exact_expected") is True for row in rows)
+        and all(row.get("content") == row.get("expected") for row in rows)
+        and all(
+            isinstance(row.get("prompt_tokens"), int) and row["prompt_tokens"] > 0
+            for row in rows
+        )
+        and rows[1]["prompt_tokens"] >= 32768
+        and rows[2]["prompt_tokens"] >= 65536
+        and all(
+            re.fullmatch(r"[0-9a-f]{64}", str(row.get("response_sha256", "")))
+            for row in rows
+        )
+        and all(isinstance(row.get("usage"), dict) for row in rows)
+    )
+    if not valid:
+        raise RuntimeError(f"fixed parity failed for {role}: {payload}")
+
+
+def validate_serving_record(row: dict, concurrency: int) -> None:
+    if int(row.get("completed", -1)) != NUM_PROMPTS:
+        raise RuntimeError(f"c{concurrency} completed != {NUM_PROMPTS}")
+    for key in ("failed", "failed_requests", "num_failed_requests"):
+        if key in row and int(row[key]) != 0:
+            raise RuntimeError(f"c{concurrency} {key}={row[key]}")
+    expected = {
+        "dataset_name": "random-ids",
+        "random_input_len": 8192,
+        "random_output_len": 1024,
+        "max_concurrency": concurrency,
+        "total_input_tokens": NUM_PROMPTS * 8192,
+        "total_output_tokens": NUM_PROMPTS * 1024,
+    }
+    for key, value in expected.items():
+        if row.get(key) != value:
+            raise RuntimeError(
+                f"c{concurrency} {key}={row.get(key)!r}, expected {value!r}"
+            )
+    ratio = float(row.get("random_range_ratio", float("nan")))
+    if not math.isfinite(ratio) or ratio != 1.0:
+        raise RuntimeError(f"c{concurrency} random_range_ratio={ratio!r}, expected 1.0")
+    for key in ("output_throughput", "median_ttft_ms"):
+        value = float(row.get(key, float("nan")))
+        if not math.isfinite(value) or value <= 0:
+            raise RuntimeError(
+                f"c{concurrency} {key} must be finite and positive: {value!r}"
+            )
+
+
+def ensure_absent_output(path: Path, label: str) -> None:
+    if path.exists():
+        raise RuntimeError(f"stale {label} output already exists: {path}")
+
+
+def claim_fresh_json_output(
+    source: Path, destination: Path, started_ns: int, label: str
+) -> tuple[dict, dict]:
+    if not source.is_file():
+        raise RuntimeError(f"{label} output was not created: {source}")
+    stat = source.stat()
+    if stat.st_size <= 0:
+        raise RuntimeError(f"{label} output is empty: {source}")
+    if stat.st_mtime_ns < started_ns:
+        raise RuntimeError(
+            f"stale {label} mtime {stat.st_mtime_ns} predates start {started_ns}"
+        )
+    payload = json.loads(source.read_text())
+    digest = sha256(source)
+    receipt = {
+        "source_path": str(source),
+        "destination_path": str(destination),
+        "started_ns": started_ns,
+        "source_inode": stat.st_ino,
+        "source_mtime_ns": stat.st_mtime_ns,
+        "source_size": stat.st_size,
+        "source_sha256": digest,
+    }
+    shutil.move(str(source), destination)
+    if sha256(destination) != digest:
+        raise RuntimeError(f"{label} output changed while moving to evidence")
+    return payload, receipt
+
+
+def initialize_fresh_cache(path: Path) -> None:
+    if path.exists():
+        raise RuntimeError(f"fresh arm cache already exists: {path}")
+    path.mkdir(parents=True)
+
+
+def arm_cache_environment(cache_dir: Path) -> dict[str, str]:
+    return {
+        "FLASHINFER_WORKSPACE_BASE": str(cache_dir / "flashinfer"),
+        "TORCH_EXTENSIONS_DIR": str(cache_dir / "torch_extensions"),
+        "XDG_CACHE_HOME": str(cache_dir / "xdg"),
+        "MINFER_FMHA_CACHE_DIR": str(cache_dir / "minfer-fmha"),
+        "SGLANG_CACHE_DIR": str(cache_dir / "sglang"),
+        "SGLANG_JIT_CACHE_DIR": str(cache_dir / "sglang-jit"),
+        "SGLANG_DG_CACHE_DIR": str(cache_dir / "deep-gemm"),
+        "DG_JIT_CACHE_DIR": str(cache_dir / "deep-gemm"),
+        "TRITON_CACHE_DIR": str(cache_dir / "triton"),
+        "TORCHINDUCTOR_CACHE_DIR": str(cache_dir / "torchinductor"),
+        "CUDA_CACHE_PATH": str(cache_dir / "cuda-driver"),
+        "FLASH_ATTENTION_CUTE_DSL_CACHE_DIR": str(cache_dir / "cute-dsl"),
+    }
+
+
+def validate_checkout(
+    source: Path, expected_head: str, expected_tree: str, label: str
+) -> None:
+    head = subprocess.check_output(
+        ["git", "-C", str(source), "rev-parse", "HEAD"], text=True
+    ).strip()
+    tree = subprocess.check_output(
+        ["git", "-C", str(source), "rev-parse", "HEAD^{tree}"], text=True
+    ).strip()
+    dirty = subprocess.check_output(
+        ["git", "-C", str(source), "status", "--porcelain", "--untracked-files=all"],
+        text=True,
+    ).strip()
+    failures = []
+    if head != expected_head:
+        failures.append(f"head={head!r}, expected={expected_head!r}")
+    if tree != expected_tree:
+        failures.append(f"tree={tree!r}, expected={expected_tree!r}")
+    if dirty:
+        failures.append(f"dirty={dirty!r}")
+    if failures:
+        raise RuntimeError(f"{label} checkout is not frozen: " + "; ".join(failures))
+
+
+def lifecycle_failures(
+    *, prelaunch_clear: bool, poststop_clear: bool, measured: dict | None
+) -> list[str]:
+    failures = []
+    if not prelaunch_clear:
+        failures.append("port occupied before launch")
+    if not poststop_clear:
+        failures.append("port still occupied after teardown")
+    if not measured or measured.get("status") != "pass":
+        failures.append("measured audit missing or failed")
+    return failures
+
+
+def require_lifecycle(
+    *, prelaunch_clear: bool, poststop_clear: bool, measured: dict | None
+) -> None:
+    failures = lifecycle_failures(
+        prelaunch_clear=prelaunch_clear,
+        poststop_clear=poststop_clear,
+        measured=measured,
+    )
+    if failures:
+        raise RuntimeError("lifecycle receipt failed: " + "; ".join(failures))
+
+
+def speed_command(
+    args: argparse.Namespace, output: Path, concurrency: int
+) -> list[str]:
+    return [
+        args.python,
+        "-m",
+        "sglang.benchmark.serving",
+        "--backend",
+        "sglang",
+        "--base-url",
+        args.base_url,
+        "--model",
+        args.model,
+        "--dataset-name",
+        "random-ids",
+        "--tokenize-prompt",
+        "--num-prompts",
+        str(NUM_PROMPTS),
+        "--random-input-len",
+        "8192",
+        "--random-output-len",
+        "1024",
+        "--random-range-ratio",
+        "1",
+        "--request-rate",
+        "inf",
+        "--warmup-requests",
+        "0",
+        "--max-concurrency",
+        str(concurrency),
+        "--seed",
+        str(SEED),
+        "--flush-cache",
+        "--output-file",
+        str(output),
+    ]
+
+
+def warmup_command(args: argparse.Namespace, output: Path) -> list[str]:
+    return [
+        args.python,
+        "-m",
+        "sglang.benchmark.serving",
+        "--backend",
+        "sglang",
+        "--base-url",
+        args.base_url,
+        "--model",
+        args.model,
+        "--dataset-name",
+        "random-ids",
+        "--tokenize-prompt",
+        "--num-prompts",
+        "1",
+        "--random-input-len",
+        "8192",
+        "--random-output-len",
+        "1024",
+        "--random-range-ratio",
+        "1",
+        "--request-rate",
+        "inf",
+        "--warmup-requests",
+        "0",
+        "--max-concurrency",
+        "1",
+        "--seed",
+        str(SEED),
+        "--flush-cache",
+        "--output-file",
+        str(output),
+    ]
+
+
+def gpqa_command(
+    args: argparse.Namespace, public_output: Path, private_output: Path
+) -> list[str]:
+    return [
+        args.python,
+        "-m",
+        "sglang.test.run_eval",
+        "--base-url",
+        args.base_url,
+        "--model",
+        args.model,
+        "--eval-name",
+        "gpqa",
+        "--gpqa-data-path",
+        str(args.gpqa_dataset),
+        "--per-example-output",
+        str(public_output),
+        "--per-example-private-responses",
+        str(private_output),
+        "--num-examples",
+        str(GPQA_TOTAL),
+        "--num-threads",
+        "1",
+        "--max-tokens",
+        "8192",
+        "--temperature",
+        "0",
+        "--repeat",
+        "1",
+    ]
+
+
+def longbench_command(args: argparse.Namespace) -> list[str]:
+    return [
+        args.python,
+        "-m",
+        "sglang.test.run_eval",
+        "--base-url",
+        args.base_url,
+        "--model",
+        args.model,
+        "--eval-name",
+        "longbench_v2",
+        "--dataset-path",
+        str(args.longbench_subset),
+        "--num-examples",
+        str(LONGBENCH_TOTAL),
+        "--num-threads",
+        "1",
+        "--max-tokens",
+        "4096",
+        "--temperature",
+        "0",
+        "--repeat",
+        "1",
+    ]
+
+
+def run_fixed_parity(
+    args: argparse.Namespace, repo: Path, env: dict[str, str], role_dir: Path, role: str
+) -> None:
+    run_checked(
+        [
+            args.python,
+            "benchmark/minimax_m3/record_fixed_parity.py",
+            "--base-url",
+            args.base_url,
+            "--model",
+            args.model,
+            "--label",
+            role,
+            "--output",
+            str(role_dir / "fixed_parity.json"),
+            "--long-tokens",
+            "32768",
+            "65536",
+        ],
+        cwd=repo,
+        env=env,
+    )
+    payload = json.loads((role_dir / "fixed_parity.json").read_text())
+    validate_fixed_parity_payload(payload, role, args.model)
+
+
+def run_warmup(
+    args: argparse.Namespace, repo: Path, env: dict[str, str], role_dir: Path
+) -> None:
+    run_checked(
+        warmup_command(args, role_dir / "warmup.jsonl"),
+        cwd=repo,
+        env=env,
+    )
+    if int(last_jsonl(role_dir / "warmup.jsonl").get("completed", -1)) != 1:
+        raise RuntimeError("warmup did not complete exactly one request")
+
+
+def run_accuracy(
+    args: argparse.Namespace,
+    repo: Path,
+    env: dict[str, str],
+    role_dir: Path,
+    private_dir: Path,
+) -> int:
+    gpqa_public = role_dir / "gpqa_per_example.json"
+    gpqa_private = private_dir / "gpqa_responses.private.jsonl"
+    gpqa_metrics = Path(f"/tmp/gpqa_{args.model.replace('/', '_')}.json")
+    ensure_absent_output(gpqa_metrics, "GPQA legacy metrics")
+    gpqa_started_ns = time.time_ns()
+    run_checked_log(
+        gpqa_command(args, gpqa_public, gpqa_private),
+        cwd=repo,
+        env=env,
+        output=role_dir / "gpqa.log",
+    )
+    client_log_audit(role_dir / "gpqa.log", role_dir / "gpqa_client_audit.json")
+    gpqa_private.chmod(0o600)
+    gpqa = json.loads(gpqa_public.read_text())
+    if len(gpqa.get("examples", [])) != GPQA_TOTAL:
+        raise RuntimeError("GPQA public evidence does not contain 198 examples")
+    correct = sum(bool(row["correct"]) for row in gpqa["examples"])
+    gpqa_score = float(gpqa["summary"]["score"])
+    if not math.isfinite(gpqa_score) or not 0 <= gpqa_score <= 1:
+        raise RuntimeError(f"GPQA score outside [0, 1]: {gpqa_score!r}")
+    if not math.isclose(correct / GPQA_TOTAL, gpqa_score, abs_tol=1e-12):
+        raise RuntimeError("GPQA summary disagrees with public per-example evidence")
+    (role_dir / "gpqa.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "source": "public_per_example_summary",
+                "score": gpqa_score,
+                "correct": correct,
+                "total": GPQA_TOTAL,
+                "per_example_sha256": sha256(gpqa_public),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    legacy_gpqa, gpqa_output_receipt = claim_fresh_json_output(
+        gpqa_metrics,
+        role_dir / "gpqa_legacy_metrics.json",
+        gpqa_started_ns,
+        "GPQA legacy metrics",
+    )
+    legacy_gpqa_score = float(legacy_gpqa["score"])
+    if not math.isfinite(legacy_gpqa_score) or not math.isclose(
+        legacy_gpqa_score, gpqa_score, abs_tol=1e-12
+    ):
+        raise RuntimeError(
+            f"GPQA legacy score disagrees with per-example summary: "
+            f"{legacy_gpqa_score!r} vs {gpqa_score!r}"
+        )
+    (role_dir / "gpqa_legacy_output_receipt.json").write_text(
+        json.dumps(gpqa_output_receipt, indent=2, sort_keys=True) + "\n"
+    )
+
+    longbench_metrics = Path(f"/tmp/longbench_v2_{args.model.replace('/', '_')}.json")
+    ensure_absent_output(longbench_metrics, "LongBench metrics")
+    longbench_started_ns = time.time_ns()
+    run_checked_log(
+        longbench_command(args),
+        cwd=repo,
+        env=env,
+        output=role_dir / "longbench_v2.log",
+    )
+    client_log_audit(
+        role_dir / "longbench_v2.log", role_dir / "longbench_v2_client_audit.json"
+    )
+    longbench, output_receipt = claim_fresh_json_output(
+        longbench_metrics,
+        role_dir / "longbench_v2.json",
+        longbench_started_ns,
+        "LongBench metrics",
+    )
+    (role_dir / "longbench_v2_output_receipt.json").write_text(
+        json.dumps(output_receipt, indent=2, sort_keys=True) + "\n"
+    )
+    shutil.copy2(
+        Path(str(args.longbench_subset) + ".manifest.json"),
+        role_dir / "longbench_v2_subset_manifest.json",
+    )
+    longbench_score = float(longbench["score"])
+    if not math.isfinite(longbench_score) or not 0 <= longbench_score <= 1:
+        raise RuntimeError("LongBench score is outside [0, 1]")
+    log_text = (role_dir / "longbench_v2.log").read_text(errors="replace")
+    matches = re.findall(r"^Score: ([0-9]+(?:\.[0-9]+)?)$", log_text, re.MULTILINE)
+    if len(matches) != 1 or not math.isclose(
+        float(matches[0]), longbench_score, abs_tol=0.00051
+    ):
+        raise RuntimeError(
+            f"LongBench stdout score does not match JSON: {matches} vs {longbench_score}"
+        )
+    return GPQA_TOTAL + LONGBENCH_TOTAL
+
+
+def run_speed(
+    args: argparse.Namespace, repo: Path, env: dict[str, str], role_dir: Path
+) -> int:
+    for concurrency in CONCURRENCIES:
+        output = role_dir / f"serving_c{concurrency}.jsonl"
+        run_checked_log(
+            speed_command(args, output, concurrency),
+            cwd=repo,
+            env=env,
+            output=role_dir / f"serving_c{concurrency}.log",
+        )
+        client_log_audit(
+            role_dir / f"serving_c{concurrency}.log",
+            role_dir / f"serving_c{concurrency}_client_audit.json",
+        )
+        row = last_jsonl(output)
+        validate_serving_record(row, concurrency)
+    return NUM_PROMPTS * len(CONCURRENCIES)
+
+
+def precompile_source(
+    args: argparse.Namespace,
+    repo: Path,
+    env: dict[str, str],
+    role_dir: Path,
+    cache_dir: Path,
+) -> None:
+    run_checked(
+        [
+            args.python,
+            "benchmark/minimax_m3/precompile_fmha_sm100.py",
+            "--cache-dir",
+            str(cache_dir / "minfer-fmha"),
+            "--output",
+            str(role_dir / "source_precompile_receipt.json"),
+        ],
+        cwd=repo,
+        env=env,
+    )
+
+
+def run_role(
+    *,
+    args: argparse.Namespace,
+    repo: Path,
+    base_environment: dict[str, str],
+    repetition: int,
+    role: str,
+) -> None:
+    rep_dir = args.output_root / f"rep{repetition:02d}"
+    role_dir = rep_dir / role
+    role_dir.mkdir()
+    private_dir = args.output_root / "private" / f"rep{repetition:02d}" / role
+    private_dir.mkdir(parents=True)
+    private_dir.chmod(0o700)
+    server_log = rep_dir / f"{role}_server.log"
+    cache_dir = args.cache_root / args.mode / f"rep{repetition:02d}" / role
+    initialize_fresh_cache(cache_dir)
+
+    environment = role_environment(base_environment, role)
+    environment["PYTHONUNBUFFERED"] = "1"
+    environment.update(arm_cache_environment(cache_dir))
+    if role == "external":
+        precompile_source(args, repo, environment, role_dir, cache_dir)
+
+    prelaunch_clear = not server_healthy(args.base_url)
+    if not prelaunch_clear:
+        raise RuntimeError(f"port is not clear before {role} launch")
+    launch = server_command(args)
+    print(
+        f"+ {args.mode}/rep{repetition:02d}/{role}: {command_text(launch)}", flush=True
+    )
+    process: subprocess.Popen | None = None
+    route_line = ""
+    measured: dict | None = None
+    try:
+        with server_log.open("x") as log:
+            process = subprocess.Popen(
+                launch,
+                cwd=repo,
+                env=environment,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+            wait_for_server(process, args.base_url, server_log, args.server_timeout)
+            log.flush()
+            os.fsync(log.fileno())
+            route_line = validate_route(server_log, role)
+            run_warmup(args, repo, environment, role_dir)
+            if fixed_parity_required(args.mode):
+                run_fixed_parity(args, repo, environment, role_dir, role)
+            log.flush()
+            os.fsync(log.fileno())
+            start = server_log.stat().st_size
+            (role_dir / "measured_server_log_start_offset.txt").write_text(f"{start}\n")
+            startup_audit(server_log, start, role_dir / "startup_audit.json")
+            sampler = ThermalSampler(role_dir / "thermal.csv")
+            sampler.start()
+            try:
+                if args.mode == "accuracy":
+                    expected_posts = run_accuracy(
+                        args, repo, environment, role_dir, private_dir
+                    )
+                else:
+                    expected_posts = run_speed(args, repo, environment, role_dir)
+                if process.poll() is not None:
+                    raise RuntimeError(
+                        f"server exited during {role}:\n{tail(server_log)}"
+                    )
+            finally:
+                sampler.stop()
+            log.flush()
+            os.fsync(log.fileno())
+            end = server_log.stat().st_size
+            (role_dir / "measured_server_log_end_offset.txt").write_text(f"{end}\n")
+            measured = measured_audit(
+                role_dir=role_dir,
+                log_path=server_log,
+                start=start,
+                end=end,
+                sampler=sampler,
+                expected_posts=expected_posts,
+                expected_endpoint=(
+                    "/v1/chat/completions" if args.mode == "accuracy" else "/generate"
+                ),
+            )
+    finally:
+        if process is not None:
+            stop_server(process, args.base_url)
+    poststop_clear = not server_healthy(args.base_url)
+    lifecycle_problems = lifecycle_failures(
+        prelaunch_clear=prelaunch_clear,
+        poststop_clear=poststop_clear,
+        measured=measured,
+    )
+    lifecycle = {
+        "schema_version": 1,
+        "status": "pass" if not lifecycle_problems else "fail",
+        "mode": args.mode,
+        "repetition": repetition,
+        "role": role,
+        "route_fragments": list(route_fragments(role)),
+        "matched_route_line": route_line,
+        "prelaunch_port_clear": prelaunch_clear,
+        "poststop_port_clear": poststop_clear,
+        "fresh_server_process": True,
+        "fresh_cache_policy": {
+            "cache_root": str(cache_dir),
+            "initially_absent": True,
+            "source_serial_precompile": role == "external",
+            "shared_across_arms": False,
+            "redirected_environment": {
+                name: environment[name]
+                for name in (
+                    "FLASHINFER_WORKSPACE_BASE",
+                    "TORCH_EXTENSIONS_DIR",
+                    "XDG_CACHE_HOME",
+                    "MINFER_FMHA_CACHE_DIR",
+                    "SGLANG_CACHE_DIR",
+                    "SGLANG_JIT_CACHE_DIR",
+                    "SGLANG_DG_CACHE_DIR",
+                    "DG_JIT_CACHE_DIR",
+                    "TRITON_CACHE_DIR",
+                    "TORCHINDUCTOR_CACHE_DIR",
+                    "CUDA_CACHE_PATH",
+                    "FLASH_ATTENTION_CUTE_DSL_CACHE_DIR",
+                )
+            },
+        },
+        "fixed_parity_sha256": (
+            sha256(role_dir / "fixed_parity.json")
+            if fixed_parity_required(args.mode)
+            else None
+        ),
+        "measured_window_audit_sha256": sha256(role_dir / "measured_window_audit.json"),
+        "failures": lifecycle_problems,
+    }
+    (role_dir / "lifecycle_route_cache_receipt.json").write_text(
+        json.dumps(lifecycle, indent=2, sort_keys=True) + "\n"
+    )
+    require_lifecycle(
+        prelaunch_clear=prelaunch_clear,
+        poststop_clear=poststop_clear,
+        measured=measured,
+    )
+
+
+def gpqa_pair_audit(source_path: Path, export_path: Path) -> dict:
+    external = json.loads(source_path.read_text())
+    flashinfer = json.loads(export_path.read_text())
+    left = {row["question_id"]: row for row in external["examples"]}
+    right = {row["question_id"]: row for row in flashinfer["examples"]}
+    if list(left) != list(right) or len(left) != GPQA_TOTAL:
+        raise ValueError("GPQA per-example IDs/order differ")
+    rows = []
+    for question_id in left:
+        a, b = left[question_id], right[question_id]
+        rows.append(
+            {
+                "question_id": question_id,
+                "source_correct": bool(a["correct"]),
+                "export_correct": bool(b["correct"]),
+                "source_parsed_answer": a["parsed_answer"],
+                "export_parsed_answer": b["parsed_answer"],
+                "source_response_sha256": a["response_sha256"],
+                "export_response_sha256": b["response_sha256"],
+            }
+        )
+    source_correct = sum(row["source_correct"] for row in rows)
+    export_correct = sum(row["export_correct"] for row in rows)
+    return {
+        "summary": {
+            "total": GPQA_TOTAL,
+            "source_correct": source_correct,
+            "export_correct": export_correct,
+            "delta_questions": export_correct - source_correct,
+            "gain": sum(
+                (not row["source_correct"]) and row["export_correct"] for row in rows
+            ),
+            "loss": sum(
+                row["source_correct"] and (not row["export_correct"]) for row in rows
+            ),
+            "parsed_answer_changed": sum(
+                row["source_parsed_answer"] != row["export_parsed_answer"]
+                for row in rows
+            ),
+            "response_hash_changed": sum(
+                row["source_response_sha256"] != row["export_response_sha256"]
+                for row in rows
+            ),
+        },
+        "examples": rows,
+    }
+
+
+def cross_rep_stability(root: Path, role: str) -> dict:
+    per_rep = []
+    for repetition in range(1, repetitions_for_mode("accuracy") + 1):
+        payload = json.loads(
+            (root / f"rep{repetition:02d}" / role / "gpqa_per_example.json").read_text()
+        )
+        per_rep.append({row["question_id"]: row for row in payload["examples"]})
+    ids = list(per_rep[0])
+    if any(list(rep) != ids for rep in per_rep[1:]):
+        raise ValueError(f"{role} GPQA IDs/order differ across repetitions")
+    pairwise = []
+    for left_index, right_index in ((0, 1), (0, 2), (1, 2)):
+        pairwise.append(
+            {
+                "left_rep": left_index + 1,
+                "right_rep": right_index + 1,
+                "correctness_changed": sum(
+                    bool(per_rep[left_index][qid]["correct"])
+                    != bool(per_rep[right_index][qid]["correct"])
+                    for qid in ids
+                ),
+                "parsed_answer_changed": sum(
+                    per_rep[left_index][qid]["parsed_answer"]
+                    != per_rep[right_index][qid]["parsed_answer"]
+                    for qid in ids
+                ),
+                "response_hash_changed": sum(
+                    per_rep[left_index][qid]["response_sha256"]
+                    != per_rep[right_index][qid]["response_sha256"]
+                    for qid in ids
+                ),
+            }
+        )
+    return {"role": role, "total": GPQA_TOTAL, "pairwise": pairwise}
+
+
+def summarize_accuracy(root: Path) -> dict:
+    repetitions = []
+    gpqa_deltas = []
+    longbench_deltas = []
+    failures = []
+    for repetition in range(1, repetitions_for_mode("accuracy") + 1):
+        rep_dir = root / f"rep{repetition:02d}"
+        audit = gpqa_pair_audit(
+            rep_dir / "external" / "gpqa_per_example.json",
+            rep_dir / "flashinfer" / "gpqa_per_example.json",
+        )
+        (rep_dir / "gpqa_pair_audit.json").write_text(
+            json.dumps(audit, indent=2, sort_keys=True) + "\n"
+        )
+        gpqa_delta = audit["summary"]["delta_questions"]
+        source_lb = float(
+            json.loads((rep_dir / "external" / "longbench_v2.json").read_text())[
+                "score"
+            ]
+        )
+        export_lb = float(
+            json.loads((rep_dir / "flashinfer" / "longbench_v2.json").read_text())[
+                "score"
+            ]
+        )
+        if not math.isfinite(source_lb) or not 0 <= source_lb <= 1:
+            raise RuntimeError(
+                f"rep{repetition:02d} external LongBench invalid: {source_lb!r}"
+            )
+        if not math.isfinite(export_lb) or not 0 <= export_lb <= 1:
+            raise RuntimeError(
+                f"rep{repetition:02d} FlashInfer LongBench invalid: {export_lb!r}"
+            )
+        lb_delta = export_lb - source_lb
+        gpqa_pass = gpqa_delta >= -GPQA_MARGIN_QUESTIONS
+        lb_pass = within_noninferiority_margin(lb_delta, LONGBENCH_MARGIN)
+        if not gpqa_pass:
+            failures.append(f"rep{repetition:02d} GPQA delta {gpqa_delta} < -1")
+        if not lb_pass:
+            failures.append(f"rep{repetition:02d} LongBench delta {lb_delta} < -0.02")
+        gpqa_deltas.append(gpqa_delta)
+        longbench_deltas.append(lb_delta)
+        repetitions.append(
+            {
+                "repetition": repetition,
+                "order": expected_order("accuracy", repetition),
+                "gpqa": {**audit["summary"], "pass": gpqa_pass},
+                "longbench_v2": {
+                    "source_score": source_lb,
+                    "export_score": export_lb,
+                    "delta": lb_delta,
+                    "pass": lb_pass,
+                },
+            }
+        )
+    gpqa_mean = statistics.mean(gpqa_deltas)
+    gpqa_median = statistics.median(gpqa_deltas)
+    lb_mean = statistics.mean(longbench_deltas)
+    lb_median = statistics.median(longbench_deltas)
+    if gpqa_mean < -1 or gpqa_median < -1:
+        failures.append("aggregate GPQA mean/median violates one-question margin")
+    if not within_noninferiority_margin(
+        lb_mean, LONGBENCH_MARGIN
+    ) or not within_noninferiority_margin(lb_median, LONGBENCH_MARGIN):
+        failures.append("aggregate LongBench mean/median violates 0.02 margin")
+    payload = {
+        "schema_version": 1,
+        "status": "pass" if not failures else "fail",
+        "repetitions": repetitions,
+        "aggregate": {
+            "gpqa_delta_questions_mean": gpqa_mean,
+            "gpqa_delta_questions_median": gpqa_median,
+            "longbench_delta_mean": lb_mean,
+            "longbench_delta_median": lb_median,
+        },
+        "cross_rep_stability": {
+            role: cross_rep_stability(root, role) for role in ("external", "flashinfer")
+        },
+        "failures": failures,
+    }
+    if failures:
+        raise RuntimeError("accuracy summary failed: " + "; ".join(failures))
+    return payload
+
+
+def summarize_speed(root: Path, mode: str, min_median_gain: float) -> dict:
+    if not math.isfinite(min_median_gain) or min_median_gain < 0:
+        raise RuntimeError(
+            f"minimum median throughput gain must be finite and nonnegative: {min_median_gain!r}"
+        )
+    baseline, candidate = roles_for_mode(mode)
+    repetitions = []
+    gains = {str(value): [] for value in CONCURRENCIES}
+    for repetition in range(1, repetitions_for_mode(mode) + 1):
+        rep = {
+            "repetition": repetition,
+            "order": expected_order(mode, repetition),
+            "metrics": {},
+        }
+        for concurrency in CONCURRENCIES:
+            left = last_jsonl(
+                root
+                / f"rep{repetition:02d}"
+                / baseline
+                / f"serving_c{concurrency}.jsonl"
+            )
+            right = last_jsonl(
+                root
+                / f"rep{repetition:02d}"
+                / candidate
+                / f"serving_c{concurrency}.jsonl"
+            )
+            validate_serving_record(left, concurrency)
+            validate_serving_record(right, concurrency)
+            left_throughput = float(left["output_throughput"])
+            right_throughput = float(right["output_throughput"])
+            left_ttft = float(left["median_ttft_ms"])
+            right_ttft = float(right["median_ttft_ms"])
+            throughput_gain = right_throughput / left_throughput - 1
+            ttft_reduction = 1 - right_ttft / left_ttft
+            if not math.isfinite(throughput_gain) or not math.isfinite(ttft_reduction):
+                raise RuntimeError(
+                    f"c{concurrency} derived speed metric is non-finite: "
+                    f"throughput_gain={throughput_gain!r}, ttft_reduction={ttft_reduction!r}"
+                )
+            gains[str(concurrency)].append(throughput_gain)
+            rep["metrics"][str(concurrency)] = {
+                "baseline_role": baseline,
+                "baseline_output_throughput": left["output_throughput"],
+                "export_output_throughput": right["output_throughput"],
+                "output_throughput_gain": throughput_gain,
+                "baseline_median_ttft_ms": left["median_ttft_ms"],
+                "export_median_ttft_ms": right["median_ttft_ms"],
+                "ttft_latency_reduction": ttft_reduction,
+            }
+        repetitions.append(rep)
+    aggregate = {}
+    failures = []
+    for concurrency in CONCURRENCIES:
+        values = gains[str(concurrency)]
+        aggregate[str(concurrency)] = {
+            "output_throughput_gain_mean": statistics.mean(values),
+            "output_throughput_gain_median": statistics.median(values),
+        }
+        if statistics.median(values) < min_median_gain:
+            failures.append(
+                f"c{concurrency} median throughput gain {statistics.median(values)} "
+                f"< {min_median_gain}"
+            )
+    payload = {
+        "schema_version": 1,
+        "status": "pass" if not failures else "fail",
+        "mode": mode,
+        "baseline_role": baseline,
+        "candidate_role": candidate,
+        "repetitions": repetitions,
+        "aggregate": aggregate,
+        "minimum_median_output_throughput_gain": min_median_gain,
+        "failures": failures,
+    }
+    if failures:
+        raise RuntimeError("speed summary failed: " + "; ".join(failures))
+    return payload
+
+
+def run_test_only(output: Path | None) -> None:
+    results: list[dict[str, str]] = []
+
+    def require(condition: bool, message: str) -> None:
+        if not condition:
+            raise AssertionError(message)
+
+    def passed(test_id: str, detail: str = "") -> None:
+        results.append({"id": test_id, "status": "pass", "detail": detail})
+
+    def expect_failure(
+        test_id: str,
+        function,
+        exception_type: type[BaseException] = RuntimeError,
+        contains: str | None = None,
+    ) -> str:
+        try:
+            function()
+        except exception_type as error:
+            message = str(error)
+            if contains is not None and contains not in message:
+                raise AssertionError(
+                    f"{test_id}: expected {contains!r} in {message!r}"
+                ) from error
+            passed(test_id, f"observed {type(error).__name__}: {message}")
+            return message
+        raise AssertionError(f"{test_id}: synthetic failure was accepted")
+
+    orders = {
+        mode: [
+            expected_order(mode, rep)
+            for rep in range(1, repetitions_for_mode(mode) + 1)
+        ]
+        for mode in ("accuracy", "external-speed", "triton-speed")
+    }
+    require(
+        loopback_environment({})["OPENAI_API_KEY"] == "EMPTY",
+        "loopback evaluator dummy key was not injected",
+    )
+    require(
+        loopback_environment({"OPENAI_API_KEY": "explicit"})["OPENAI_API_KEY"]
+        == "explicit",
+        "explicit evaluator API key was overwritten",
+    )
+    passed("loopback_api_key_default_and_preservation_contract")
+    require(
+        orders["accuracy"]
+        == [
+            ["external", "flashinfer"],
+            ["flashinfer", "external"],
+            ["external", "flashinfer"],
+        ],
+        "accuracy order contract mismatch",
+    )
+    require(
+        orders["external-speed"] == [["external", "flashinfer"]],
+        "external speed order contract mismatch",
+    )
+    require(
+        orders["triton-speed"] == [["triton", "flashinfer"]],
+        "triton speed order contract mismatch",
+    )
+    passed("alternating_order_contract")
+    require(
+        repetitions_for_mode("accuracy") == 3
+        and repetitions_for_mode("external-speed") == 1
+        and repetitions_for_mode("triton-speed") == 1,
+        "mode-specific repetition counts drifted",
+    )
+    passed("mode_specific_repetition_counts")
+    require(fixed_parity_required("accuracy"), "accuracy fixed parity was disabled")
+    require(
+        not fixed_parity_required("external-speed")
+        and not fixed_parity_required("triton-speed"),
+        "a speed-only mode would send accuracy requests",
+    )
+    passed("speed_modes_have_no_accuracy_requests")
+    expect_failure(
+        "wrong_order_rejected",
+        lambda: validate_order("accuracy", 1, ["flashinfer", "external"]),
+        contains="wrong accuracy",
+    )
+
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "server.log"
+        for role in ("external", "flashinfer", "triton"):
+            line = "prefix " + ", ".join(route_fragments(role)) + " suffix"
+            path.write_text(line + "\n")
+            require(validate_route(path, role) == line, f"{role} route mismatch")
+            path.write_text("wrong route\n")
+            expect_failure(
+                f"wrong_{role}_route_rejected",
+                lambda role=role: validate_route(path, role),
+                contains="did not confirm",
+            )
+        passed("all_routes_positive_contract")
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        server_log = root / "server.log"
+        role_dir = root / "role"
+        role_dir.mkdir()
+        thermal_path = role_dir / "thermal.csv"
+
+        def write_thermal(active: bool = False) -> None:
+            rows = [
+                "timestamp,index,temperature_gpu_c,power_draw_w,clocks_current_sm_mhz,"
+                "clocks_max_sm_mhz,sw_thermal_slowdown,hw_thermal_slowdown"
+            ]
+            for sample in range(2):
+                for index in range(4):
+                    value = (
+                        "Active"
+                        if active and sample == 0 and index == 0
+                        else "Not Active"
+                    )
+                    rows.append(
+                        f"t{sample},{index},40,100,1000,2000,{value},Not Active"
+                    )
+            thermal_path.write_text("\n".join(rows) + "\n")
+
+        sampler = argparse.Namespace(errors=[])
+        startup = "startup JIT compile\n"
+        post = 'POST /v1/chat/completions HTTP/1.1" 200 OK\n'
+        server_log.write_text(startup + post)
+        write_thermal()
+        require(
+            measured_audit(
+                role_dir=role_dir,
+                log_path=server_log,
+                start=len(startup.encode()),
+                end=server_log.stat().st_size,
+                sampler=sampler,
+                expected_posts=1,
+                expected_endpoint="/v1/chat/completions",
+            )["status"]
+            == "pass",
+            "measured offset contract failed",
+        )
+        passed("measured_offset_excludes_startup_jit")
+        expect_failure(
+            "measured_log_shrink_rejected",
+            lambda: log_segment(server_log, 10, 9),
+            ValueError,
+            "shrank",
+        )
+        expect_failure(
+            "measured_post_count_rejected",
+            lambda: measured_audit(
+                role_dir=role_dir,
+                log_path=server_log,
+                start=len(startup.encode()),
+                end=server_log.stat().st_size,
+                sampler=sampler,
+                expected_posts=2,
+                expected_endpoint="/v1/chat/completions",
+            ),
+            contains="/v1/chat/completions posts 1/2",
+        )
+        for test_id, bad_line, wanted in (
+            ("measured_jit_rejected", "NVRTC compilation\n", "jit_or_compilation"),
+            ("measured_error_rejected", "RuntimeError: boom\n", "errors"),
+            (
+                "measured_generic_error_rejected",
+                "[worker ERROR] request aborted\n",
+                "errors",
+            ),
+            ("measured_retry_rejected", "retrying request\n", "retries"),
+        ):
+            server_log.write_text(post + bad_line)
+            write_thermal()
+            expect_failure(
+                test_id,
+                lambda: measured_audit(
+                    role_dir=role_dir,
+                    log_path=server_log,
+                    start=0,
+                    end=server_log.stat().st_size,
+                    sampler=sampler,
+                    expected_posts=1,
+                    expected_endpoint="/v1/chat/completions",
+                ),
+                contains=wanted,
+            )
+        server_log.write_text(post)
+        write_thermal(active=True)
+        expect_failure(
+            "thermal_throttle_rejected",
+            lambda: measured_audit(
+                role_dir=role_dir,
+                log_path=server_log,
+                start=0,
+                end=server_log.stat().st_size,
+                sampler=sampler,
+                expected_posts=1,
+                expected_endpoint="/v1/chat/completions",
+            ),
+            contains="thermal_slowdown",
+        )
+
+        server_log.write_text(
+            'POST /generate HTTP/1.1" 200 OK\nPOST /generate HTTP/1.1" 200 OK\n'
+        )
+        write_thermal()
+        require(
+            measured_audit(
+                role_dir=role_dir,
+                log_path=server_log,
+                start=0,
+                end=server_log.stat().st_size,
+                sampler=sampler,
+                expected_posts=2,
+                expected_endpoint="/generate",
+            )["successful_posts"]
+            == 2,
+            "native serving endpoint count mismatch",
+        )
+        passed("native_generate_endpoint_count_contract")
+        expect_failure(
+            "wrong_endpoint_count_rejected",
+            lambda: measured_audit(
+                role_dir=role_dir,
+                log_path=server_log,
+                start=0,
+                end=server_log.stat().st_size,
+                sampler=sampler,
+                expected_posts=2,
+                expected_endpoint="/v1/chat/completions",
+            ),
+            contains="posts 0/2",
+        )
+
+        client_log = root / "client.log"
+        client_receipt = root / "client-audit.json"
+        client_log.write_text("Score: 0.5\nCompleted: 198\n")
+        require(
+            client_log_audit(client_log, client_receipt)["status"] == "pass",
+            "positive client log was rejected",
+        )
+        passed("client_log_positive_contract")
+        for test_id, bad_line, wanted in (
+            ("client_log_retry_rejected", "retrying request 7\n", "retries"),
+            ("client_log_error_rejected", "RuntimeError: request failed\n", "errors"),
+            ("client_log_exhausted_rejected", "attempts exhausted\n", "errors"),
+            ("client_log_timeout_rejected", "request timed out\n", "timeouts"),
+        ):
+            client_log.write_text(bad_line)
+            expect_failure(
+                test_id,
+                lambda: client_log_audit(client_log, client_receipt),
+                contains=wanted,
+            )
+
+    def valid_serving_record(
+        concurrency: int, throughput: float = 100.0, ttft: float = 10.0
+    ) -> dict:
+        return {
+            "completed": NUM_PROMPTS,
+            "failed": 0,
+            "dataset_name": "random-ids",
+            "random_input_len": 8192,
+            "random_output_len": 1024,
+            "random_range_ratio": 1.0,
+            "max_concurrency": concurrency,
+            "total_input_tokens": NUM_PROMPTS * 8192,
+            "total_output_tokens": NUM_PROMPTS * 1024,
+            "output_throughput": throughput,
+            "median_ttft_ms": ttft,
+        }
+
+    good_record = valid_serving_record(8)
+    validate_serving_record(good_record, 8)
+    passed("serving_request_count_positive")
+    expect_failure(
+        "serving_completed_count_rejected",
+        lambda: validate_serving_record(
+            {**valid_serving_record(8), "completed": NUM_PROMPTS - 1}, 8
+        ),
+        contains="completed",
+    )
+    for key in ("failed", "failed_requests", "num_failed_requests"):
+        expect_failure(
+            f"serving_{key}_rejected",
+            lambda key=key: validate_serving_record(
+                {**valid_serving_record(8), key: 1}, 8
+            ),
+            contains=key,
+        )
+    for key, bad_value in (
+        ("dataset_name", "sharegpt"),
+        ("random_input_len", 8191),
+        ("random_output_len", 1023),
+        ("random_range_ratio", 0.9),
+        ("max_concurrency", 7),
+        ("total_input_tokens", NUM_PROMPTS * 8192 - 1),
+        ("total_output_tokens", NUM_PROMPTS * 1024 - 1),
+    ):
+        expect_failure(
+            f"serving_{key}_tamper_rejected",
+            lambda key=key, bad_value=bad_value: validate_serving_record(
+                {**valid_serving_record(8), key: bad_value}, 8
+            ),
+            contains=key,
+        )
+    for key in ("output_throughput", "median_ttft_ms"):
+        for suffix, bad_value in (
+            ("nan", float("nan")),
+            ("inf", float("inf")),
+            ("zero", 0.0),
+            ("negative", -1.0),
+        ):
+            expect_failure(
+                f"serving_{key}_{suffix}_rejected",
+                lambda key=key, bad_value=bad_value: validate_serving_record(
+                    {**valid_serving_record(8), key: bad_value}, 8
+                ),
+                contains="finite and positive",
+            )
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "serving.jsonl"
+        path.write_text(json.dumps(valid_serving_record(1)) + "\n")
+        require(last_jsonl(path)["completed"] == NUM_PROMPTS, "single JSONL rejected")
+        passed("single_serving_record_positive")
+        path.write_text(
+            json.dumps(valid_serving_record(1))
+            + "\n"
+            + json.dumps(valid_serving_record(1))
+            + "\n"
+        )
+        expect_failure(
+            "duplicate_serving_records_rejected",
+            lambda: last_jsonl(path),
+            ValueError,
+            "exactly one benchmark record",
+        )
+
+    args = argparse.Namespace(
+        python="python",
+        base_url="http://127.0.0.1:30000",
+        model="/model",
+        gpqa_dataset=Path("/gpqa.csv"),
+        longbench_subset=Path("/longbench.json"),
+    )
+    command = speed_command(args, Path("/out.jsonl"), 32)
+    option = lambda name: command[command.index(name) + 1]
+    require(option("--backend") == "sglang", "speed backend is not native sglang")
+    require(option("--num-prompts") == "256", "speed prompt count drifted")
+    require(option("--random-input-len") == "8192", "speed input length drifted")
+    require(option("--random-output-len") == "1024", "speed output length drifted")
+    require(
+        option("--warmup-requests") == "0", "speed implicit warmup was not disabled"
+    )
+    require(option("--max-concurrency") == "32", "speed concurrency drifted")
+    require(
+        option("--seed") == str(SEED) and "--flush-cache" in command,
+        "speed seed or cache-flush contract drifted",
+    )
+    passed("speed_fixed_workload_contract")
+    warmup = warmup_command(args, Path("/warmup.jsonl"))
+    warmup_option = lambda name: warmup[warmup.index(name) + 1]
+    require(warmup_option("--num-prompts") == "1", "warmup prompt count drifted")
+    require(
+        warmup_option("--warmup-requests") == "0",
+        "warmup command would send an implicit extra request",
+    )
+    passed("exactly_one_unmeasured_warmup_contract")
+    gpqa = gpqa_command(args, Path("/public.json"), Path("/private.jsonl"))
+    longbench = longbench_command(args)
+    gpqa_option = lambda name: gpqa[gpqa.index(name) + 1]
+    lb_option = lambda name: longbench[longbench.index(name) + 1]
+    require(
+        gpqa_option("--num-examples") == "198" and gpqa_option("--num-threads") == "1",
+        "GPQA fixed workload drifted",
+    )
+    require(
+        "--per-example-output" in gpqa and "--per-example-private-responses" in gpqa,
+        "GPQA evidence flags are incomplete",
+    )
+    require(
+        lb_option("--num-examples") == "100" and lb_option("--num-threads") == "1",
+        "LongBench fixed workload drifted",
+    )
+    passed("accuracy_fixed_workload_and_private_evidence_contract")
+
+    with tempfile.TemporaryDirectory() as directory:
+        cache = Path(directory) / "cache"
+        initialize_fresh_cache(cache)
+        expect_failure(
+            "stale_cache_rejected",
+            lambda: initialize_fresh_cache(cache),
+            contains="already exists",
+        )
+        first = arm_cache_environment(cache)
+        second = arm_cache_environment(Path(directory) / "other-cache")
+        require(set(first) == set(second), "cache variable sets differ across arms")
+        require(
+            all(Path(value).is_relative_to(cache) for value in first.values()),
+            "a cache variable escapes its arm-local root",
+        )
+        require(
+            set(first.values()).isdisjoint(second.values()),
+            "arm-local cache paths overlap",
+        )
+        passed("all_jit_caches_are_arm_local_and_disjoint")
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        source = root / "producer.json"
+        destination = root / "evidence.json"
+        ensure_absent_output(source, "synthetic")
+        passed("fresh_output_absence_positive")
+        source.write_text('{"score": 1}\n')
+        expect_failure(
+            "stale_output_preexisting_rejected",
+            lambda: ensure_absent_output(source, "synthetic"),
+            contains="already exists",
+        )
+        source.unlink()
+        expect_failure(
+            "missing_fresh_output_rejected",
+            lambda: claim_fresh_json_output(
+                source, destination, time.time_ns(), "synthetic"
+            ),
+            contains="was not created",
+        )
+        started_ns = time.time_ns()
+        source.write_bytes(b"")
+        expect_failure(
+            "empty_fresh_output_rejected",
+            lambda: claim_fresh_json_output(
+                source, destination, started_ns, "synthetic"
+            ),
+            contains="empty",
+        )
+        source.write_text('{"score": 1}\n')
+        os.utime(source, ns=(1, 1))
+        expect_failure(
+            "stale_output_mtime_rejected",
+            lambda: claim_fresh_json_output(
+                source, destination, started_ns, "synthetic"
+            ),
+            contains="predates start",
+        )
+        source.unlink()
+        started_ns = time.time_ns()
+        source.write_text('{"score": 1}\n')
+        payload, receipt = claim_fresh_json_output(
+            source, destination, started_ns, "synthetic"
+        )
+        require(payload == {"score": 1}, "fresh output payload drifted")
+        require(
+            not source.exists() and destination.is_file(), "fresh output was not moved"
+        )
+        require(
+            receipt["source_sha256"] == sha256(destination)
+            and receipt["source_mtime_ns"] >= started_ns
+            and receipt["source_inode"] > 0,
+            "fresh output receipt is incomplete",
+        )
+        passed("fresh_output_claim_receipt_positive")
+
+    with tempfile.TemporaryDirectory() as directory:
+        repo = Path(directory) / "repo"
+        subprocess.run(["git", "init", "-q", str(repo)], check=True)
+        (repo / "tracked").write_text("frozen\n")
+        subprocess.run(["git", "-C", str(repo), "add", "tracked"], check=True)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "-c",
+                "user.name=Formal V2",
+                "-c",
+                "user.email=formal-v2@example.invalid",
+                "commit",
+                "-qm",
+                "frozen",
+            ],
+            check=True,
+        )
+        head = subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True
+        ).strip()
+        tree = subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD^{tree}"], text=True
+        ).strip()
+        validate_checkout(repo, head, tree, "synthetic")
+        passed("frozen_checkout_positive")
+        expect_failure(
+            "stale_head_rejected",
+            lambda: validate_checkout(repo, "0" * 40, tree, "synthetic"),
+            contains="head=",
+        )
+        expect_failure(
+            "stale_tree_rejected",
+            lambda: validate_checkout(repo, head, "0" * 40, "synthetic"),
+            contains="tree=",
+        )
+        (repo / "untracked").write_text("dirty\n")
+        expect_failure(
+            "dirty_checkout_rejected",
+            lambda: validate_checkout(repo, head, tree, "synthetic"),
+            contains="dirty=",
+        )
+
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "input"
+        path.write_text("frozen\n")
+        expected = sha256(path)
+        require_sha256(path, expected, "positive")
+        passed("immutable_hash_positive")
+        path.write_text("tampered\n")
+        for test_id, label in (
+            ("stale_dataset_hash_rejected", "dataset"),
+            ("stale_container_hash_rejected", "container"),
+            ("stale_bundle_hash_rejected", "bundle"),
+        ):
+            expect_failure(
+                test_id,
+                lambda label=label: require_sha256(path, expected, label),
+                contains="SHA-256 mismatch",
+            )
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory) / "checkpoint"
+        root.mkdir()
+        (root / "config.json").write_text("{}\n")
+        (root / "weights.bin").write_bytes(b"weights")
+        rows = []
+        aggregate = hashlib.sha256()
+        for path in sorted(root.iterdir()):
+            relative = path.name
+            size = path.stat().st_size
+            digest = sha256(path)
+            rows.append({"path": relative, "size": size, "sha256": digest})
+            aggregate.update(
+                relative.encode()
+                + b"\0"
+                + str(size).encode()
+                + b"\0"
+                + digest.encode()
+                + b"\n"
+            )
+        manifest = Path(directory) / "manifest.json"
+        payload = {
+            "schema_version": 1,
+            "status": "pass",
+            "file_count": len(rows),
+            "total_bytes": sum(row["size"] for row in rows),
+            "aggregate_sha256": aggregate.hexdigest(),
+            "files": rows,
+        }
+        manifest.write_text(json.dumps(payload, sort_keys=True) + "\n")
+        receipt = verify_file_manifest(
+            root, manifest, sha256(manifest), aggregate.hexdigest(), "synthetic model"
+        )
+        require(receipt["file_count"] == 2, "model manifest positive count drifted")
+        passed("full_model_manifest_positive")
+        expect_failure(
+            "stale_model_manifest_hash_rejected",
+            lambda: verify_file_manifest(
+                root, manifest, "0" * 64, aggregate.hexdigest(), "synthetic model"
+            ),
+            contains="manifest SHA-256 mismatch",
+        )
+        expect_failure(
+            "stale_model_aggregate_rejected",
+            lambda: verify_file_manifest(
+                root, manifest, sha256(manifest), "0" * 64, "synthetic model"
+            ),
+            contains="manifest aggregate mismatch",
+        )
+        (root / "weights.bin").write_bytes(b"tampered")
+        expect_failure(
+            "model_file_tamper_rejected",
+            lambda: verify_file_manifest(
+                root,
+                manifest,
+                sha256(manifest),
+                aggregate.hexdigest(),
+                "synthetic model",
+            ),
+            contains="file mismatch",
+        )
+        (root / "weights.bin").write_bytes(b"weights")
+        (root / "unexpected").write_text("x")
+        expect_failure(
+            "model_file_set_drift_rejected",
+            lambda: verify_file_manifest(
+                root,
+                manifest,
+                sha256(manifest),
+                aggregate.hexdigest(),
+                "synthetic model",
+            ),
+            contains="file-set mismatch",
+        )
+
+    parity_records = [
+        {
+            "name": name,
+            "expected": expected,
+            "content": expected,
+            "exact_expected": True,
+            "prompt_tokens": prompt_tokens,
+            "reasoning_content": "",
+            "response_sha256": digest * 64,
+            "usage": {},
+        }
+        for name, expected, prompt_tokens, digest in (
+            ("short", "MSA-SHORT-4B19", 8, "a"),
+            ("long_32768", "MSA-32768-C7F29A", 32768, "b"),
+            ("long_65536", "MSA-65536-C7F29A", 65536, "c"),
+        )
+    ]
+    valid_parity = {"label": "external", "model": "/model", "records": parity_records}
+    validate_fixed_parity_payload(valid_parity, "external", "/model")
+    passed("fixed_parity_real_producer_schema_positive")
+    expect_failure(
+        "fixed_parity_list_schema_rejected",
+        lambda: validate_fixed_parity_payload(parity_records, "external", "/model"),
+        contains="fixed parity failed",
+    )
+    expect_failure(
+        "fixed_parity_results_schema_rejected",
+        lambda: validate_fixed_parity_payload(
+            {"label": "external", "model": "/model", "results": parity_records},
+            "external",
+            "/model",
+        ),
+        contains="fixed parity failed",
+    )
+    expect_failure(
+        "fixed_parity_mismatch_rejected",
+        lambda: validate_fixed_parity_payload(
+            {
+                "label": "flashinfer",
+                "model": "/model",
+                "records": [
+                    parity_records[0],
+                    {**parity_records[1], "exact_expected": False},
+                    parity_records[2],
+                ],
+            },
+            "flashinfer",
+            "/model",
+        ),
+        contains="fixed parity failed",
+    )
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        for repetition in range(1, repetitions_for_mode("accuracy") + 1):
+            rep = root / f"rep{repetition:02d}"
+            for role in ("external", "flashinfer"):
+                role_dir = rep / role
+                role_dir.mkdir(parents=True)
+                correct_limit = 100 if role == "external" else 98
+                rows = [
+                    {
+                        "question_id": f"q{index:03d}",
+                        "correct": index < correct_limit,
+                        "parsed_answer": "A",
+                        "response_sha256": f"{index:064x}",
+                    }
+                    for index in range(GPQA_TOTAL)
+                ]
+                (role_dir / "gpqa_per_example.json").write_text(
+                    json.dumps({"examples": rows}) + "\n"
+                )
+                (role_dir / "longbench_v2.json").write_text(
+                    json.dumps({"score": 0.64 if role == "external" else 0.61}) + "\n"
+                )
+        message = expect_failure(
+            "accuracy_per_rep_and_aggregate_gates_rejected",
+            lambda: summarize_accuracy(root),
+            contains="rep01 GPQA",
+        )
+        require(
+            "aggregate GPQA" in message and "aggregate LongBench" in message,
+            "aggregate accuracy failures were not both reported",
+        )
+        for repetition in range(1, repetitions_for_mode("accuracy") + 1):
+            role_dir = root / f"rep{repetition:02d}" / "flashinfer"
+            payload = json.loads((role_dir / "gpqa_per_example.json").read_text())
+            payload["examples"][98]["correct"] = True
+            (role_dir / "gpqa_per_example.json").write_text(json.dumps(payload) + "\n")
+            (role_dir / "longbench_v2.json").write_text(
+                json.dumps({"score": 0.62}) + "\n"
+            )
+        require(
+            summarize_accuracy(root)["status"] == "pass", "accuracy boundary failed"
+        )
+        passed("accuracy_boundary_positive")
+        passed("longbench_exact_float_boundary_positive")
+        require(
+            not within_noninferiority_margin(0.61 - 0.64, LONGBENCH_MARGIN),
+            "LongBench regression beyond the margin was accepted",
+        )
+        passed("longbench_beyond_margin_rejected")
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        for repetition in range(1, repetitions_for_mode("external-speed") + 1):
+            for role, throughput in (("external", 100.0), ("flashinfer", 99.0)):
+                role_dir = root / f"rep{repetition:02d}" / role
+                role_dir.mkdir(parents=True)
+                for concurrency in CONCURRENCIES:
+                    (role_dir / f"serving_c{concurrency}.jsonl").write_text(
+                        json.dumps(valid_serving_record(concurrency, throughput, 10.0))
+                        + "\n"
+                    )
+        expect_failure(
+            "speed_median_gate_rejected",
+            lambda: summarize_speed(root, "external-speed", 0.0),
+            contains="median throughput gain",
+        )
+        for path in root.glob("rep*/flashinfer/serving_c*.jsonl"):
+            concurrency = int(path.stem.removeprefix("serving_c"))
+            path.write_text(
+                json.dumps(valid_serving_record(concurrency, 101.0, 9.0)) + "\n"
+            )
+        require(
+            summarize_speed(root, "external-speed", 0.0)["status"] == "pass",
+            "speed positive boundary failed",
+        )
+        passed("speed_gate_positive")
+        for test_id, threshold in (
+            ("speed_nan_threshold_rejected", float("nan")),
+            ("speed_inf_threshold_rejected", float("inf")),
+            ("speed_negative_threshold_rejected", -0.001),
+        ):
+            expect_failure(
+                test_id,
+                lambda threshold=threshold: summarize_speed(
+                    root, "external-speed", threshold
+                ),
+                contains="finite and nonnegative",
+            )
+
+    require(
+        not lifecycle_failures(
+            prelaunch_clear=True, poststop_clear=True, measured={"status": "pass"}
+        ),
+        "positive lifecycle contract failed",
+    )
+    passed("server_lifecycle_positive")
+    for test_id, kwargs, wanted in (
+        (
+            "prelaunch_port_occupied_rejected",
+            {
+                "prelaunch_clear": False,
+                "poststop_clear": True,
+                "measured": {"status": "pass"},
+            },
+            "before launch",
+        ),
+        (
+            "teardown_port_cleanup_rejected",
+            {
+                "prelaunch_clear": True,
+                "poststop_clear": False,
+                "measured": {"status": "pass"},
+            },
+            "after teardown",
+        ),
+        (
+            "missing_measured_audit_rejected",
+            {"prelaunch_clear": True, "poststop_clear": True, "measured": None},
+            "measured audit",
+        ),
+    ):
+        expect_failure(
+            test_id,
+            lambda kwargs=kwargs: require_lifecycle(**kwargs),
+            contains=wanted,
+        )
+
+    require(
+        GPQA_MARGIN_QUESTIONS == 1 and math.isclose(LONGBENCH_MARGIN, 0.02),
+        "accuracy margins drifted",
+    )
+    passed("accuracy_margin_constants")
+    receipt = {
+        "schema_version": 1,
+        "status": "pass",
+        "test_count": len(results),
+        "test_results": results,
+        "orders": orders,
+        "roles": {
+            role: list(route_fragments(role))
+            for role in ("external", "flashinfer", "triton")
+        },
+        "gpqa_margin_questions": GPQA_MARGIN_QUESTIONS,
+        "longbench_margin": LONGBENCH_MARGIN,
+        "private_evidence_mode": "0600",
+        "fresh_cache_per_arm": True,
+    }
+    text = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+    if output:
+        output.write_text(text)
+    print(text, end="")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--test-only", action="store_true")
+    parser.add_argument("--test-receipt", type=Path)
+    parser.add_argument(
+        "--mode", choices=("accuracy", "external-speed", "triton-speed")
+    )
+    parser.add_argument("--model")
+    parser.add_argument("--gpqa-dataset", type=Path)
+    parser.add_argument("--longbench-subset", type=Path)
+    parser.add_argument("--flashinfer-source-dir", type=Path)
+    parser.add_argument("--expected-flashinfer-head")
+    parser.add_argument("--expected-flashinfer-tree")
+    parser.add_argument("--sglang-source-dir", type=Path)
+    parser.add_argument("--expected-sglang-head")
+    parser.add_argument("--expected-sglang-tree")
+    parser.add_argument("--expected-model-config-sha256")
+    parser.add_argument("--model-manifest", type=Path)
+    parser.add_argument("--expected-model-manifest-sha256")
+    parser.add_argument("--expected-model-aggregate-sha256")
+    parser.add_argument("--expected-gpqa-sha256")
+    parser.add_argument("--expected-longbench-sha256")
+    parser.add_argument("--expected-longbench-manifest-sha256")
+    parser.add_argument("--output-root", type=Path)
+    parser.add_argument("--cache-root", type=Path)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=30000)
+    parser.add_argument("--server-timeout", type=int, default=7200)
+    parser.add_argument("--python", default=sys.executable)
+    parser.add_argument("--min-median-throughput-gain", type=float, default=0.0)
+    args = parser.parse_args()
+    if args.test_only:
+        run_test_only(args.test_receipt)
+        return
+    required = (
+        "mode",
+        "model",
+        "flashinfer_source_dir",
+        "expected_flashinfer_head",
+        "expected_flashinfer_tree",
+        "sglang_source_dir",
+        "expected_sglang_head",
+        "expected_sglang_tree",
+        "gpqa_dataset",
+        "longbench_subset",
+        "expected_model_config_sha256",
+        "model_manifest",
+        "expected_model_manifest_sha256",
+        "expected_model_aggregate_sha256",
+        "expected_gpqa_sha256",
+        "expected_longbench_sha256",
+        "expected_longbench_manifest_sha256",
+        "output_root",
+        "cache_root",
+    )
+    missing = [name for name in required if getattr(args, name) is None]
+    if missing:
+        parser.error("missing required arguments: " + ", ".join(missing))
+    if args.mode == "accuracy":
+        if args.min_median_throughput_gain != 0.0:
+            parser.error("accuracy mode requires --min-median-throughput-gain=0.0")
+    elif (
+        not math.isfinite(args.min_median_throughput_gain)
+        or args.min_median_throughput_gain < 0
+    ):
+        parser.error("minimum median throughput gain must be finite and nonnegative")
+    args.base_url = f"http://{args.host}:{args.port}"
+    args.output_root = args.output_root.resolve()
+    args.cache_root = args.cache_root.resolve()
+    repo = args.sglang_source_dir.resolve()
+    flashinfer = args.flashinfer_source_dir.resolve()
+    if args.output_root.exists():
+        raise SystemExit(f"refusing to reuse output root: {args.output_root}")
+    validate_checkout(
+        repo, args.expected_sglang_head, args.expected_sglang_tree, "SGLang"
+    )
+    validate_checkout(
+        flashinfer,
+        args.expected_flashinfer_head,
+        args.expected_flashinfer_tree,
+        "FlashInfer",
+    )
+    require_sha256(
+        Path(args.model) / "config.json",
+        args.expected_model_config_sha256,
+        "model config",
+    )
+    require_sha256(args.gpqa_dataset, args.expected_gpqa_sha256, "GPQA")
+    require_sha256(args.longbench_subset, args.expected_longbench_sha256, "LongBench")
+    require_sha256(
+        Path(str(args.longbench_subset) + ".manifest.json"),
+        args.expected_longbench_manifest_sha256,
+        "LongBench manifest",
+    )
+    args.output_root.mkdir(parents=True)
+    checkpoint_receipt = verify_file_manifest(
+        Path(args.model),
+        args.model_manifest,
+        args.expected_model_manifest_sha256,
+        args.expected_model_aggregate_sha256,
+        "model checkpoint",
+    )
+    (args.output_root / "model_checkpoint_verification.json").write_text(
+        json.dumps(checkpoint_receipt, indent=2, sort_keys=True) + "\n"
+    )
+    (args.output_root / "private").mkdir(mode=0o700)
+    environment = loopback_environment(dict(os.environ))
+    environment["PYTHONPATH"] = os.pathsep.join(
+        [str(repo / "python"), str(flashinfer)]
+        + ([environment["PYTHONPATH"]] if environment.get("PYTHONPATH") else [])
+    )
+    environment.update({"HF_HUB_OFFLINE": "1", "TRANSFORMERS_OFFLINE": "1"})
+    manifest = {
+        "schema_version": 1,
+        "mode": args.mode,
+        "model": args.model,
+        "seed": SEED,
+        "repetitions": repetitions_for_mode(args.mode),
+        "orders": [
+            expected_order(args.mode, rep)
+            for rep in range(1, repetitions_for_mode(args.mode) + 1)
+        ],
+        "roles": list(roles_for_mode(args.mode)),
+        "server_command": server_command(args),
+        "fresh_server_and_cache_per_arm": True,
+        "runner_sha256": sha256(Path(__file__)),
+        "flashinfer_head": args.expected_flashinfer_head,
+        "flashinfer_tree": args.expected_flashinfer_tree,
+        "sglang_head": args.expected_sglang_head,
+        "sglang_tree": args.expected_sglang_tree,
+        "immutable_input_sha256": {
+            "model_config": args.expected_model_config_sha256,
+            "model_manifest": args.expected_model_manifest_sha256,
+            "model_aggregate": args.expected_model_aggregate_sha256,
+            "gpqa": args.expected_gpqa_sha256,
+            "longbench": args.expected_longbench_sha256,
+            "longbench_manifest": args.expected_longbench_manifest_sha256,
+        },
+    }
+    if args.mode == "accuracy":
+        manifest["accuracy"] = {
+            "fixed_parity_visible_tokens": ["short", 32768, 65536],
+            "gpqa_examples": GPQA_TOTAL,
+            "gpqa_threads": 1,
+            "gpqa_margin_questions": GPQA_MARGIN_QUESTIONS,
+            "longbench_examples": LONGBENCH_TOTAL,
+            "longbench_threads": 1,
+            "longbench_margin": LONGBENCH_MARGIN,
+            "private_responses_mode": "0600",
+        }
+    else:
+        manifest["serving"] = {
+            "concurrencies": list(CONCURRENCIES),
+            "num_prompts": NUM_PROMPTS,
+            "input_tokens": 8192,
+            "output_tokens": 1024,
+            "random_range_ratio": 1,
+            "backend": "sglang",
+            "endpoint": "/generate",
+            "warmup_requests_per_invocation": 0,
+            "min_median_throughput_gain": args.min_median_throughput_gain,
+        }
+    (args.output_root / "run_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    )
+    for repetition in range(1, repetitions_for_mode(args.mode) + 1):
+        rep_dir = args.output_root / f"rep{repetition:02d}"
+        rep_dir.mkdir()
+        order = expected_order(args.mode, repetition)
+        validate_order(args.mode, repetition, order)
+        (rep_dir / "order.json").write_text(
+            json.dumps({"order": order}, indent=2, sort_keys=True) + "\n"
+        )
+        for role in order:
+            run_role(
+                args=args,
+                repo=repo,
+                base_environment=environment,
+                repetition=repetition,
+                role=role,
+            )
+    if args.mode == "accuracy":
+        summary = summarize_accuracy(args.output_root)
+    else:
+        summary = summarize_speed(
+            args.output_root, args.mode, args.min_median_throughput_gain
+        )
+    (args.output_root / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/minimax_m3/run_msa_formal_v2.py
+++ b/benchmark/minimax_m3/run_msa_formal_v2.py
@@ -178,6 +178,8 @@ def loopback_environment(base: dict[str, str]) -> dict[str, str]:
 def roles_for_mode(mode: str) -> tuple[str, str]:
     if mode in ("accuracy", "external-speed"):
         return ("external", "flashinfer")
+    if mode == "cake-speed":
+        return ("cake", "vibecuda")
     if mode == "triton-speed":
         return ("triton", "flashinfer")
     raise ValueError(f"unsupported mode: {mode}")
@@ -1487,7 +1489,7 @@ def run_test_only(output: Path | None) -> None:
             expected_order(mode, rep)
             for rep in range(1, repetitions_for_mode(mode) + 1)
         ]
-        for mode in ("accuracy", "external-speed", "triton-speed")
+        for mode in ("accuracy", "external-speed", "cake-speed", "triton-speed")
     }
     require(
         loopback_environment({})["OPENAI_API_KEY"] == "EMPTY",
@@ -1513,6 +1515,10 @@ def run_test_only(output: Path | None) -> None:
         "external speed order contract mismatch",
     )
     require(
+        orders["cake-speed"] == [["cake", "vibecuda"]],
+        "CAKE speed order contract mismatch",
+    )
+    require(
         orders["triton-speed"] == [["triton", "flashinfer"]],
         "triton speed order contract mismatch",
     )
@@ -1520,6 +1526,7 @@ def run_test_only(output: Path | None) -> None:
     require(
         repetitions_for_mode("accuracy") == 3
         and repetitions_for_mode("external-speed") == 1
+        and repetitions_for_mode("cake-speed") == 1
         and repetitions_for_mode("triton-speed") == 1,
         "mode-specific repetition counts drifted",
     )
@@ -1527,6 +1534,7 @@ def run_test_only(output: Path | None) -> None:
     require(fixed_parity_required("accuracy"), "accuracy fixed parity was disabled")
     require(
         not fixed_parity_required("external-speed")
+        and not fixed_parity_required("cake-speed")
         and not fixed_parity_required("triton-speed"),
         "a speed-only mode would send accuracy requests",
     )
@@ -1899,6 +1907,8 @@ def run_test_only(output: Path | None) -> None:
         )
         source.unlink()
         started_ns = time.time_ns()
+        # Some shared filesystems expose sub-second mtimes at coarser resolution.
+        time.sleep(0.02)
         source.write_text('{"score": 1}\n')
         payload, receipt = claim_fresh_json_output(
             source, destination, started_ns, "synthetic"
@@ -2264,7 +2274,8 @@ def main() -> None:
     parser.add_argument("--test-only", action="store_true")
     parser.add_argument("--test-receipt", type=Path)
     parser.add_argument(
-        "--mode", choices=("accuracy", "external-speed", "triton-speed")
+        "--mode",
+        choices=("accuracy", "external-speed", "cake-speed", "triton-speed"),
     )
     parser.add_argument("--model")
     parser.add_argument("--gpqa-dataset", type=Path)

--- a/benchmark/minimax_m3/run_msa_formal_v2.py
+++ b/benchmark/minimax_m3/run_msa_formal_v2.py
@@ -59,6 +59,16 @@ CLIENT_FAILURE_PATTERNS = {
     "retries": re.compile(r"\bretr(?:y|ies|ied|ying)\b", re.IGNORECASE),
     "timeouts": re.compile(r"\b(?:timed out|timeouts?)\b", re.IGNORECASE),
 }
+STARTUP_BENIGN_LINE_PATTERNS = (
+    re.compile(
+        r"Tokenizer for .* is still TokenizersBackend after retries with "
+        r"--trust-remote-code\. Model-specific tokenizer attributes may be missing\."
+    ),
+    re.compile(
+        r"Ignore import error when loading "
+        r"sglang\.srt\.multimodal\.processors\.[^:]+:"
+    ),
+)
 
 
 def sha256(path: Path) -> str:
@@ -529,6 +539,16 @@ def measured_audit(
 
 def startup_audit(log_path: Path, end: int, output: Path) -> dict:
     data, matches = log_segment(log_path, 0, end)
+    text = data.decode(errors="replace")
+    relevant_text = "\n".join(
+        line
+        for line in text.splitlines()
+        if not any(pattern.search(line) for pattern in STARTUP_BENIGN_LINE_PATTERNS)
+    )
+    for category in ("errors", "retries"):
+        matches[category] = sorted(
+            set(FAILURE_PATTERNS[category].findall(relevant_text))
+        )
     failures = []
     for category in ("errors", "retries"):
         if matches[category]:
@@ -1602,6 +1622,29 @@ def run_test_only(output: Path | None) -> None:
             "measured offset contract failed",
         )
         passed("measured_offset_excludes_startup_jit")
+        server_log.write_text(
+            "Tokenizer for /model is still TokenizersBackend after retries with "
+            "--trust-remote-code. Model-specific tokenizer attributes may be missing.\n"
+            "Ignore import error when loading "
+            "sglang.srt.multimodal.processors.optional: dependency unavailable\n"
+        )
+        require(
+            startup_audit(
+                server_log, server_log.stat().st_size, role_dir / "startup.json"
+            )["status"]
+            == "pass",
+            "known optional startup warnings were treated as runtime failures",
+        )
+        server_log.write_text("RuntimeError: real startup failure\n")
+        expect_failure(
+            "startup_runtime_error_rejected",
+            lambda: startup_audit(
+                server_log, server_log.stat().st_size, role_dir / "startup.json"
+            ),
+            contains="errors",
+        )
+        server_log.write_text(startup + post)
+        write_thermal()
         expect_failure(
             "measured_log_shrink_rejected",
             lambda: log_segment(server_log, 10, 9),

--- a/benchmark/minimax_m3/test_msa_formal_v2.py
+++ b/benchmark/minimax_m3/test_msa_formal_v2.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import http.client
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from precompile_fmha_sm100 import runtime_variants
+from probe_msa_e2e_dependencies import (
+    REQUIRED_TP4_SM103_ROUTES,
+    probe_blackwell_msa_route_manifest,
+)
+from run_msa_formal_v2 import (
+    repetitions_for_mode,
+)
+from run_msa_formal_v2 import run_test_only as run_formal_v2_self_tests
+from run_msa_formal_v2 import (
+    server_healthy,
+)
+
+
+class MSAFormalV2Test(unittest.TestCase):
+    def write_json(self, path: Path, payload: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload))
+
+    def make_route_manifest(self, root: Path) -> Path:
+        routes = [
+            {
+                "id": route_id,
+                "architectures": ["sm100", "sm103"],
+                "source_units": sorted(source_units),
+            }
+            for route_id, source_units in REQUIRED_TP4_SM103_ROUTES.items()
+        ]
+        units = sorted(
+            {
+                source_unit
+                for source_units in REQUIRED_TP4_SM103_ROUTES.values()
+                for source_unit in source_units
+            }
+        )
+        hashes = {
+            field: "a" * 64
+            for field in (
+                "generated_input_sha256",
+                "vendored_sha256",
+                "binding_sha256",
+                "arg_plan_sha256",
+            )
+        }
+        manifest = {
+            "operation": "blackwell_msa",
+            "attention_topk": 16,
+            "reachable_specialization_count": len(routes),
+            "reachable_specializations": routes,
+            "source_inventory": {
+                "entries": [
+                    {"target": "sm103a", "source_unit": unit, **hashes}
+                    for unit in units
+                ]
+            },
+        }
+        path = root / "csrc" / "blackwell_msa" / "route_manifest.json"
+        self.write_json(path, manifest)
+        return path
+
+    def test_route_manifest_covers_tp4_gb300_source_routes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            path = self.make_route_manifest(root)
+            result = probe_blackwell_msa_route_manifest(root)
+
+        self.assertEqual(result["path"], str(path.resolve()))
+        self.assertEqual(result["required_routes"], sorted(REQUIRED_TP4_SM103_ROUTES))
+
+    def test_route_manifest_rejects_missing_decode_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            path = self.make_route_manifest(root)
+            manifest = json.loads(path.read_text())
+            manifest["source_inventory"]["entries"] = [
+                entry
+                for entry in manifest["source_inventory"]["entries"]
+                if entry["source_unit"] != "decode_m16_bf16_paged"
+            ]
+            self.write_json(path, manifest)
+            with self.assertRaisesRegex(RuntimeError, "decode_m16_bf16_paged"):
+                probe_blackwell_msa_route_manifest(root)
+
+    def test_transient_http_protocol_error_is_not_healthy(self) -> None:
+        with mock.patch(
+            "run_msa_formal_v2.urllib.request.urlopen",
+            side_effect=http.client.BadStatusLine("GET /health_generate HTTP/1.1"),
+        ):
+            self.assertFalse(server_healthy("http://127.0.0.1:30000"))
+
+    def test_precompile_variants_cover_tp4_sparse_paged_routes(self) -> None:
+        dtype_code = 42
+        variants = runtime_variants(dtype_code)
+
+        self.assertEqual(len(variants), 9)
+        self.assertEqual(len(set(variants)), 9)
+        self.assertEqual(
+            set(variants),
+            {
+                (dtype_code, 128, single_wg, 0, 128, split_kv, pack_factor)
+                for single_wg in (True, False)
+                for split_kv in (False, True)
+                for pack_factor in (1, 16)
+            }
+            | {(dtype_code, 256, False, 0, 128, False, 1)},
+        )
+
+    def test_formal_mode_repetition_counts(self) -> None:
+        self.assertEqual(repetitions_for_mode("accuracy"), 3)
+        self.assertEqual(repetitions_for_mode("external-speed"), 1)
+        self.assertEqual(repetitions_for_mode("triton-speed"), 1)
+        with self.assertRaisesRegex(ValueError, "unsupported mode"):
+            repetitions_for_mode("unknown")
+
+    def test_formal_v2_fail_closed_contract(self) -> None:
+        required = {
+            "alternating_order_contract",
+            "mode_specific_repetition_counts",
+            "loopback_api_key_default_and_preservation_contract",
+            "speed_modes_have_no_accuracy_requests",
+            "wrong_external_route_rejected",
+            "wrong_flashinfer_route_rejected",
+            "wrong_triton_route_rejected",
+            "measured_post_count_rejected",
+            "measured_generic_error_rejected",
+            "client_log_retry_rejected",
+            "client_log_error_rejected",
+            "client_log_exhausted_rejected",
+            "client_log_timeout_rejected",
+            "duplicate_serving_records_rejected",
+            "serving_completed_count_rejected",
+            "serving_total_input_tokens_tamper_rejected",
+            "serving_output_throughput_nan_rejected",
+            "speed_fixed_workload_contract",
+            "exactly_one_unmeasured_warmup_contract",
+            "fresh_output_claim_receipt_positive",
+            "stale_output_mtime_rejected",
+            "fixed_parity_real_producer_schema_positive",
+            "full_model_manifest_positive",
+            "stale_model_manifest_hash_rejected",
+            "stale_model_aggregate_rejected",
+            "model_file_tamper_rejected",
+            "model_file_set_drift_rejected",
+            "accuracy_per_rep_and_aggregate_gates_rejected",
+            "longbench_exact_float_boundary_positive",
+            "longbench_beyond_margin_rejected",
+            "speed_nan_threshold_rejected",
+            "speed_negative_threshold_rejected",
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            receipt_path = Path(temporary) / "receipt.json"
+            with redirect_stdout(io.StringIO()):
+                run_formal_v2_self_tests(receipt_path)
+            receipt = json.loads(receipt_path.read_text())
+
+        passed = {
+            row["id"] for row in receipt["test_results"] if row.get("status") == "pass"
+        }
+        self.assertEqual(receipt["status"], "pass")
+        self.assertEqual(receipt["test_count"], 88)
+        self.assertEqual(len(receipt["test_results"]), 88)
+        self.assertEqual(len(passed), 88)
+        self.assertTrue(required <= passed, sorted(required - passed))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -320,8 +320,6 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         # that wide. Head split mirrors MiniMaxM3 sparse attention's.
         self._idx_group_size = 1
         if self.index_cache_enabled:
-            from sglang.srt.runtime_context import get_parallel
-
             _num_idx_heads = max(
                 sparse_cfg["sparse_num_index_heads"] // get_parallel().attn_tp_size, 1
             )

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING
 
 import torch
 
@@ -59,7 +59,7 @@ logger = logging.getLogger(__name__)
 
 def _kv_cache_to_bnsd(
     k_cache: torch.Tensor, v_cache: torch.Tensor, page_size: int
-) -> Tuple[torch.Tensor, torch.Tensor, int, int, int]:
+) -> tuple[torch.Tensor, torch.Tensor, int, int, int]:
     """Reshape NHD slot-major KV caches to BNSD [pages, page_size, heads, dim].
 
     Already-paged 4D inputs pass through unchanged.
@@ -81,9 +81,9 @@ def _kv_cache_to_bnsd(
 
 def _idx_cache_to_bnsd(
     idx_k_cache: torch.Tensor,
-    idx_v_cache: Optional[torch.Tensor],
+    idx_v_cache: torch.Tensor | None,
     page_size: int,
-) -> Tuple[torch.Tensor, Optional[torch.Tensor], int, int]:
+) -> tuple[torch.Tensor, torch.Tensor | None, int, int]:
     """Reshape NHD slot-major index caches to BNSD; already-paged 4D passes through."""
     if idx_k_cache.dim() == 4:
         return idx_k_cache, idx_v_cache, idx_k_cache.shape[2], idx_k_cache.shape[3]
@@ -103,7 +103,7 @@ def _idx_cache_to_bnsd(
     )
 
 
-def _quant_q_fp8(q: torch.Tensor, q_scale: Optional[float]) -> torch.Tensor:
+def _quant_q_fp8(q: torch.Tensor, q_scale: float | None) -> torch.Tensor:
     # Same convention as the KV pools: the fp8 tensor stores value/scale and
     # the attention kernels multiply the logits back by the scale (None = unit).
     if q_scale is not None:
@@ -147,15 +147,15 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         self._max_seqlen_k: int = 1
 
         # NPU: per-forward cached metadata for the triton paths (rebuilt each forward).
-        self._prefill_meta: Optional[SimpleNamespace] = None
+        self._prefill_meta: SimpleNamespace | None = None
         # (owning ForwardBatch, cu_seqlens, seq_lens, prefix_lens, cu_seqblocks_q,
         # max_seqblock_q, all_seqblock_q). The owner is part of the key because one
         # metadata init can be followed by more than one ForwardBatch reaching the
         # layers (two-batch overlap splits into two children with different
         # extend_seq_lens); a hit requires the SAME object, not just a live cache.
-        self._prefill_seqblock_meta: Optional[tuple] = None
-        self._extend_meta: Optional[SimpleNamespace] = None
-        self._extend_meta_key: Optional[int] = None
+        self._prefill_seqblock_meta: tuple | None = None
+        self._extend_meta: SimpleNamespace | None = None
+        self._extend_meta_key: int | None = None
         self._decode_seq_lens_i32_cg: dict[int, torch.Tensor] = {}
         self._verify_meta_cg: dict[tuple, SimpleNamespace] = {}
 
@@ -177,10 +177,11 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             ) // self.block_size_k + 1
         self.topk_blocks = sparse_cfg["sparse_topk_blocks"]
 
-        # MSA (fmha_sm100) is SM100-only; fall back to the Triton sparse path when
-        # the kernel is unavailable or its constraints don't hold.
+        # MSA is SM100-only. Prefer FlashInfer's public source implementation;
+        # retain fmha_sm100 for older installations and all-FP8 Q/K/V.
         if self.is_npu:
             self.use_msa = False
+            self.msa_backend = None
             # Prime the native sparse op probe before cuda-graph capture.
             from sgl_kernel_npu.attention.gqa_share_sparse_attention import (
                 _get_native_sparse_op,
@@ -191,6 +192,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             self._native_sparse_ok = False
             from sglang.srt.layers.attention.minimax_sparse_ops.msa import (
                 msa_available,
+                selected_msa_backend,
             )
 
             # MSA (fmha_sm100) runs bf16, or uniform fp8_e4m3 under fp8 attn-GEMM mode
@@ -207,9 +209,19 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 self.fp8_attn_gemm
                 and self.kv_pool.main_pool.dtype == torch.float8_e4m3fn
             )
+            self.msa_backend = (
+                None
+                if envs.SGLANG_DISABLE_MSA.get()
+                else selected_msa_backend(
+                    self.kv_pool.main_pool.dtype,
+                    self.kv_pool.main_pool.head_num,
+                    self.topk_blocks,
+                )
+            )
             self.use_msa = (
                 not envs.SGLANG_DISABLE_MSA.get()
                 and msa_available()
+                and self.msa_backend is not None
                 and self.block_size_k == 128
                 and self.kv_pool.page_size == self.block_size_k
                 and self.topk_blocks in (4, 8, 16, 32)
@@ -232,6 +244,10 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 )
 
         self._msa_dec_meta = None
+        self._msa_prefill_meta = None
+        self._msa_capture_active = False
+        self._msa_active_graph_states: dict[int, object] | None = None
+        self._msa_bcg_prefill_warned = False
         if self.use_msa:
             self.num_q_heads = (
                 runner.model_config.num_attention_heads // get_parallel().attn_tp_size
@@ -241,6 +257,11 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 self.max_context_len + self.block_size_k - 1
             ) // self.block_size_k
             self._msa_cg: dict[int, tuple] = {}
+            self._msa_prefill_cg: dict[tuple[int, int], tuple] = {}
+            # A public workspace becomes capture-owned after one graph capture
+            # and cannot be captured again. Retain every per-capture state for
+            # the lifetime of the backend so its graph pointers remain valid.
+            self._msa_graph_state_lifetime: list[dict[int, object]] = []
 
         self.page_size = self.kv_pool.page_size
         self.use_dense_sparse_decode = (
@@ -263,7 +284,12 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             Phase.DECODE, Backend.DISABLED
         )
         self._use_msa_decode = self.use_msa and (
-            not _decode_cuda_graph or envs.SGLANG_OPT_USE_MSA_DECODE_UNDER_GRAPH.get()
+            not _decode_cuda_graph
+            # FlashInfer's public workspace has an explicit warm/capture/replay
+            # contract. Keep the opt-in for the standalone compatibility path,
+            # whose graph support depends on undocumented plan internals.
+            or self.msa_backend == "flashinfer"
+            or envs.SGLANG_OPT_USE_MSA_DECODE_UNDER_GRAPH.get()
         )
 
         # MSA + spec decode + cuda graph crashes mid-capture: TARGET_VERIFY batches
@@ -281,7 +307,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         self._msa_owns_decode = self._use_msa_decode and not (
             self.use_dense_sparse_decode and self.kv_pool.main_pool.head_num == 1
         )
-        self.dense_backend: Optional[AttentionBackend] = None
+        self.dense_backend: AttentionBackend | None = None
 
         self.index_topk_freq = (
             max(int(envs.SGLANG_MINIMAX_M3_INDEX_TOPK_FREQ.get()), 1)
@@ -315,12 +341,13 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             self._topk_group_of_layer[lid] = group
             self._topk_is_source[lid] = (ordinal % self.index_topk_freq) == 0
         self._topk_cache: dict = {}
-        self._topk_cache_owner: Optional[ForwardBatch] = None
+        self._topk_cache_owner: ForwardBatch | None = None
 
         logger.info(
             f"[MiniMaxSparse] Backend initialized "
             f"(score_type={self.score_type!r}, "
-            f"main_attn={'MSA' if self.use_msa else 'triton'}, "
+            f"main_attn={self.msa_backend if self.use_msa else 'triton'}, "
+            f"flashinfer_provider={os.environ.get('SGLANG_MINIMAX_MSA_FLASHINFER_BACKEND', 'auto') if self.use_msa and self.msa_backend == 'flashinfer' else 'none'}, "
             f"index_topk_freq={self.index_topk_freq}, "
             f"msa_decode={self._use_msa_decode}, "
             f"msa_owns_decode={self._msa_owns_decode}, "
@@ -389,6 +416,9 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 )
         # Per-forward cache of the layer-invariant prefill seqblock trio.
         self._prefill_seqblock_meta = None
+        self._msa_prefill_meta = None
+        self._msa_capture_active = in_capture
+        self._msa_active_graph_states = None
         if self.is_npu:
             # Invalidate cached prefill/extend metadata; rebuilt on first sparse layer.
             self._prefill_meta = None
@@ -412,7 +442,14 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         # Build plan + page table eager (outside capture) so captured forward_decode
         # runs only device-side ops; host-side code can't be captured.
         if self._msa_owns_decode and forward_batch.forward_mode.is_decode_or_idle():
-            self._prepare_msa_decode_meta(forward_batch)
+            self._prepare_msa_decode_meta(forward_batch, in_capture=in_capture)
+
+        if (
+            self.use_msa
+            and self.msa_backend == "flashinfer"
+            and forward_batch.forward_mode.is_extend()
+        ):
+            self._prepare_msa_prefill_meta(forward_batch, in_capture=in_capture)
 
         # ---- REPLAY-FRESH native verify block_table ----
         if (
@@ -454,16 +491,57 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                     // self.page_size
                 ).to(torch.int32)
 
-    def _prepare_msa_decode_meta(self, forward_batch: ForwardBatch):
+    def shared_read_ends(self, fm: ForwardMode) -> SharedReadEnds:
+        # Both MSA decode paths read persistent per-batch metadata in every
+        # sparse layer. The next replay refreshes those buffers out of graph,
+        # so it must not overlap the preceding graph's attention kernels.
+        if fm.is_decode() and self._msa_owns_decode:
+            return SharedReadEnds.POST_REPLAY
+        return super().shared_read_ends(fm)
+
+    def _prepare_msa_decode_meta(
+        self, forward_batch: ForwardBatch, *, in_capture: bool = False
+    ):
         """Refresh the persistent per-batch-size MSA decode plan + page table in place."""
         from sglang.srt.layers.attention.minimax_sparse_ops.msa import (
+            build_flashinfer_page_table,
             build_msa_decode_cg_plan,
+            make_flashinfer_msa_graph_state,
             update_msa_decode_cg_meta,
         )
 
         bs = forward_batch.seq_lens.shape[0]
         if bs == 0:
             return
+        if self.msa_backend == "flashinfer":
+            entry = self._msa_cg.get(bs)
+            if entry is None:
+                device = forward_batch.seq_lens.device
+                page_table = torch.empty(
+                    (bs, self._msa_nb_max), dtype=torch.int32, device=device
+                )
+                entry = (page_table, None)
+                self._msa_cg[bs] = entry
+            page_table, _ = entry
+            if in_capture:
+                graph_states = {
+                    layer_id: make_flashinfer_msa_graph_state(
+                        forward_batch.seq_lens.device
+                    )
+                    for layer_id in self.sparse_layer_ids
+                }
+                self._msa_graph_state_lifetime.append(graph_states)
+                self._msa_active_graph_states = graph_states
+            build_flashinfer_page_table(
+                self.req_to_token,
+                forward_batch.req_pool_indices,
+                forward_batch.seq_lens,
+                self.block_size_k,
+                out=page_table,
+            )
+            self._msa_dec_meta = (page_table, None)
+            return
+
         entry = self._msa_cg.get(bs)
         if entry is None:
             device = forward_batch.seq_lens.device
@@ -494,6 +572,91 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             self.num_kv_heads,
         )
         self._msa_dec_meta = (kv_indices_buf, plan)
+
+    def _prepare_msa_prefill_meta(
+        self, forward_batch: ForwardBatch, *, in_capture: bool = False
+    ):
+        """Build one page table per prefill and persistent workspaces for CG."""
+        from sglang.srt.layers.attention.minimax_sparse_ops.msa import (
+            build_flashinfer_page_table,
+            make_flashinfer_msa_graph_state,
+        )
+
+        bs = int(forward_batch.seq_lens.shape[0])
+        total_q = int(forward_batch.input_ids.shape[0])
+        if bs == 0:
+            return
+        key = (bs, total_q)
+        # Capture records the page-table address, so replay must refresh the
+        # same cached tensor rather than building an equivalent new tensor.
+        # Eager calls may reuse it too; the next graph replay refreshes it again.
+        entry = self._msa_prefill_cg.get(key)
+        if entry is None and in_capture:
+            page_table = torch.empty(
+                (bs, self._msa_nb_max),
+                dtype=torch.int32,
+                device=forward_batch.seq_lens.device,
+            )
+            entry = (page_table, None)
+            self._msa_prefill_cg[key] = entry
+        if entry is None:
+            max_pages = (
+                self._max_seqlen_k + self.block_size_k - 1
+            ) // self.block_size_k
+            page_table = build_flashinfer_page_table(
+                self.req_to_token,
+                forward_batch.req_pool_indices,
+                forward_batch.seq_lens,
+                self.block_size_k,
+                max_pages=max_pages,
+            )
+        else:
+            page_table, _ = entry
+            build_flashinfer_page_table(
+                self.req_to_token,
+                forward_batch.req_pool_indices,
+                forward_batch.seq_lens,
+                self.block_size_k,
+                out=page_table,
+            )
+        self._msa_prefill_meta = page_table
+        if in_capture:
+            graph_states = {
+                layer_id: make_flashinfer_msa_graph_state(forward_batch.seq_lens.device)
+                for layer_id in self.sparse_layer_ids
+            }
+            self._msa_graph_state_lifetime.append(graph_states)
+            self._msa_active_graph_states = graph_states
+
+    def _use_msa_for_prefill(self) -> bool:
+        """Keep dynamic-request BCG on its existing capture-safe prefill path.
+
+        Breakable prefill graphs are keyed by aggregate query tokens, while the
+        public MSA capture contract fixes the request axis and page-table shape.
+        Full prefill graphs have a fixed padded request axis and are supported;
+        eager prefill is supported as well.
+        """
+
+        if not self.use_msa or self.msa_backend != "flashinfer":
+            return self.use_msa
+        from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
+            is_in_breakable_cuda_graph,
+        )
+
+        in_breakable_graph = is_in_breakable_cuda_graph()
+        if in_breakable_graph and not self._msa_bcg_prefill_warned:
+            logger.info(
+                "[MiniMaxSparse] FlashInfer MSA prefill uses the Triton path "
+                "inside dynamic-request breakable CUDA graphs; eager prefill "
+                "and fixed-request full CUDA graphs retain FlashInfer MSA."
+            )
+            self._msa_bcg_prefill_warned = True
+        return not in_breakable_graph
+
+    def on_after_cuda_graph_warmup(self):
+        """Honor FlashInfer's requirement to finish workspace warmup first."""
+        if self._msa_capture_active and self.msa_backend == "flashinfer":
+            torch.cuda.current_stream().synchronize()
 
     def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch):
         if not self.is_npu:
@@ -702,9 +865,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         v_cache: torch.Tensor,  # [num_slots, num_kv_heads, head_dim]
         idx_q: torch.Tensor,  # [B, num_idx_heads, idx_dim]
         idx_k_cache: torch.Tensor,  # [num_slots, idx_kv_heads, idx_dim]
-        idx_v_cache: Optional[
-            torch.Tensor
-        ],  # [num_slots, idx_kv_heads, idx_dim] or None
+        idx_v_cache: torch.Tensor | None,  # [num_slots, idx_kv_heads, idx_dim] or None
         forward_batch: ForwardBatch,
     ):
         """NPU decode via the ported triton kernels (BNSD paged).
@@ -719,7 +880,6 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         )
 
         page_size = self.page_size  # == block_size_k
-        num_q_heads = q.shape[1]
         head_dim = q.shape[2]
         num_idx_heads = idx_q.shape[1]
         idx_dim = idx_q.shape[2]
@@ -836,7 +996,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         v_cache: torch.Tensor,
         idx_q: torch.Tensor,
         idx_k_cache: torch.Tensor,
-        idx_v_cache: Optional[torch.Tensor],
+        idx_v_cache: torch.Tensor | None,
         forward_batch: ForwardBatch,
         prefix_lens: torch.Tensor,
     ):
@@ -852,7 +1012,6 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         )
 
         page_size = self.page_size  # == block_size_k
-        num_q_heads = q.shape[1]
         head_dim = q.shape[2]
         num_idx_heads = idx_q.shape[1]
         idx_dim = idx_q.shape[2]
@@ -1108,7 +1267,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         v_cache: torch.Tensor,
         idx_q: torch.Tensor,  # [total_extend_tokens, num_idx_heads, idx_dim]
         idx_k_cache: torch.Tensor,
-        idx_v_cache: Optional[torch.Tensor],
+        idx_v_cache: torch.Tensor | None,
         forward_batch: ForwardBatch,
         cu_seqlens: torch.Tensor,
         seq_lens: torch.Tensor,
@@ -1130,7 +1289,6 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         )
 
         page_size = self.page_size  # == block_size_k
-        num_q_heads = q.shape[1]
         head_dim = q.shape[2]
         num_idx_heads = idx_q.shape[1]
         idx_dim = idx_q.shape[2]
@@ -1158,7 +1316,6 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             )
             self._prefill_meta = meta
         per_query_seq_lens = meta.per_query_seq_lens
-        max_seqlen = meta.max_seqlen
         max_blocks = meta.max_blocks
         block_size_q = meta.block_size_q
         per_query_req = meta.per_query_req
@@ -1307,7 +1464,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             idx_q = kwargs.get("idx_q")
             num_idx_heads = idx_q.shape[1]
             disable_value = layer.layer_id in self.disable_value_layer_ids
-            idx_out: Optional[torch.Tensor] = (
+            idx_out: torch.Tensor | None = (
                 None
                 if disable_value
                 else q.new_zeros(q.shape[0], num_idx_heads * self.idx_head_dim)
@@ -1380,7 +1537,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         *,
         idx_q: torch.Tensor,
         idx_k: torch.Tensor,
-        idx_v: Optional[torch.Tensor],
+        idx_v: torch.Tensor | None,
     ):
         disable_value = layer.layer_id in self.disable_value_layer_ids
         kv_cached_by_fusion = self._is_sparse_kv_cached_by_fusion(
@@ -1536,7 +1693,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 self.local_blocks,
                 score_type=self.score_type,
                 disable_index_value=disable_value,
-                use_msa=self.use_msa,
+                use_msa=self._use_msa_for_prefill(),
                 seqlens_cpu=forward_batch.extend_seq_lens_cpu,
                 cu_seqblocks_q=cu_seqblocks_q,
                 max_seqblock_q=max_seqblock_q,
@@ -1549,6 +1706,13 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 idx_v_scale=layer.idx_v_scale_float,
                 cached_topk_idx=cached_topk_idx,
                 return_topk_idx=want_topk,
+                msa_backend=self.msa_backend,
+                msa_page_table=self._msa_prefill_meta,
+                msa_graph_state=(
+                    self._msa_active_graph_states.get(layer.layer_id)
+                    if self._msa_active_graph_states is not None
+                    else None
+                ),
             )
             if want_topk:
                 idx_o, o, reduced_topk_idx = result
@@ -1619,7 +1783,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         *,
         idx_q: torch.Tensor,
         idx_k: torch.Tensor,
-        idx_v: Optional[torch.Tensor],
+        idx_v: torch.Tensor | None,
         **kwargs,
     ):
         assert len(kwargs) == 0
@@ -1659,9 +1823,13 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 )
 
         msa_kv_indices = msa_plan = None
+        msa_page_table = None
         if self._use_msa_decode and attn_fn is None:
             if self._msa_dec_meta is not None:
-                msa_kv_indices, msa_plan = self._msa_dec_meta
+                if self.msa_backend == "flashinfer":
+                    msa_page_table, _ = self._msa_dec_meta
+                else:
+                    msa_kv_indices, msa_plan = self._msa_dec_meta
             elif q.shape[0] > 0:
                 # Rebuilding the plan inline would run host-side code inside
                 # CUDA-graph capture; fail loudly instead.
@@ -1735,6 +1903,13 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 idx_v_scale=layer.idx_v_scale_float,
                 cached_topk_idx=_cached_topk,
                 topk_out=_topk_buf if _want_topk else None,
+                msa_backend=self.msa_backend,
+                msa_page_table=msa_page_table,
+                msa_graph_state=(
+                    self._msa_active_graph_states.get(layer.layer_id)
+                    if self._msa_active_graph_states is not None
+                    else None
+                ),
             )
         return (
             None if idx_o is None else idx_o.reshape(q.shape[0], -1).contiguous(),
@@ -1780,6 +1955,12 @@ class MiniMaxHybridAttnBackend(AttentionBackend):
     def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch):
         self.sparse.init_forward_metadata_in_graph(forward_batch)
         self.dense.init_forward_metadata_in_graph(forward_batch)
+
+    def on_after_cuda_graph_warmup(self):
+        self.sparse.on_after_cuda_graph_warmup()
+        hook = getattr(self.dense, "on_after_cuda_graph_warmup", None)
+        if hook is not None:
+            hook()
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         self.dense.init_cuda_graph_state(max_bs, max_num_tokens)

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
@@ -75,6 +75,9 @@ def minimax_sparse_prefill(
     idx_v_scale: Optional[float] = None,
     cached_topk_idx: Optional[torch.Tensor] = None,
     return_topk_idx: bool = False,
+    msa_backend: Optional[str] = None,
+    msa_page_table: Optional[torch.Tensor] = None,
+    msa_graph_state: object | None = None,
 ):
     """Run MiniMax-M3 sparse prefill.
 
@@ -165,8 +168,15 @@ def minimax_sparse_prefill(
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                backend=msa_backend,
+                page_table=msa_page_table,
+                graph_state=msa_graph_state,
             )
         except MSAUnavailableError as err:
+            from .msa import msa_runtime_fallback_allowed
+
+            if not msa_runtime_fallback_allowed():
+                raise
             _warn_msa_fallback(err)
             o = flash_prefill_with_gqa_share_sparse(
                 q=q,
@@ -255,6 +265,9 @@ def minimax_sparse_decode(
     idx_v_scale: Optional[float] = None,
     cached_topk_idx: Optional[torch.Tensor] = None,
     topk_out: Optional[torch.Tensor] = None,
+    msa_backend: Optional[str] = None,
+    msa_page_table: Optional[torch.Tensor] = None,
+    msa_graph_state: object | None = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     # Index top-k sharing for DECODE. A group's source layer passes ``topk_out``
     # (a persistent buffer) and publishes its reduced top-k there; the group's
@@ -340,8 +353,15 @@ def minimax_sparse_decode(
                     q_scale=q_scale,
                     k_scale=k_scale,
                     v_scale=v_scale,
+                    backend=msa_backend,
+                    page_table=msa_page_table,
+                    graph_state=msa_graph_state,
                 )
             except MSAUnavailableError as err:
+                from .msa import msa_runtime_fallback_allowed
+
+                if not msa_runtime_fallback_allowed():
+                    raise
                 _warn_msa_fallback(err)
                 o = flash_decode_with_gqa_share_sparse(
                     q=q,

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
@@ -171,6 +171,7 @@ def minimax_sparse_prefill(
                 backend=msa_backend,
                 page_table=msa_page_table,
                 graph_state=msa_graph_state,
+                seqlens_cpu=seqlens_cpu,
             )
         except MSAUnavailableError as err:
             from .msa import msa_runtime_fallback_allowed

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/msa.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/msa.py
@@ -1,8 +1,11 @@
-# MSA (fmha_sm100) drop-in for the MiniMax-M3 main sparse-attention step.
+# MSA drop-in for the MiniMax-M3 main sparse-attention step.
 #
 # Replaces only step 3 of MiniMax sparse prefill/decode. The lightning indexer
 # (steps 1-2) is unchanged and still produces `topk_idx`.
 # NVIDIA Blackwell (SM100/sm_103) only; callers gate on `msa_available()`.
+# Prefer FlashInfer's public source-kernel API.  The standalone fmha_sm100
+# package remains a compatibility fallback for installations that have not yet
+# upgraded FlashInfer and for its all-FP8 Q/K/V mode.
 #
 # Dtypes: bf16 end-to-end, or uniform fp8_e4m3fn Q/K/V under fp8 attn-GEMM mode
 # (output bf16). fmha_sm100 selects its kernel variant from q.dtype alone and
@@ -15,7 +18,9 @@
 from __future__ import annotations
 
 import functools
-from typing import Optional
+import inspect
+import logging
+import os
 
 import torch
 
@@ -23,7 +28,129 @@ from sglang.kernels.ops.attention.minimax_sparse.common.utils import unit_scale
 
 
 class MSAUnavailableError(RuntimeError):
-    """Raised when fmha_sm100 cannot serve the MiniMax MSA path."""
+    """Raised when no installed MSA implementation can serve this call."""
+
+
+_FLASHINFER_PREFILL_PARAMS = frozenset(
+    {
+        "q",
+        "k",
+        "v",
+        "q2k_indices",
+        "cu_seqlens_q",
+        "causal",
+        "softmax_scale",
+        "page_table",
+        "seqused_k",
+        "q_offset",
+        "workspace",
+    }
+)
+_FLASHINFER_DECODE_PARAMS = frozenset(
+    {
+        "q",
+        "k",
+        "v",
+        "q2k_indices",
+        "page_table",
+        "seqused_k",
+        "seqlen_q",
+        "causal",
+        "softmax_scale",
+        "workspace",
+    }
+)
+
+
+@functools.lru_cache(maxsize=1)
+def _load_flashinfer_msa():
+    """Load and signature-check FlashInfer's stable public MSA surface."""
+
+    try:
+        from flashinfer import msa_ops
+    except Exception as err:
+        raise MSAUnavailableError("flashinfer.msa_ops is not importable") from err
+
+    prefill = getattr(msa_ops, "msa_sparse_attention", None)
+    decode = getattr(msa_ops, "msa_sparse_decode_attention", None)
+    topk = getattr(msa_ops, "msa_topk_select", None)
+    workspace_type = getattr(msa_ops, "MSASparseAttentionWorkspace", None)
+    if not all(callable(op) for op in (prefill, decode, topk)):
+        raise MSAUnavailableError(
+            "flashinfer.msa_ops must export callable msa_sparse_attention, "
+            "msa_sparse_decode_attention, and msa_topk_select"
+        )
+    if workspace_type is None or not callable(workspace_type):
+        raise MSAUnavailableError(
+            "flashinfer.msa_ops.MSASparseAttentionWorkspace is required for "
+            "SGLang CUDA-graph capture"
+        )
+
+    try:
+        prefill_params = frozenset(inspect.signature(prefill).parameters)
+        decode_params = frozenset(inspect.signature(decode).parameters)
+    except (TypeError, ValueError) as err:
+        raise MSAUnavailableError(
+            "FlashInfer MSA call signatures are not inspectable"
+        ) from err
+    missing_prefill = _FLASHINFER_PREFILL_PARAMS - prefill_params
+    missing_decode = _FLASHINFER_DECODE_PARAMS - decode_params
+    if missing_prefill or missing_decode:
+        raise MSAUnavailableError(
+            "FlashInfer MSA API is missing required parameters: "
+            f"prefill={sorted(missing_prefill)}, decode={sorted(missing_decode)}"
+        )
+    provider = os.environ.get("SGLANG_MINIMAX_MSA_FLASHINFER_BACKEND", "auto")
+    if provider not in ("auto", "vibecuda"):
+        raise MSAUnavailableError(f"Unsupported FlashInfer MSA provider: {provider!r}")
+    if provider == "vibecuda":
+        if "backend" not in prefill_params or "backend" not in decode_params:
+            raise MSAUnavailableError(
+                "The installed FlashInfer MSA API cannot explicitly select VibeCUDA"
+            )
+        prefill = functools.partial(prefill, backend=provider)
+        decode = functools.partial(decode, backend=provider)
+    logging.getLogger(__name__).info("FlashInfer MSA provider=%s", provider)
+    return prefill, decode, topk, workspace_type
+
+
+class FlashInferMSAGraphState:
+    """Stable inputs plus one public FlashInfer workspace for one graph call.
+
+    FlashInfer intentionally binds a workspace to the exact tensor addresses
+    warmed before capture.  Model Q and sparse indices are intermediates whose
+    allocator addresses need not be stable across SGLang's warmup and capture
+    forwards, so copy them into caller-owned buffers first.  The copies become
+    graph nodes and replay with fresh values.
+    """
+
+    def __init__(self, device: torch.device | str):
+        _, _, _, workspace_type = _load_flashinfer_msa()
+        self.workspace = workspace_type(device)
+        self._buffers: dict[str, torch.Tensor] = {}
+
+    def stage(self, name: str, value: torch.Tensor) -> torch.Tensor:
+        buffer = self._buffers.get(name)
+        if (
+            buffer is None
+            or buffer.shape != value.shape
+            or buffer.dtype != value.dtype
+            or buffer.device != value.device
+        ):
+            if torch.cuda.is_current_stream_capturing():
+                raise MSAUnavailableError(
+                    f"FlashInfer MSA graph buffer {name!r} was not warmed before capture"
+                )
+            buffer = torch.empty_like(value, memory_format=torch.contiguous_format)
+            self._buffers[name] = buffer
+        buffer.copy_(value)
+        return buffer
+
+
+def make_flashinfer_msa_graph_state(
+    device: torch.device | str,
+) -> FlashInferMSAGraphState:
+    return FlashInferMSAGraphState(device)
 
 
 def _check_msa_dtypes(q: torch.Tensor, k_cache: torch.Tensor, v_cache: torch.Tensor):
@@ -66,22 +193,165 @@ def _run_fmha_sm100_plan(*args, **kwargs):
         raise MSAUnavailableError("fmha_sm100_plan failed") from err
 
 
-@functools.lru_cache(maxsize=1)
-def msa_available() -> bool:
-    """True iff the fmha_sm100 sparse kernels and plan API are usable here."""
+def _msa_device_supported() -> bool:
     try:
         cap = torch.cuda.get_device_capability()
     except Exception:
         return False
-    # SM100 family: B200 (10,0) and B300 (10,3). fmha_sm100/jit.py emits both
-    # sm_100a and sm_103a; the kernels run on either.
-    if cap[0] != 10 or cap[1] not in (0, 3):
+    return cap[0] == 10 and cap[1] in (0, 3)
+
+
+def _flashinfer_msa_device_supported() -> bool:
+    if not _msa_device_supported():
+        return False
+    try:
+        cap = torch.cuda.get_device_capability()
+        major, minor = (int(part) for part in torch.version.cuda.split(".")[:2])
+    except (AttributeError, TypeError, ValueError):
+        return False
+    minimum = (12, 9) if cap == (10, 3) else (12, 8)
+    return (major, minor) >= minimum
+
+
+@functools.lru_cache(maxsize=1)
+def flashinfer_msa_available() -> bool:
+    if not _flashinfer_msa_device_supported():
+        return False
+    try:
+        _load_flashinfer_msa()
+        return True
+    except MSAUnavailableError:
+        return False
+
+
+@functools.lru_cache(maxsize=1)
+def fmha_sm100_available() -> bool:
+    if not _msa_device_supported():
         return False
     try:
         _load_fmha_sm100()
         return True
     except MSAUnavailableError:
         return False
+
+
+def selected_msa_backend(
+    kv_dtype: torch.dtype, num_kv_heads: int, topk: int
+) -> str | None:
+    """Resolve ``flashinfer`` / ``fmha_sm100`` without probing private APIs.
+
+    ``SGLANG_MINIMAX_MSA_BACKEND`` is an A/B and emergency control.  ``auto``
+    prefers the source-distributed FlashInfer implementation.  FlashInfer's
+    SM100 paged API currently requires an HND-contiguous view of SGLang's
+    slot-major cache; that view is zero-copy when the TP-local KV-head count is
+    one, and its MiniMax-M3 source route is fixed to top-k 16. Other layouts
+    and top-k values retain the existing standalone implementation.
+    """
+
+    requested = os.environ.get("SGLANG_MINIMAX_MSA_BACKEND", "auto").lower()
+    provider = os.environ.get("SGLANG_MINIMAX_MSA_FLASHINFER_BACKEND", "auto")
+    if provider != "auto":
+        if provider != "vibecuda" or requested not in ("auto", "flashinfer"):
+            raise MSAUnavailableError(
+                "Explicit FlashInfer provider conflicts with MSA route"
+            )
+        requested = "flashinfer"
+    if requested not in ("auto", "flashinfer", "fmha_sm100"):
+        raise ValueError(
+            "SGLANG_MINIMAX_MSA_BACKEND must be auto, flashinfer, or fmha_sm100"
+        )
+    flashinfer_compatible = (
+        kv_dtype in (torch.bfloat16, torch.float16) and num_kv_heads == 1 and topk == 16
+    )
+    if requested == "flashinfer":
+        if not flashinfer_compatible:
+            raise MSAUnavailableError(
+                "FlashInfer MSA requires BF16/FP16 KV, one TP-local KV head, "
+                "and top-k 16"
+            )
+        if not flashinfer_msa_available():
+            raise MSAUnavailableError(
+                "the requested FlashInfer MSA source API is unavailable"
+            )
+        return "flashinfer"
+    if requested == "fmha_sm100":
+        if not fmha_sm100_available():
+            raise MSAUnavailableError(
+                "the requested fmha_sm100 compatibility backend is unavailable"
+            )
+        return "fmha_sm100"
+    if flashinfer_compatible and flashinfer_msa_available():
+        return "flashinfer"
+    if fmha_sm100_available():
+        return "fmha_sm100"
+    return None
+
+
+def msa_runtime_fallback_allowed() -> bool:
+    """Whether a provider failure may fall back to the Triton implementation.
+
+    ``auto`` is the production availability policy and may recover from a
+    provider-specific runtime rejection.  An explicitly selected provider is
+    also an A/B-validation contract: silently falling back there would label a
+    Triton run as FlashInfer/fmha_sm100 and invalidate correctness and speed
+    evidence, so explicit selections fail closed.
+    """
+
+    return (
+        os.environ.get("SGLANG_MINIMAX_MSA_BACKEND", "auto").lower() == "auto"
+        and os.environ.get("SGLANG_MINIMAX_MSA_FLASHINFER_BACKEND", "auto") == "auto"
+    )
+
+
+@functools.lru_cache(maxsize=1)
+def msa_available() -> bool:
+    """True iff either public FlashInfer MSA or the compatibility backend loads."""
+
+    return flashinfer_msa_available() or fmha_sm100_available()
+
+
+def build_flashinfer_page_table(
+    req_to_token: torch.Tensor,
+    slot_ids: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_size: int,
+    *,
+    max_pages: int | None = None,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Build SGLang's logical-to-physical page table in FlashInfer's 2D form.
+
+    When ``out`` is supplied its address and shape remain stable across CUDA
+    graph replay; all contents are refreshed without a host synchronization.
+    """
+
+    batch_size = int(slot_ids.shape[0])
+    if out is not None:
+        if out.shape[0] != batch_size or out.dtype != torch.int32:
+            raise ValueError("persistent MSA page table has incompatible shape/dtype")
+        max_pages = int(out.shape[1])
+    elif max_pages is None:
+        max_seq_len = int(seq_lens.max().item()) if batch_size else 0
+        max_pages = (max_seq_len + page_size - 1) // page_size
+    assert max_pages is not None
+    if out is None:
+        out = torch.empty(
+            (batch_size, max_pages), dtype=torch.int32, device=req_to_token.device
+        )
+    if max_pages == 0:
+        return out
+    logical_first = torch.arange(
+        max_pages, dtype=torch.int64, device=req_to_token.device
+    ).mul_(page_size)
+    if (max_pages - 1) * page_size >= req_to_token.shape[1]:
+        raise ValueError(
+            f"MSA page table width {max_pages} exceeds request table capacity"
+        )
+    rows = slot_ids.to(torch.int64).unsqueeze(1)
+    out.copy_(
+        (req_to_token[rows, logical_first.unsqueeze(0)] // page_size).to(torch.int32)
+    )
+    return out
 
 
 def _build_page_table(
@@ -118,6 +388,96 @@ def _build_page_table(
     return (req_to_token[rows, logical_first] // P).to(torch.int32)
 
 
+def _flashinfer_paged_kv(
+    k_cache: torch.Tensor, v_cache: torch.Tensor, page_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    max_slots, num_kv_heads, head_dim = k_cache.shape
+    if num_kv_heads != 1:
+        raise MSAUnavailableError(
+            "FlashInfer MSA serving integration requires one TP-local KV head"
+        )
+    if max_slots % page_size:
+        raise MSAUnavailableError(
+            f"max_slots={max_slots} is not divisible by page_size={page_size}"
+        )
+    num_pages = max_slots // page_size
+    k_paged = k_cache.view(num_pages, page_size, num_kv_heads, head_dim).permute(
+        0, 2, 1, 3
+    )
+    v_paged = v_cache.view(num_pages, page_size, num_kv_heads, head_dim).permute(
+        0, 2, 1, 3
+    )
+    # Do not hide a whole-cache transpose behind this serving call.  MiniMax-M3
+    # TP4 has one local KV head, for which this HND view is already contiguous.
+    if not k_paged.is_contiguous() or not v_paged.is_contiguous():
+        raise MSAUnavailableError(
+            "FlashInfer MSA requires zero-copy contiguous HND paged K/V; "
+            "use TP with one local KV head or the fmha_sm100 compatibility backend"
+        )
+    return k_paged, v_paged
+
+
+def _flashinfer_prefill(
+    *,
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    topk_idx: torch.Tensor,
+    req_to_token: torch.Tensor,
+    slot_ids: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    seq_lens: torch.Tensor,
+    prefix_lens: torch.Tensor,
+    block_size_k: int,
+    sm_scale: float | None,
+    page_table: torch.Tensor | None,
+    graph_state: FlashInferMSAGraphState | None,
+) -> torch.Tensor:
+    prefill, _, _, _ = _load_flashinfer_msa()
+    if topk_idx.shape[-1] != 16:
+        raise MSAUnavailableError("FlashInfer MSA source kernels require top-k 16")
+    if q.dtype not in (torch.bfloat16, torch.float16):
+        raise MSAUnavailableError("FlashInfer source MSA requires BF16/FP16 Q")
+    if k_cache.dtype != q.dtype or v_cache.dtype != q.dtype:
+        raise MSAUnavailableError(
+            "FlashInfer source MSA integration currently requires K/V dtype to match Q"
+        )
+    k_paged, v_paged = _flashinfer_paged_kv(k_cache, v_cache, block_size_k)
+    if page_table is None:
+        page_table = build_flashinfer_page_table(
+            req_to_token, slot_ids, seq_lens, block_size_k
+        )
+    q = q.contiguous()
+    q2k = topk_idx.contiguous().to(torch.int32)
+    cu_q = cu_seqlens.to(torch.int32)
+    kv_lens = seq_lens.to(torch.int32)
+    q_offsets = prefix_lens.to(torch.int32)
+    workspace = None
+    if graph_state is not None:
+        q = graph_state.stage("q", q)
+        q2k = graph_state.stage("q2k_indices", q2k)
+        cu_q = graph_state.stage("cu_seqlens_q", cu_q)
+        kv_lens = graph_state.stage("seqused_k", kv_lens)
+        q_offsets = graph_state.stage("q_offset", q_offsets)
+        workspace = graph_state.workspace
+    try:
+        return prefill(
+            q=q,
+            k=k_paged,
+            v=v_paged,
+            q2k_indices=q2k,
+            cu_seqlens_q=cu_q,
+            causal=True,
+            softmax_scale=sm_scale,
+            page_table=page_table,
+            seqused_k=kv_lens,
+            q_offset=q_offsets,
+            workspace=workspace,
+        )
+    except (AttributeError, TypeError, ValueError) as err:
+        raise MSAUnavailableError("FlashInfer MSA prefill rejected the call") from err
+
+
 def msa_sparse_prefill_main(
     q: torch.Tensor,  # [total_q, num_q_heads, head_dim]
     k_cache: torch.Tensor,  # [max_slots, num_kv_heads, head_dim] (slot-major NHD)
@@ -129,10 +489,13 @@ def msa_sparse_prefill_main(
     seq_lens: torch.Tensor,  # [batch] total K length (prefix + chunk)
     prefix_lens: torch.Tensor,  # [batch]
     block_size_k: int,  # == page_size == 128 for M3
-    sm_scale: Optional[float] = None,
-    q_scale: Optional[float] = None,
-    k_scale: Optional[float] = None,
-    v_scale: Optional[float] = None,
+    sm_scale: float | None = None,
+    q_scale: float | None = None,
+    k_scale: float | None = None,
+    v_scale: float | None = None,
+    page_table: torch.Tensor | None = None,
+    graph_state: FlashInferMSAGraphState | None = None,
+    backend: str | None = None,
 ) -> torch.Tensor:
     """Drop-in for flash_prefill_with_gqa_share_sparse using MSA fmha_sm100.
 
@@ -143,6 +506,33 @@ def msa_sparse_prefill_main(
     q_scale*k_scale is folded into sm_scale (exact for softmax) and v_scale is
     applied on the output; the short-q cutlass path gets the same folded values.
     """
+    if backend is None:
+        backend = selected_msa_backend(
+            k_cache.dtype, int(k_cache.shape[1]), int(topk_idx.shape[-1])
+        )
+    if backend == "flashinfer":
+        if any(unit_scale(scale) != 1.0 for scale in (q_scale, k_scale, v_scale)):
+            raise MSAUnavailableError(
+                "FlashInfer source MSA scale support is not part of the frozen SM100 contract"
+            )
+        return _flashinfer_prefill(
+            q=q,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            topk_idx=topk_idx,
+            req_to_token=req_to_token,
+            slot_ids=slot_ids,
+            cu_seqlens=cu_seqlens,
+            seq_lens=seq_lens,
+            prefix_lens=prefix_lens,
+            block_size_k=block_size_k,
+            sm_scale=sm_scale,
+            page_table=page_table,
+            graph_state=graph_state,
+        )
+    if backend != "fmha_sm100":
+        raise MSAUnavailableError("no MSA prefill backend supports this input")
+
     fmha_sm100, _ = _load_fmha_sm100()
     _check_msa_dtypes(q, k_cache, v_cache)
     is_fp8 = q.dtype == torch.float8_e4m3fn
@@ -291,7 +681,7 @@ def build_msa_decode_cg_plan(
     block_size_k: int,
     topk: int,
     batch_size: int,
-    device: Optional[torch.device] = None,
+    device: torch.device | None = None,
     is_fp8: bool = False,
 ):
     """Persistent fmha_sm100 decode plan for one batch size (CUDA-graph stable).
@@ -381,6 +771,60 @@ def update_msa_decode_cg_meta(
     kv_indices_buf.copy_((req_to_token[rows, logical_first] // P).to(torch.int32))
 
 
+def _flashinfer_decode(
+    *,
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    topk_idx: torch.Tensor,
+    req_to_token: torch.Tensor,
+    slot_ids: torch.Tensor,
+    seq_lens: torch.Tensor,
+    block_size_k: int,
+    sm_scale: float | None,
+    page_table: torch.Tensor | None,
+    graph_state: FlashInferMSAGraphState | None,
+) -> torch.Tensor:
+    _, decode, _, _ = _load_flashinfer_msa()
+    if topk_idx.shape[-1] != 16:
+        raise MSAUnavailableError("FlashInfer MSA source kernels require top-k 16")
+    if q.dtype not in (torch.bfloat16, torch.float16):
+        raise MSAUnavailableError("FlashInfer source MSA requires BF16/FP16 Q")
+    if k_cache.dtype != q.dtype or v_cache.dtype != q.dtype:
+        raise MSAUnavailableError(
+            "FlashInfer source MSA integration currently requires K/V dtype to match Q"
+        )
+    k_paged, v_paged = _flashinfer_paged_kv(k_cache, v_cache, block_size_k)
+    if page_table is None:
+        page_table = build_flashinfer_page_table(
+            req_to_token, slot_ids, seq_lens, block_size_k
+        )
+    q = q.contiguous()
+    q2k = topk_idx.contiguous().to(torch.int32)
+    kv_lens = seq_lens.to(torch.int32)
+    workspace = None
+    if graph_state is not None:
+        q = graph_state.stage("q", q)
+        q2k = graph_state.stage("q2k_indices", q2k)
+        kv_lens = graph_state.stage("seqused_k", kv_lens)
+        workspace = graph_state.workspace
+    try:
+        return decode(
+            q=q,
+            k=k_paged,
+            v=v_paged,
+            q2k_indices=q2k,
+            page_table=page_table,
+            seqused_k=kv_lens,
+            seqlen_q=1,
+            causal=True,
+            softmax_scale=sm_scale,
+            workspace=workspace,
+        )
+    except (AttributeError, TypeError, ValueError) as err:
+        raise MSAUnavailableError("FlashInfer MSA decode rejected the call") from err
+
+
 def msa_sparse_decode_main(
     q: torch.Tensor,  # [batch, num_q_heads, head_dim] (1 query token per request)
     k_cache: torch.Tensor,  # [max_slots, num_kv_heads, head_dim] (slot-major NHD)
@@ -390,14 +834,16 @@ def msa_sparse_decode_main(
     slot_ids: torch.Tensor,  # [batch]
     seq_lens: torch.Tensor,  # [batch] cached KV length per request
     block_size_k: int,  # == page_size == 128
-    sm_scale: Optional[float] = None,
-    kv_indices: Optional[
-        torch.Tensor
-    ] = None,  # precomputed page table (per-forward cache)
+    sm_scale: float | None = None,
+    kv_indices: torch.Tensor
+    | None = None,  # precomputed page table (per-forward cache)
     plan=None,  # precomputed fmha_sm100 plan (per-forward cache)
-    q_scale: Optional[float] = None,
-    k_scale: Optional[float] = None,
-    v_scale: Optional[float] = None,
+    q_scale: float | None = None,
+    k_scale: float | None = None,
+    v_scale: float | None = None,
+    page_table: torch.Tensor | None = None,
+    graph_state: FlashInferMSAGraphState | None = None,
+    backend: str | None = None,
 ) -> torch.Tensor:
     """Drop-in for flash_decode_with_gqa_share_sparse using MSA fmha_sm100.
 
@@ -414,6 +860,31 @@ def msa_sparse_decode_main(
     q_scale*k_scale into the softmax scale and applies v_scale on the output
     in-kernel.
     """
+    if backend is None:
+        backend = selected_msa_backend(
+            k_cache.dtype, int(k_cache.shape[1]), int(topk_idx.shape[-1])
+        )
+    if backend == "flashinfer":
+        if any(unit_scale(scale) != 1.0 for scale in (q_scale, k_scale, v_scale)):
+            raise MSAUnavailableError(
+                "FlashInfer source MSA scale support is not part of the frozen SM100 contract"
+            )
+        return _flashinfer_decode(
+            q=q,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            topk_idx=topk_idx,
+            req_to_token=req_to_token,
+            slot_ids=slot_ids,
+            seq_lens=seq_lens,
+            block_size_k=block_size_k,
+            sm_scale=sm_scale,
+            page_table=page_table,
+            graph_state=graph_state,
+        )
+    if backend != "fmha_sm100":
+        raise MSAUnavailableError("no MSA decode backend supports this input")
+
     fmha_sm100, _ = _load_fmha_sm100()
     _check_msa_dtypes(q, k_cache, v_cache)
 

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/msa.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/msa.py
@@ -432,6 +432,7 @@ def _flashinfer_prefill(
     sm_scale: float | None,
     page_table: torch.Tensor | None,
     graph_state: FlashInferMSAGraphState | None,
+    seqlens_cpu: list[int] | None = None,
 ) -> torch.Tensor:
     prefill, _, _, _ = _load_flashinfer_msa()
     if topk_idx.shape[-1] != 16:
@@ -460,20 +461,63 @@ def _flashinfer_prefill(
         kv_lens = graph_state.stage("seqused_k", kv_lens)
         q_offsets = graph_state.stage("q_offset", q_offsets)
         workspace = graph_state.workspace
-    try:
+
+    def run_prefill(
+        q_arg: torch.Tensor,
+        q2k_arg: torch.Tensor,
+        cu_q_arg: torch.Tensor,
+        page_table_arg: torch.Tensor,
+        kv_lens_arg: torch.Tensor,
+        q_offsets_arg: torch.Tensor,
+        workspace_arg,
+    ) -> torch.Tensor:
         return prefill(
-            q=q,
+            q=q_arg,
             k=k_paged,
             v=v_paged,
-            q2k_indices=q2k,
-            cu_seqlens_q=cu_q,
+            q2k_indices=q2k_arg,
+            cu_seqlens_q=cu_q_arg,
             causal=True,
             softmax_scale=sm_scale,
-            page_table=page_table,
-            seqused_k=kv_lens,
-            q_offset=q_offsets,
-            workspace=workspace,
+            page_table=page_table_arg,
+            seqused_k=kv_lens_arg,
+            q_offset=q_offsets_arg,
+            workspace=workspace_arg,
         )
+
+    try:
+        if seqlens_cpu and len(set(seqlens_cpu)) > 1:
+            if graph_state is not None:
+                raise MSAUnavailableError(
+                    "ragged FlashInfer MSA prefill is only supported outside CUDA graph capture"
+                )
+            if (
+                len(seqlens_cpu) != page_table.shape[0]
+                or sum(seqlens_cpu) != q.shape[0]
+            ):
+                raise MSAUnavailableError(
+                    "ragged FlashInfer MSA prefill received inconsistent CPU lengths"
+                )
+            outputs = []
+            q_start = 0
+            for request_index, q_len in enumerate(seqlens_cpu):
+                q_end = q_start + q_len
+                if q_len:
+                    outputs.append(
+                        run_prefill(
+                            q[q_start:q_end],
+                            q2k[:, q_start:q_end],
+                            cu_q[request_index : request_index + 2]
+                            - cu_q[request_index],
+                            page_table[request_index : request_index + 1],
+                            kv_lens[request_index : request_index + 1],
+                            q_offsets[request_index : request_index + 1],
+                            None,
+                        )
+                    )
+                q_start = q_end
+            return torch.cat(outputs, dim=0)
+        return run_prefill(q, q2k, cu_q, page_table, kv_lens, q_offsets, workspace)
     except (AttributeError, TypeError, ValueError) as err:
         raise MSAUnavailableError("FlashInfer MSA prefill rejected the call") from err
 
@@ -496,6 +540,7 @@ def msa_sparse_prefill_main(
     page_table: torch.Tensor | None = None,
     graph_state: FlashInferMSAGraphState | None = None,
     backend: str | None = None,
+    seqlens_cpu: list[int] | None = None,
 ) -> torch.Tensor:
     """Drop-in for flash_prefill_with_gqa_share_sparse using MSA fmha_sm100.
 
@@ -529,6 +574,7 @@ def msa_sparse_prefill_main(
             sm_scale=sm_scale,
             page_table=page_table,
             graph_state=graph_state,
+            seqlens_cpu=seqlens_cpu,
         )
     if backend != "fmha_sm100":
         raise MSAUnavailableError("no MSA prefill backend supports this input")

--- a/python/sglang/test/run_eval.py
+++ b/python/sglang/test/run_eval.py
@@ -4,7 +4,9 @@ python3 -m sglang.test.run_eval --port 30000 --eval-name mmlu --num-examples 10
 """
 
 import argparse
+import hashlib
 import json
+import math
 import os
 import statistics
 import subprocess
@@ -20,6 +22,100 @@ from sglang.test.simple_eval_common import (
     make_report,
     set_ulimit,
 )
+
+
+def validate_per_example_evidence_args(args) -> None:
+    output = getattr(args, "per_example_output", None)
+    private_responses = getattr(args, "per_example_private_responses", None)
+    if private_responses and not output:
+        raise ValueError(
+            "--per-example-private-responses requires --per-example-output"
+        )
+    if not output:
+        return
+    if args.eval_name not in {"gpqa", "longbench_v2"}:
+        raise ValueError(
+            "per-example evidence is supported only for GPQA and LongBench-v2"
+        )
+    if getattr(args, "repeat", 1) != 1:
+        raise ValueError("per-example evidence requires --repeat 1")
+    for value in (output, private_responses):
+        if value and Path(value).exists():
+            raise FileExistsError(
+                f"refusing to overwrite per-example evidence: {value}"
+            )
+
+
+def write_per_example_evidence(
+    *,
+    result,
+    metrics: dict,
+    eval_name: str,
+    model: str,
+    output_path: str,
+    private_responses_path: str | None = None,
+) -> None:
+    if not result.examples:
+        raise ValueError(f"{eval_name} did not produce per-example evidence")
+    if len(result.examples) != len(result.convos):
+        raise ValueError("per-example evidence and conversations are misaligned")
+    question_ids = [example["question_id"] for example in result.examples]
+    if len(question_ids) != len(set(question_ids)):
+        raise ValueError("per-example evidence contains duplicate question IDs")
+    example_score = sum(bool(example["correct"]) for example in result.examples) / len(
+        result.examples
+    )
+    if "score" not in metrics or not math.isclose(
+        example_score, float(metrics["score"]), abs_tol=1e-12
+    ):
+        raise ValueError(
+            f"summary score {metrics.get('score')} does not match examples {example_score}"
+        )
+
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": 1,
+        "eval_name": eval_name,
+        "model": model,
+        "summary": metrics,
+        "examples": result.examples,
+    }
+    with output.open("x") as destination:
+        json.dump(payload, destination, indent=2, sort_keys=True)
+        destination.write("\n")
+    output.chmod(0o444)
+    print(f"Writing per-example evidence to {output}")
+
+    if private_responses_path is None:
+        return
+    private_output = Path(private_responses_path)
+    private_output.parent.mkdir(parents=True, exist_ok=True)
+    private_fd = os.open(
+        private_output,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        0o600,
+    )
+    with os.fdopen(private_fd, "w") as destination:
+        for example, convo in zip(result.examples, result.convos, strict=True):
+            response = convo[-1].get("content") or ""
+            response_sha256 = hashlib.sha256(response.encode()).hexdigest()
+            if response_sha256 != example["response_sha256"]:
+                raise ValueError(f"response hash mismatch for {example['question_id']}")
+            destination.write(
+                json.dumps(
+                    {
+                        "question_id": example["question_id"],
+                        "response": response,
+                        "response_sha256": response_sha256,
+                    },
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+    private_output.chmod(0o600)
+    print(f"Writing private per-example responses to {private_output}")
 
 
 def get_thinking_kwargs(args):
@@ -66,15 +162,12 @@ def run_eval_once(args, base_url: str, eval_obj: Eval) -> dict:
         if value is not None:
             extra_body[param_name] = value
 
-    max_tokens = getattr(args, "max_tokens", None)
-    top_p = getattr(args, "top_p", None)
-    temperature = getattr(args, "temperature", None)
     common_kwargs = dict(
         model=getattr(args, "model", None),
-        max_tokens=2048 if max_tokens is None else max_tokens,
-        top_p=1.0 if top_p is None else top_p,
+        max_tokens=getattr(args, "max_tokens", 2048),
+        top_p=getattr(args, "top_p", 1.0),
         base_url=base_url,
-        temperature=0.0 if temperature is None else temperature,
+        temperature=getattr(args, "temperature", 0.0),
     )
 
     api_mode = getattr(args, "api", "chat")
@@ -122,55 +215,42 @@ def _run_sgl_eval(eval_name, args) -> dict:
     ).expanduser()
     out_parent.mkdir(parents=True, exist_ok=True)
 
-    model_preset_id = getattr(args, "load_preset_from_model_id", None)
     cmd = [
         "sgl-eval",
         "run",
         eval_name,
         "--base-url",
         base_url,
+        "--num-threads",
+        str(getattr(args, "num_threads", 64)),
+        "--temperature",
+        str(getattr(args, "temperature", 0.0)),
         "--out-dir",
         str(out_parent),
     ]
-    if model_preset_id:
-        cmd += ["--load-preset-from-model-id", model_preset_id]
     if getattr(args, "model", None):
         cmd += ["--model", args.model]
     if getattr(args, "num_examples", None) is not None:
         cmd += ["--num-examples", str(args.num_examples)]
-    if getattr(args, "num_threads", None) is not None:
-        cmd += ["--num-threads", str(args.num_threads)]
-    if getattr(args, "temperature", None) is not None:
-        cmd += ["--temperature", str(args.temperature)]
-    elif not model_preset_id:
-        cmd += ["--temperature", "0.0"]
     if getattr(args, "top_p", None) is not None:
         cmd += ["--top-p", str(args.top_p)]
-    elif not model_preset_id and getattr(args, "_sgl_eval_from_cli", False):
-        cmd += ["--top-p", "1.0"]
     # Unset by default in sgl-eval; only a sampling caller (temperature > 0) needs it.
     if getattr(args, "seed", None) is not None:
         cmd += ["--seed", str(args.seed)]
-    # gpt-oss grades one score per effort tier, so dropping this collapses every
-    # tier onto the served model's default.
-    if getattr(args, "reasoning_effort", None) is not None:
-        cmd += ["--reasoning-effort", str(args.reasoning_effort)]
     if getattr(args, "repeat", None) is not None:
         cmd += ["--n-repeats", str(args.repeat)]
     # Bound generation length so long-reasoning models don't stall the eval.
     if getattr(args, "max_tokens", None) is not None:
         cmd += ["--max-tokens", str(args.max_tokens)]
-    elif not model_preset_id:
+    else:
         cmd += ["--max-tokens", "2048"]
     # Reasoning models (e.g. Qwen3.5) put their answer in the reasoning channel;
     # without --thinking their message.content is empty and sgl-eval scores 0.
-    sgl_eval_thinking = getattr(args, "sgl_eval_thinking", None)
-    if sgl_eval_thinking is None:
-        if not model_preset_id:
-            model_l = (getattr(args, "model", None) or "").lower()
-            if "qwen3.5" in model_l or "qwen3-thinking" in model_l:
-                cmd += ["--thinking"]
-    elif sgl_eval_thinking:
+    if getattr(args, "sgl_eval_thinking", None) is None:
+        model_l = (getattr(args, "model", None) or "").lower()
+        if "qwen3.5" in model_l or "qwen3-thinking" in model_l:
+            cmd += ["--thinking"]
+    elif args.sgl_eval_thinking:
         cmd += ["--thinking"]
 
     try:
@@ -255,6 +335,7 @@ def run_eval(args):
     # Lazy import to avoid circular dependency with test_utils
     from sglang.test.test_utils import dump_metric
 
+    validate_per_example_evidence_args(args)
     set_ulimit()
 
     if "OPENAI_API_KEY" not in os.environ:
@@ -269,18 +350,52 @@ def run_eval(args):
         # caller's threshold has to be measured against it, not inherited.
         # `simple_eval_mmlu` stays: the ascend eval imports its subject2category.
         return _run_sgl_eval("mmlu", args)
+    elif args.eval_name == "math":
+        from sglang.test.simple_eval_math import MathEval
+
+        equality_checker = ChatCompletionSampler(model="gpt-4-turbo")
+
+        filename = (
+            "https://openaipublic.blob.core.windows.net/simple-evals/math_test.csv"
+        )
+        eval_obj = MathEval(
+            filename, equality_checker, args.num_examples, args.num_threads
+        )
+    elif args.eval_name == "mgsm":
+        from sglang.test.simple_eval_mgsm import MGSMEval
+
+        eval_obj = MGSMEval(args.num_examples, args.num_threads)
     elif args.eval_name == "mgsm_en":
         from sglang.test.simple_eval_mgsm import MGSMEval
 
         eval_obj = MGSMEval(args.num_examples, args.num_threads, languages=["en"])
     elif args.eval_name == "gpqa":
-        # Scored by sgl-eval (NeMo-Skills' mcq prompt + eval_mcq grader), so a
-        # caller's threshold has to be measured against it, not inherited.
-        return _run_sgl_eval("gpqa", args)
+        from sglang.test.simple_eval_gpqa import GPQAEval
+
+        filename = args.gpqa_data_path or (
+            "https://openaipublic.blob.core.windows.net/simple-evals/gpqa_diamond.csv"
+        )
+        eval_obj = GPQAEval(filename, args.num_examples, args.num_threads)
     elif args.eval_name == "humaneval":
         from sglang.test.simple_eval_humaneval import HumanEval
 
         eval_obj = HumanEval(args.num_examples, args.num_threads)
+    elif args.eval_name == "longbench_v2":
+        from sglang.test.simple_eval_longbench_v2 import LongBenchV2Eval
+
+        # Default to HuggingFace dataset, can be overridden with --dataset-path
+        data_source = args.dataset_path
+        categories = args.categories.split(",") if args.categories else None
+
+        eval_obj = LongBenchV2Eval(
+            model=getattr(args, "model", None),
+            data_source=data_source,
+            num_examples=args.num_examples,
+            num_threads=args.num_threads,
+            categories=categories,
+            max_context_length=getattr(args, "max_context_length", None),
+            min_context_length=getattr(args, "min_context_length", None),
+        )
     elif args.eval_name == "mmmu":
         # VLM MMMU evaluation with fixed 100 examples by default
         from sglang.test.simple_eval_mmmu_vlm import MMMUVLMEval
@@ -290,17 +405,14 @@ def run_eval(args):
             args.num_threads,
             response_answer_regex=getattr(args, "response_answer_regex", None),
         )
-    elif args.eval_name in ("mmmu_pro", "mmmu-pro"):
-        # Canonical sgl-eval name for MMMU-Pro's standard 10-option split.
-        return _run_sgl_eval("mmmu_pro", args)
     elif args.eval_name == "mmmu_pro_vision":
         # sgl-eval owns this benchmark's dataset, prompt and grader; there is no
         # simple_eval implementation to fall back to.
         return _run_sgl_eval("mmmu_pro_vision", args)
     elif args.eval_name == "aime25":
-        return _run_sgl_eval("aime25", args)
-    elif args.eval_name == "aime26":
-        return _run_sgl_eval("aime26", args)
+        from sglang.test.simple_eval_aime25 import AIME25Eval
+
+        eval_obj = AIME25Eval(args.num_examples, args.num_threads)
     elif args.eval_name == "gsm8k":
         if getattr(args, "api", None) == "sgl_eval":
             # Only the nightly correctness eval opts into sgl-eval (zero-shot
@@ -422,6 +534,17 @@ def run_eval(args):
         f.write(json.dumps(metrics, indent=2))
     print(f"Writing results to {result_filename}")
 
+    per_example_output = getattr(args, "per_example_output", None)
+    if per_example_output:
+        write_per_example_evidence(
+            result=result,
+            metrics=metrics,
+            eval_name=args.eval_name,
+            model=sampler.model,
+            output_path=per_example_output,
+            private_responses_path=getattr(args, "per_example_private_responses", None),
+        )
+
     if getattr(args, "return_latency", False):
         return metrics, latency
     return metrics
@@ -451,12 +574,6 @@ if __name__ == "__main__":
         help="Name or path of the model. If not set, the default model will request /v1/models for conf.",
     )
     parser.add_argument(
-        "--load-preset-from-model-id",
-        type=str,
-        default=None,
-        help="Load repository-maintained sgl-eval generation defaults for this model ID.",
-    )
-    parser.add_argument(
         "--repeat", type=int, default=1, help="repeat the evaluation n times"
     )
     parser.add_argument("--eval-name", type=str, default="mmlu")
@@ -469,9 +586,9 @@ if __name__ == "__main__":
     )
     parser.add_argument("--num-examples", type=int)
     parser.add_argument("--num-threads", type=int, default=512)
-    parser.add_argument("--max-tokens", type=int, default=None)
-    parser.add_argument("--temperature", type=float, default=None)
-    parser.add_argument("--top-p", type=float, default=None)
+    parser.add_argument("--max-tokens", type=int, default=2048)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--top-p", type=float, default=1.0)
     parser.add_argument(
         "--top-k", type=int, default=None, help="Top-k sampling parameter"
     )
@@ -486,6 +603,16 @@ if __name__ == "__main__":
     )
     parser.add_argument("--reasoning-effort", type=str)
     parser.add_argument(
+        "--per-example-output",
+        type=str,
+        help="Write GPQA or LongBench-v2 hashes, parsed answers, and correctness without raw responses",
+    )
+    parser.add_argument(
+        "--per-example-private-responses",
+        type=str,
+        help="Explicitly write raw GPQA or LongBench-v2 responses to a mode-0600 JSONL file",
+    )
+    parser.add_argument(
         "--thinking-mode",
         default=None,
         type=str,
@@ -494,6 +621,34 @@ if __name__ == "__main__":
     )
 
     # LongBench-v2 specific arguments
+    parser.add_argument(
+        "--dataset-path",
+        type=str,
+        default="THUDM/LongBench-v2",
+        help="Path to dataset file or HuggingFace dataset name for LongBench-v2",
+    )
+    parser.add_argument(
+        "--gpqa-data-path",
+        type=str,
+        default=None,
+        help="Optional local GPQA-Diamond CSV; avoids downloading it during a run",
+    )
+    parser.add_argument(
+        "--categories",
+        type=str,
+        default=None,
+        help="Comma-separated list of categories to evaluate for LongBench-v2",
+    )
+    parser.add_argument(
+        "--max-context-length",
+        type=int,
+        help="Maximum context length in characters for LongBench-v2",
+    )
+    parser.add_argument(
+        "--min-context-length",
+        type=int,
+        help="Minimum context length in characters for LongBench-v2",
+    )
     parser.add_argument(
         "--num-shots",
         type=int,
@@ -520,6 +675,5 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-    args._sgl_eval_from_cli = True
 
     run_eval(args)

--- a/python/sglang/test/simple_eval_common.py
+++ b/python/sglang/test/simple_eval_common.py
@@ -47,6 +47,7 @@ class EvalResult:
     metrics: Optional[Dict[str, float]]  # other metrics
     htmls: List[str]  # strings of valid HTML
     convos: List[MessageList]  # sampled conversations
+    examples: List[Dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass
@@ -59,6 +60,7 @@ class SingleEvalResult:
     metrics: Dict[str, float] = field(default_factory=dict)
     html: Optional[str] = None
     convo: Optional[MessageList] = None  # sampled conversation
+    example: Optional[Dict[str, Any]] = None
 
 
 class Eval:
@@ -473,6 +475,7 @@ def aggregate_results(
     name2values = defaultdict(list)
     htmls = []
     convos = []
+    examples = []
     for single_eval_result in single_eval_results:
         # Skip None results
         if single_eval_result is None:
@@ -483,6 +486,8 @@ def aggregate_results(
             name2values["score"].append(single_eval_result.score)
         htmls.append(single_eval_result.html)
         convos.append(single_eval_result.convo)
+        if single_eval_result.example is not None:
+            examples.append(single_eval_result.example)
     final_metrics = {}
     for name, values in name2values.items():
         stats = name2stats.get(name, default_stats)
@@ -494,6 +499,7 @@ def aggregate_results(
         metrics=final_metrics,
         htmls=htmls,
         convos=convos,
+        examples=examples,
     )
 
 

--- a/python/sglang/test/simple_eval_gpqa.py
+++ b/python/sglang/test/simple_eval_gpqa.py
@@ -1,0 +1,163 @@
+# Adapted from https://github.com/openai/simple-evals/
+
+"""
+GPQA: A Graduate-Level Google-Proof Q&A Benchmark
+David Rein, Betty Li Hou, Asa Cooper Stickland, Jackson Petty, Richard Yuanzhe Pang, Julien Dirani, Julian Michael, Samuel R. Bowman
+https://arxiv.org/abs/2311.12022
+"""
+
+import hashlib
+import json
+import random
+import re
+from typing import Optional
+
+import pandas
+
+from sglang.test import simple_eval_common as common
+from sglang.test.simple_eval_common import (
+    ANSWER_PATTERN_MULTICHOICE,
+    HTML_JINJA,
+    Eval,
+    EvalResult,
+    SamplerBase,
+    SingleEvalResult,
+    format_multichoice_question,
+)
+
+GPQA_SOURCE_FIELDS = (
+    "Question",
+    "Correct Answer",
+    "Incorrect Answer 1",
+    "Incorrect Answer 2",
+    "Incorrect Answer 3",
+)
+
+
+class GPQAEval(Eval):
+    def __init__(
+        self,
+        filename: str,
+        num_examples: Optional[int],
+        num_threads: int,
+        n_repeats: int = 1,
+    ):
+        if "://" in filename:
+            df = pandas.read_csv(filename, storage_options={"timeout": 30})
+        else:
+            df = pandas.read_csv(filename)
+        missing_columns = set(GPQA_SOURCE_FIELDS) - set(df.columns)
+        if missing_columns:
+            raise ValueError(f"GPQA data is missing columns: {sorted(missing_columns)}")
+        invalid_fields = [
+            field
+            for field in GPQA_SOURCE_FIELDS
+            if any(
+                not isinstance(value, str) or not value.strip() for value in df[field]
+            )
+        ]
+        if invalid_fields:
+            raise ValueError(
+                "GPQA semantic fields must contain non-empty strings: "
+                f"{invalid_fields}"
+            )
+        examples = [
+            {field: row[field] for field in GPQA_SOURCE_FIELDS}
+            | {"source_row_index": source_row_index}
+            for source_row_index, (_, row) in enumerate(df.iterrows())
+        ]
+        rng = random.Random(0)
+        if num_examples:
+            assert n_repeats == 1, "n_repeats only supported for num_examples"
+            examples = rng.sample(examples, num_examples)
+        examples = examples * n_repeats
+        examples = [
+            example | {"permutation": rng.sample(range(4), 4)} for example in examples
+        ]
+        self.examples = examples
+        self.n_repeats = n_repeats
+        self.num_threads = num_threads
+
+    def __call__(self, sampler: SamplerBase) -> EvalResult:
+        def fn(row: dict):
+            choices = [
+                row["Correct Answer"],
+                row["Incorrect Answer 1"],
+                row["Incorrect Answer 2"],
+                row["Incorrect Answer 3"],
+            ]
+            choices = [choices[i] for i in row["permutation"]]
+            correct_index = choices.index(row["Correct Answer"])
+            correct_answer = "ABCD"[correct_index]
+            choices_dict = dict(
+                A=choices[0],
+                B=choices[1],
+                C=choices[2],
+                D=choices[3],
+                Question=row["Question"],
+            )
+            prompt_messages = [
+                sampler._pack_message(
+                    content=format_multichoice_question(choices_dict), role="user"
+                )
+            ]
+            response_text = sampler(prompt_messages)
+            if response_text is None:
+                response_text = ""
+            match = re.search(ANSWER_PATTERN_MULTICHOICE, response_text)
+            extracted_answer = match.group(1) if match else None
+            score = 1.0 if extracted_answer == correct_answer else 0.0
+            question_sha256 = hashlib.sha256(row["Question"].encode()).hexdigest()
+            source_row = {field: row[field] for field in GPQA_SOURCE_FIELDS}
+            source_row_sha256 = hashlib.sha256(
+                json.dumps(
+                    source_row,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                ).encode()
+            ).hexdigest()
+            prompt_sha256 = hashlib.sha256(
+                json.dumps(
+                    prompt_messages,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                ).encode()
+            ).hexdigest()
+            html = common.jinja_env.from_string(HTML_JINJA).render(
+                prompt_messages=prompt_messages,
+                next_message=dict(content=response_text, role="assistant"),
+                score=score,
+                correct_answer=correct_answer,
+                extracted_answer=extracted_answer,
+            )
+            convo = prompt_messages + [dict(content=response_text, role="assistant")]
+            return SingleEvalResult(
+                html=html,
+                score=score,
+                convo=convo,
+                metrics={"chars": len(response_text)},
+                example={
+                    "question_id": (
+                        f"gpqa-{row['source_row_index']:03d}-{question_sha256[:16]}"
+                    ),
+                    "source_row_index": row["source_row_index"],
+                    "source_row_sha256": source_row_sha256,
+                    "question_sha256": question_sha256,
+                    "prompt_sha256": prompt_sha256,
+                    "permutation": row["permutation"],
+                    "expected_answer": correct_answer,
+                    "parsed_answer": extracted_answer,
+                    "correct": bool(score),
+                    "response_sha256": hashlib.sha256(
+                        response_text.encode()
+                    ).hexdigest(),
+                    "response_chars": len(response_text),
+                },
+            )
+
+        results = common.map_with_progress(fn, self.examples, self.num_threads)
+        return common.aggregate_results(results)

--- a/python/sglang/test/simple_eval_gpqa.py
+++ b/python/sglang/test/simple_eval_gpqa.py
@@ -58,8 +58,7 @@ class GPQAEval(Eval):
         ]
         if invalid_fields:
             raise ValueError(
-                "GPQA semantic fields must contain non-empty strings: "
-                f"{invalid_fields}"
+                f"GPQA semantic fields must contain non-empty strings: {invalid_fields}"
             )
         examples = [
             {field: row[field] for field in GPQA_SOURCE_FIELDS}

--- a/test/registered/unit/attention/test_minimax_msa_public_contract.py
+++ b/test/registered/unit/attention/test_minimax_msa_public_contract.py
@@ -11,6 +11,7 @@ from sglang.srt.layers.attention.minimax_sparse_backend import (
     MiniMaxSparseAttnBackend,
 )
 from sglang.srt.layers.attention.minimax_sparse_ops import msa
+from sglang.srt.layers.attention.minimax_sparse_ops import minimax_sparse as sparse_ops
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -106,6 +107,47 @@ def test_explicit_provider_selection_disables_runtime_fallback(monkeypatch):
 
     monkeypatch.setenv("SGLANG_MINIMAX_MSA_BACKEND", "flashinfer")
     assert not msa.msa_runtime_fallback_allowed()
+
+
+def test_decode_forwards_explicit_provider_and_graph_state(monkeypatch):
+    q = torch.zeros(2, 16, 128, dtype=torch.bfloat16)
+    k = torch.zeros(256, 1, 128, dtype=torch.bfloat16)
+    v = torch.zeros_like(k)
+    topk = torch.zeros(1, 2, 16, dtype=torch.int32)
+    page_table = torch.zeros(2, 2, dtype=torch.int32)
+    graph_state = object()
+    public_decode = Mock(return_value=q)
+    monkeypatch.setattr(msa, "msa_sparse_decode_main", public_decode)
+
+    _, output = sparse_ops.minimax_sparse_decode(
+        q,
+        None,
+        k,
+        v,
+        torch.zeros(2, 1, 128, dtype=torch.bfloat16),
+        None,
+        torch.zeros_like(k),
+        None,
+        torch.zeros(2, 256, dtype=torch.int32),
+        torch.arange(2, dtype=torch.int32),
+        torch.full((2,), 256, dtype=torch.int32),
+        256,
+        1,
+        128,
+        16,
+        1,
+        1,
+        use_msa=True,
+        cached_topk_idx=topk,
+        msa_backend="flashinfer",
+        msa_page_table=page_table,
+        msa_graph_state=graph_state,
+    )
+
+    assert output is q
+    assert public_decode.call_args.kwargs["backend"] == "flashinfer"
+    assert public_decode.call_args.kwargs["page_table"] is page_table
+    assert public_decode.call_args.kwargs["graph_state"] is graph_state
 
     monkeypatch.setenv("SGLANG_MINIMAX_MSA_BACKEND", "fmha_sm100")
     assert not msa.msa_runtime_fallback_allowed()

--- a/test/registered/unit/attention/test_minimax_msa_public_contract.py
+++ b/test/registered/unit/attention/test_minimax_msa_public_contract.py
@@ -1,0 +1,344 @@
+import inspect
+import sys
+import types
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from sglang.srt.layers.attention.base_attn_backend import SharedReadEnds
+from sglang.srt.layers.attention.minimax_sparse_backend import (
+    MiniMaxSparseAttnBackend,
+)
+from sglang.srt.layers.attention.minimax_sparse_ops import msa
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+@pytest.mark.parametrize("provider", ["auto", "vibecuda"])
+def test_public_provider_is_forwarded_to_both_kernels(monkeypatch, provider):
+    def operation(required):
+        call = Mock(return_value=object())
+        call.__signature__ = inspect.Signature(
+            [
+                inspect.Parameter(name, inspect.Parameter.KEYWORD_ONLY, default=None)
+                for name in sorted(required | {"backend"})
+            ]
+        )
+        return call
+
+    prefill = operation(msa._FLASHINFER_PREFILL_PARAMS)
+    decode = operation(msa._FLASHINFER_DECODE_PARAMS)
+    module = types.ModuleType("flashinfer")
+    module.msa_ops = types.SimpleNamespace(
+        msa_sparse_attention=prefill,
+        msa_sparse_decode_attention=decode,
+        msa_topk_select=Mock(),
+        MSASparseAttentionWorkspace=Mock(),
+    )
+    monkeypatch.setitem(sys.modules, "flashinfer", module)
+    monkeypatch.setenv("SGLANG_MINIMAX_MSA_FLASHINFER_BACKEND", provider)
+    msa._load_flashinfer_msa.cache_clear()
+    try:
+        bound_prefill, bound_decode, _, _ = msa._load_flashinfer_msa()
+        bound_prefill(q="prefill")
+        bound_decode(q="decode")
+        kwargs = {} if provider == "auto" else {"backend": provider}
+        prefill.assert_called_once_with(q="prefill", **kwargs)
+        decode.assert_called_once_with(q="decode", **kwargs)
+        if provider == "vibecuda":
+            assert not msa.msa_runtime_fallback_allowed()
+    finally:
+        msa._load_flashinfer_msa.cache_clear()
+
+
+class _RecordingGraphState:
+    def __init__(self):
+        self.workspace = object()
+        self.staged = {}
+
+    def stage(self, name: str, value: torch.Tensor) -> torch.Tensor:
+        self.staged[name] = value
+        return value
+
+
+def _production_inputs():
+    total_q = 4
+    num_q_heads = 16
+    num_kv_heads = 1
+    head_dim = 128
+    page_size = 128
+    num_pages = 2
+    q = torch.zeros(total_q, num_q_heads, head_dim, dtype=torch.bfloat16)
+    k = torch.zeros(num_pages * page_size, num_kv_heads, head_dim, dtype=torch.bfloat16)
+    v = torch.zeros_like(k)
+    q2k = torch.zeros(num_kv_heads, total_q, 16, dtype=torch.int32)
+    page_table = torch.tensor([[0, 1], [0, 1]], dtype=torch.int32)
+    seq_lens = torch.tensor([128, 256], dtype=torch.int32)
+    return q, k, v, q2k, page_table, seq_lens
+
+
+def _noncontiguous_q(total_q: int = 4) -> torch.Tensor:
+    q = torch.zeros(total_q, 128, 16, dtype=torch.bfloat16).transpose(1, 2)
+    assert q.shape == (total_q, 16, 128)
+    assert not q.is_contiguous()
+    return q
+
+
+def test_topk16_only_provider_selection(monkeypatch):
+    monkeypatch.setenv("SGLANG_MINIMAX_MSA_BACKEND", "auto")
+    monkeypatch.setattr(msa, "flashinfer_msa_available", lambda: True)
+    monkeypatch.setattr(msa, "fmha_sm100_available", lambda: True)
+
+    assert msa.selected_msa_backend(torch.bfloat16, 1, 16) == "flashinfer"
+    assert msa.selected_msa_backend(torch.bfloat16, 1, 8) == "fmha_sm100"
+
+    monkeypatch.setenv("SGLANG_MINIMAX_MSA_BACKEND", "flashinfer")
+    with pytest.raises(msa.MSAUnavailableError, match="top-k 16"):
+        msa.selected_msa_backend(torch.bfloat16, 1, 8)
+
+
+def test_explicit_provider_selection_disables_runtime_fallback(monkeypatch):
+    monkeypatch.setenv("SGLANG_MINIMAX_MSA_BACKEND", "auto")
+    assert msa.msa_runtime_fallback_allowed()
+
+    monkeypatch.setenv("SGLANG_MINIMAX_MSA_BACKEND", "flashinfer")
+    assert not msa.msa_runtime_fallback_allowed()
+
+    monkeypatch.setenv("SGLANG_MINIMAX_MSA_BACKEND", "fmha_sm100")
+    assert not msa.msa_runtime_fallback_allowed()
+
+
+def test_public_loader_rejects_missing_forwarded_abi_keywords(monkeypatch):
+    def prefill(
+        q,
+        k,
+        v,
+        q2k_indices,
+        cu_seqlens_q,
+        page_table,
+        seqused_k,
+        q_offset,
+        workspace,
+    ):
+        pass
+
+    def decode(
+        q,
+        k,
+        v,
+        q2k_indices,
+        *,
+        page_table,
+        seqused_k,
+        seqlen_q,
+        workspace,
+    ):
+        pass
+
+    fake_ops = types.SimpleNamespace(
+        msa_sparse_attention=prefill,
+        msa_sparse_decode_attention=decode,
+        msa_topk_select=lambda: None,
+        MSASparseAttentionWorkspace=lambda _device: None,
+    )
+    fake_flashinfer = types.ModuleType("flashinfer")
+    fake_flashinfer.msa_ops = fake_ops
+    monkeypatch.setitem(sys.modules, "flashinfer", fake_flashinfer)
+    msa._load_flashinfer_msa.cache_clear()
+    try:
+        with pytest.raises(msa.MSAUnavailableError, match="causal.*softmax_scale"):
+            msa._load_flashinfer_msa()
+    finally:
+        msa._load_flashinfer_msa.cache_clear()
+
+
+def test_prefill_forwards_tp4_public_contract(monkeypatch):
+    q, k, v, q2k, page_table, seq_lens = _production_inputs()
+    public_prefill = Mock(return_value=q)
+    monkeypatch.setattr(
+        msa,
+        "_load_flashinfer_msa",
+        lambda: (public_prefill, Mock(), Mock(), Mock()),
+    )
+    graph_state = _RecordingGraphState()
+    cu_q = torch.tensor([0, 2, 4], dtype=torch.int32)
+    q_offset = torch.tensor([126, 254], dtype=torch.int32)
+
+    out = msa._flashinfer_prefill(
+        q=q,
+        k_cache=k,
+        v_cache=v,
+        topk_idx=q2k,
+        req_to_token=torch.empty(2, 256, dtype=torch.int32),
+        slot_ids=torch.tensor([0, 1], dtype=torch.int32),
+        cu_seqlens=cu_q,
+        seq_lens=seq_lens,
+        prefix_lens=q_offset,
+        block_size_k=128,
+        sm_scale=128**-0.5,
+        page_table=page_table,
+        graph_state=graph_state,
+    )
+
+    assert out is q
+    call = public_prefill.call_args.kwargs
+    assert call["q"].shape == (4, 16, 128)
+    assert call["k"].shape == call["v"].shape == (2, 1, 128, 128)
+    assert call["q2k_indices"].shape == (1, 4, 16)
+    assert call["cu_seqlens_q"].shape == (3,)
+    assert call["page_table"].shape == (2, 2)
+    assert call["seqused_k"].shape == call["q_offset"].shape == (2,)
+    assert call["workspace"] is graph_state.workspace
+    assert set(graph_state.staged) == {
+        "q",
+        "q2k_indices",
+        "cu_seqlens_q",
+        "seqused_k",
+        "q_offset",
+    }
+
+
+def test_decode_forwards_tp4_public_contract(monkeypatch):
+    q, k, v, q2k, page_table, seq_lens = _production_inputs()
+    q = q[:2]
+    q2k = q2k[:, :2]
+    public_decode = Mock(return_value=q)
+    monkeypatch.setattr(
+        msa,
+        "_load_flashinfer_msa",
+        lambda: (Mock(), public_decode, Mock(), Mock()),
+    )
+    graph_state = _RecordingGraphState()
+
+    out = msa._flashinfer_decode(
+        q=q,
+        k_cache=k,
+        v_cache=v,
+        topk_idx=q2k,
+        req_to_token=torch.empty(2, 256, dtype=torch.int32),
+        slot_ids=torch.tensor([0, 1], dtype=torch.int32),
+        seq_lens=seq_lens,
+        block_size_k=128,
+        sm_scale=128**-0.5,
+        page_table=page_table,
+        graph_state=graph_state,
+    )
+
+    assert out is q
+    call = public_decode.call_args.kwargs
+    assert call["q"].shape == (2, 16, 128)
+    assert call["k"].shape == call["v"].shape == (2, 1, 128, 128)
+    assert call["q2k_indices"].shape == (1, 2, 16)
+    assert call["page_table"].shape == (2, 2)
+    assert call["seqused_k"].shape == (2,)
+    assert call["seqlen_q"] == 1
+    assert call["workspace"] is graph_state.workspace
+    assert set(graph_state.staged) == {"q", "q2k_indices", "seqused_k"}
+
+
+def test_prefill_makes_public_q_contiguous_without_graph_state(monkeypatch):
+    _, k, v, q2k, page_table, seq_lens = _production_inputs()
+    q = _noncontiguous_q()
+    public_prefill = Mock(return_value=q)
+    monkeypatch.setattr(
+        msa,
+        "_load_flashinfer_msa",
+        lambda: (public_prefill, Mock(), Mock(), Mock()),
+    )
+
+    msa._flashinfer_prefill(
+        q=q,
+        k_cache=k,
+        v_cache=v,
+        topk_idx=q2k,
+        req_to_token=torch.empty(2, 256, dtype=torch.int32),
+        slot_ids=torch.tensor([0, 1], dtype=torch.int32),
+        cu_seqlens=torch.tensor([0, 2, 4], dtype=torch.int32),
+        seq_lens=seq_lens,
+        prefix_lens=torch.tensor([126, 254], dtype=torch.int32),
+        block_size_k=128,
+        sm_scale=128**-0.5,
+        page_table=page_table,
+        graph_state=None,
+    )
+
+    assert public_prefill.call_args.kwargs["q"].is_contiguous()
+
+
+def test_decode_makes_public_q_contiguous_without_graph_state(monkeypatch):
+    _, k, v, q2k, page_table, seq_lens = _production_inputs()
+    q = _noncontiguous_q(total_q=2)
+    q2k = q2k[:, :2]
+    public_decode = Mock(return_value=q)
+    monkeypatch.setattr(
+        msa,
+        "_load_flashinfer_msa",
+        lambda: (Mock(), public_decode, Mock(), Mock()),
+    )
+
+    msa._flashinfer_decode(
+        q=q,
+        k_cache=k,
+        v_cache=v,
+        topk_idx=q2k,
+        req_to_token=torch.empty(2, 256, dtype=torch.int32),
+        slot_ids=torch.tensor([0, 1], dtype=torch.int32),
+        seq_lens=seq_lens,
+        block_size_k=128,
+        sm_scale=128**-0.5,
+        page_table=page_table,
+        graph_state=None,
+    )
+
+    assert public_decode.call_args.kwargs["q"].is_contiguous()
+
+
+def test_graph_state_and_page_table_keep_stable_addresses(monkeypatch):
+    workspace = object()
+    monkeypatch.setattr(
+        msa,
+        "_load_flashinfer_msa",
+        lambda: (Mock(), Mock(), Mock(), lambda _device: workspace),
+    )
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    state = msa.FlashInferMSAGraphState("cpu")
+    first = state.stage("q", torch.ones(2, 16, 128, dtype=torch.bfloat16))
+    address = first.data_ptr()
+    second = state.stage("q", torch.zeros_like(first))
+    assert state.workspace is workspace
+    assert second.data_ptr() == address
+    assert torch.count_nonzero(second) == 0
+
+    req_to_token = torch.stack((torch.arange(128, 384), torch.arange(512, 768))).to(
+        torch.int32
+    )
+    page_table = torch.full((2, 2), -1, dtype=torch.int32)
+    result = msa.build_flashinfer_page_table(
+        req_to_token,
+        torch.tensor([0, 1], dtype=torch.int32),
+        torch.tensor([256, 256], dtype=torch.int32),
+        128,
+        out=page_table,
+    )
+    assert result.data_ptr() == page_table.data_ptr()
+    assert result.tolist() == [[1, 2], [4, 5]]
+
+
+def test_flashinfer_decode_page_table_remains_live_through_graph_replay():
+    backend = object.__new__(MiniMaxSparseAttnBackend)
+    backend.msa_backend = "flashinfer"
+    backend._msa_owns_decode = True
+
+    assert backend.shared_read_ends(ForwardMode.DECODE) is SharedReadEnds.POST_REPLAY
+    assert backend.shared_read_ends(ForwardMode.EXTEND) is SharedReadEnds.UNKNOWN
+
+    backend.msa_backend = "fmha_sm100"
+    assert backend.shared_read_ends(ForwardMode.DECODE) is SharedReadEnds.POST_REPLAY
+    assert backend.shared_read_ends(ForwardMode.EXTEND) is SharedReadEnds.UNKNOWN
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/attention/test_minimax_msa_public_contract.py
+++ b/test/registered/unit/attention/test_minimax_msa_public_contract.py
@@ -243,6 +243,44 @@ def test_prefill_forwards_tp4_public_contract(monkeypatch):
     }
 
 
+def test_prefill_splits_ragged_eager_batches_without_device_length_reads(monkeypatch):
+    q, k, v, q2k, page_table, seq_lens = _production_inputs()
+    q = q[:3]
+    q2k = q2k[:, :3]
+    public_prefill = Mock(side_effect=lambda **kwargs: kwargs["q"])
+    monkeypatch.setattr(
+        msa,
+        "_load_flashinfer_msa",
+        lambda: (public_prefill, Mock(), Mock(), Mock()),
+    )
+
+    out = msa._flashinfer_prefill(
+        q=q,
+        k_cache=k,
+        v_cache=v,
+        topk_idx=q2k,
+        req_to_token=torch.empty(2, 256, dtype=torch.int32),
+        slot_ids=torch.tensor([0, 1], dtype=torch.int32),
+        cu_seqlens=torch.tensor([0, 1, 3], dtype=torch.int32),
+        seq_lens=seq_lens,
+        prefix_lens=torch.tensor([127, 254], dtype=torch.int32),
+        block_size_k=128,
+        sm_scale=128**-0.5,
+        page_table=page_table,
+        graph_state=None,
+        seqlens_cpu=[1, 2],
+    )
+
+    assert torch.equal(out, q)
+    assert public_prefill.call_count == 2
+    first, second = [call.kwargs for call in public_prefill.call_args_list]
+    assert first["q"].shape[0] == 1
+    assert second["q"].shape[0] == 2
+    assert first["cu_seqlens_q"].tolist() == [0, 1]
+    assert second["cu_seqlens_q"].tolist() == [0, 2]
+    assert first["page_table"].shape[0] == second["page_table"].shape[0] == 1
+
+
 def test_decode_forwards_tp4_public_contract(monkeypatch):
     q, k, v, q2k, page_table, seq_lens = _production_inputs()
     q = q[:2]

--- a/test/registered/unit/attention/test_minimax_msa_public_contract.py
+++ b/test/registered/unit/attention/test_minimax_msa_public_contract.py
@@ -10,8 +10,8 @@ from sglang.srt.layers.attention.base_attn_backend import SharedReadEnds
 from sglang.srt.layers.attention.minimax_sparse_backend import (
     MiniMaxSparseAttnBackend,
 )
-from sglang.srt.layers.attention.minimax_sparse_ops import msa
 from sglang.srt.layers.attention.minimax_sparse_ops import minimax_sparse as sparse_ops
+from sglang.srt.layers.attention.minimax_sparse_ops import msa
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.ci.ci_register import register_cpu_ci
 

--- a/test/registered/unit/bench/test_simple_eval_gpqa_evidence.py
+++ b/test/registered/unit/bench/test_simple_eval_gpqa_evidence.py
@@ -1,0 +1,221 @@
+import hashlib
+import json
+import stat
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas
+import pytest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.run_eval import (
+    validate_per_example_evidence_args,
+    write_per_example_evidence,
+)
+from sglang.test.simple_eval_common import SingleEvalResult, aggregate_results
+from sglang.test.simple_eval_gpqa import GPQAEval
+
+register_cpu_ci(est_time=10, suite="base-b-test-cpu")
+
+
+class FakeSampler:
+    def _pack_message(self, *, content, role):
+        return {"content": content, "role": role}
+
+    def __call__(self, _messages):
+        return "reasoning\nAnswer: A"
+
+
+def synthetic_gpqa_rows(count: int) -> list[dict]:
+    return [
+        {
+            "Question": f"question {index}",
+            "Correct Answer": f"correct {index}",
+            "Incorrect Answer 1": f"wrong {index} one",
+            "Incorrect Answer 2": f"wrong {index} two",
+            "Incorrect Answer 3": f"wrong {index} three",
+        }
+        for index in range(count)
+    ]
+
+
+def test_gpqa_retains_non_raw_per_example_evidence(tmp_path: Path):
+    dataset = tmp_path / "gpqa.csv"
+    pandas.DataFrame(synthetic_gpqa_rows(2)).to_csv(dataset, index=False)
+
+    result = GPQAEval(str(dataset), num_examples=2, num_threads=1)(FakeSampler())
+
+    assert len(result.examples) == 2
+    assert {example["source_row_index"] for example in result.examples} == {0, 1}
+    for example in result.examples:
+        assert example["parsed_answer"] == "A"
+        assert "response" not in example
+        assert (
+            example["response_sha256"]
+            == hashlib.sha256(b"reasoning\nAnswer: A").hexdigest()
+        )
+
+
+def test_gpqa_198_question_ids_are_unique_and_ordered_stably(tmp_path: Path):
+    dataset = tmp_path / "gpqa.csv"
+    pandas.DataFrame(synthetic_gpqa_rows(198)).to_csv(dataset, index=False)
+    first_eval = GPQAEval(str(dataset), num_examples=198, num_threads=8)
+    second_eval = GPQAEval(str(dataset), num_examples=198, num_threads=8)
+
+    first = first_eval(FakeSampler())
+    second = second_eval(FakeSampler())
+    first_ids = [example["question_id"] for example in first.examples]
+    second_ids = [example["question_id"] for example in second.examples]
+
+    assert len(first_ids) == 198
+    assert len(set(first_ids)) == 198
+    assert first_ids == second_ids
+    assert [example["source_row_index"] for example in first.examples] == [
+        row["source_row_index"] for row in first_eval.examples
+    ]
+
+
+def test_source_row_hash_ignores_extra_nan_columns(tmp_path: Path):
+    rows = synthetic_gpqa_rows(2)
+    first_dataset = tmp_path / "first.csv"
+    second_dataset = tmp_path / "second.csv"
+    pandas.DataFrame(rows).assign(extra_metadata=["first", "second"]).to_csv(
+        first_dataset, index=False
+    )
+    pandas.DataFrame(rows).assign(extra_metadata=[None, None]).to_csv(
+        second_dataset, index=False
+    )
+
+    first = GPQAEval(str(first_dataset), num_examples=2, num_threads=1)(FakeSampler())
+    second = GPQAEval(str(second_dataset), num_examples=2, num_threads=1)(FakeSampler())
+
+    assert [item["source_row_sha256"] for item in first.examples] == [
+        item["source_row_sha256"] for item in second.examples
+    ]
+
+
+def test_per_example_writer_requires_explicit_private_path(tmp_path: Path):
+    response = "private reasoning\nAnswer: A"
+    response_sha256 = hashlib.sha256(response.encode()).hexdigest()
+    example = {
+        "question_id": "gpqa-000-deadbeefdeadbeef",
+        "response_sha256": response_sha256,
+        "parsed_answer": "A",
+        "correct": True,
+    }
+    result = aggregate_results(
+        [
+            SingleEvalResult(
+                score=1.0,
+                convo=[
+                    {"role": "user", "content": "question"},
+                    {"role": "assistant", "content": response},
+                ],
+                example=example,
+            )
+        ]
+    )
+    public_path = tmp_path / "public.json"
+    private_path = tmp_path / "private.jsonl"
+
+    write_per_example_evidence(
+        result=result,
+        metrics={"score": 1.0},
+        eval_name="gpqa",
+        model="model",
+        output_path=str(public_path),
+        private_responses_path=str(private_path),
+    )
+
+    public_payload = json.loads(public_path.read_text())
+    assert public_payload["examples"] == [example]
+    assert public_payload["summary"]["score"] == sum(
+        item["correct"] for item in public_payload["examples"]
+    ) / len(public_payload["examples"])
+    assert response not in public_path.read_text()
+    private_payload = json.loads(private_path.read_text())
+    assert private_payload["response"] == response
+    assert stat.S_IMODE(private_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(public_path.stat().st_mode) == 0o444
+
+
+def test_writer_refuses_overwrite_and_arm_paths_do_not_conflict(tmp_path: Path):
+    response = "Answer: A"
+    example = {
+        "question_id": "gpqa-000-deadbeefdeadbeef",
+        "response_sha256": hashlib.sha256(response.encode()).hexdigest(),
+        "parsed_answer": "A",
+        "correct": True,
+    }
+    result = aggregate_results(
+        [
+            SingleEvalResult(
+                score=1.0,
+                convo=[{"role": "assistant", "content": response}],
+                example=example,
+            )
+        ]
+    )
+    baseline = tmp_path / "baseline/gpqa_per_example.json"
+    candidate = tmp_path / "candidate/gpqa_per_example.json"
+    for output in (baseline, candidate):
+        write_per_example_evidence(
+            result=result,
+            metrics={"score": 1.0},
+            eval_name="gpqa",
+            model="model",
+            output_path=str(output),
+        )
+    assert baseline.is_file() and candidate.is_file()
+    with pytest.raises(FileExistsError):
+        write_per_example_evidence(
+            result=result,
+            metrics={"score": 1.0},
+            eval_name="gpqa",
+            model="model",
+            output_path=str(baseline),
+        )
+
+
+def test_private_responses_require_public_evidence_path(tmp_path: Path):
+    args = SimpleNamespace(
+        eval_name="gpqa",
+        repeat=1,
+        per_example_output=None,
+        per_example_private_responses=str(tmp_path / "private.jsonl"),
+    )
+    with pytest.raises(
+        ValueError,
+        match="--per-example-private-responses requires --per-example-output",
+    ):
+        validate_per_example_evidence_args(args)
+
+
+@pytest.mark.parametrize(
+    ("eval_name", "repeat", "message"),
+    [
+        ("mmlu", 1, "supported only for GPQA"),
+        ("gpqa", 2, "requires --repeat 1"),
+    ],
+)
+def test_per_example_evidence_rejects_unsupported_runs(
+    tmp_path: Path, eval_name: str, repeat: int, message: str
+):
+    args = SimpleNamespace(
+        eval_name=eval_name,
+        repeat=repeat,
+        per_example_output=str(tmp_path / "public.json"),
+        per_example_private_responses=None,
+    )
+    with pytest.raises(ValueError, match=message):
+        validate_per_example_evidence_args(args)
+
+
+@pytest.mark.parametrize("invalid_value", [None, "", "   "])
+def test_gpqa_rejects_invalid_semantic_fields(tmp_path: Path, invalid_value):
+    rows = synthetic_gpqa_rows(2)
+    rows[1]["Incorrect Answer 2"] = invalid_value
+    dataset = tmp_path / "gpqa.csv"
+    pandas.DataFrame(rows).to_csv(dataset, index=False)
+    with pytest.raises(ValueError, match="must contain non-empty strings"):
+        GPQAEval(str(dataset), num_examples=2, num_threads=1)


### PR DESCRIPTION
## Summary

This is a standalone SGLang integration for the VibeCUDA MSA provider on Blackwell. It adds:

- explicit routing to FlashInfer's `backend="vibecuda"` provider;
- fail-closed provider selection when that provider is requested;
- CUDA Graph-safe metadata staging and lifetime handling; and
- fixed-request, GPQA-Diamond, and LongBench-v2 validation utilities.

The runtime implementation is based directly on current SGLang `main`. It preserves the current MiniMax M3 top-k selector and cache behavior. The benchmark/evaluation harness is adapted from the methodology in #35846 and credited separately; this PR does not include or depend on that PR's runtime implementation.

## Validation

- Rewritten standalone head: 11/11 provider, ABI, TP4 contract, fallback, and CUDA Graph metadata tests passed on GB200.
- The matched framework campaign used one frozen 198-question GPQA-Diamond set and one frozen 100-example LongBench-v2 subset, a fresh server/cache per arm, CUDA Graph decode, and 298 successful measured requests per arm.
- Route receipts verified all four paths: no-MSA Triton, standalone `fmha_sm100`, FlashInfer CAKE (`provider=auto`), and VibeCUDA export (`provider=vibecuda`).
- Fixed requests at short, 32K, and 64K prompt lengths returned the exact expected strings in every arm.

| Arm | GPQA-Diamond | LongBench-v2 subset |
|---|---:|---:|
| no-MSA Triton | 146/198 (73.74%) | 0.68 |
| standalone `fmha_sm100` | 141/198 (71.21%) | 0.68 |
| FlashInfer CAKE source | 151/198 (76.26%) | 0.63 |
| VibeCUDA export | 150/198 (75.76%) | 0.66 |

Matched deltas:

- CAKE source - no-MSA: +5 GPQA answers (+2.53 pp), -0.05 LongBench.
- VibeCUDA export - no-MSA: +4 GPQA answers (+2.02 pp), -0.02 LongBench.
- VibeCUDA export - CAKE source: -1 GPQA answer (-0.51 pp), +0.03 LongBench.

This is one deterministic repetition, not a statistical quality ranking. It establishes that the explicitly routed VibeCUDA backend does not introduce a broad framework-level precision regression under the matched protocol.

### Fixed-request serving validation

A separate VibeCUDA-only serving run used TP4 on NVIDIA GB200, CUDA Graph decode, a fresh server/cache, 256 requests at each concurrency, and an unmeasured concurrency-128 warmup before the measured matrix. The route receipt explicitly records `main_attn=flashinfer`, `flashinfer_provider=vibecuda`, `msa_decode=True`, `msa_owns_decode=True`, and `decode_cuda_graph=True`. All 1,024/1,024 measured requests completed; startup, route/cache lifecycle, client, measured-window, and thermal audits passed with no measured-window retries, errors, or JIT/compilation.

| Concurrency | Output throughput | Request throughput | Mean TTFT | Mean TPOT |
|---:|---:|---:|---:|---:|
| 1 | 88.88 tok/s | 0.09 req/s | 268.72 ms | 11.00 ms |
| 8 | 477.33 tok/s | 0.47 req/s | 1,364.65 ms | 15.44 ms |
| 32 | 1,159.91 tok/s | 1.13 req/s | 4,233.78 ms | 23.46 ms |
| 128 | 1,541.54 tok/s | 1.51 req/s | 29,875.96 ms | 39.35 ms |

These are candidate-only serving measurements, not a paired speedup claim. The matched CAKE source arm repeatedly deadlocked under CUDA Graph and therefore did not yield a valid denominator.

Kernel-level SM100 and SM103 results and the implementation are tracked in flashinfer-ai/flashinfer#4817.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34950999097](https://github.com/sgl-project/sglang/actions/runs/34950999097)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34950998800](https://github.com/sgl-project/sglang/actions/runs/34950998800)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34950998895](https://github.com/sgl-project/sglang/actions/runs/34950998895)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
