### PR TITLE
[PD] Vectorize disaggregation staging copies with validated alignment

### DIFF
--- a/python/sglang/srt/disaggregation/common/staging_buffer.py
+++ b/python/sglang/srt/disaggregation/common/staging_buffer.py
@@ -41,6 +41,8 @@ def _fused_gather_to_staging_kernel(
     ELEMS_PER_TOKEN: tl.constexpr,
     PAGE_SIZE: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    ELEMS_PER_16B: tl.constexpr,
+    ALIGNED_16: tl.constexpr,
 ):
     layer_id = tl.program_id(0)
     block_id = tl.program_id(1)
@@ -58,13 +60,23 @@ def _fused_gather_to_staging_kernel(
     page_val = tl.load(page_indices + page_id, mask=mask, other=0)
     pool_token = page_val * PAGE_SIZE + intra_page
 
-    src_offsets = (
-        pool_token * stride_pool_token.to(tl.int64) + head_offset.to(tl.int64) + e_idx
+    src_row = (
+        layer_ptr
+        + pool_token * stride_pool_token.to(tl.int64)
+        + head_offset.to(tl.int64)
     )
-    vals = tl.load(layer_ptr + src_offsets, mask=mask)
-
-    dst_offsets = tl.program_id(0).to(tl.int64) * per_layer_elems.to(tl.int64) + offsets
-    tl.store(staging + dst_offsets, vals, mask=mask)
+    dst_row = staging + layer_id.to(tl.int64) * per_layer_elems.to(tl.int64)
+    if ALIGNED_16:
+        # `layer_ptr` is loaded from a device table, so Triton has no divisibility
+        # for it and lowers the payload one element at a time.
+        # Host validation proves both row bases. These compile-time assertions
+        # ensure the per-program index terms preserve that 16-byte alignment.
+        tl.static_assert(ELEMS_PER_TOKEN % ELEMS_PER_16B == 0)
+        tl.static_assert(BLOCK_SIZE % ELEMS_PER_16B == 0)
+        src_row = tl.multiple_of(src_row, 16)
+        dst_row = tl.multiple_of(dst_row, 16)
+    vals = tl.load(src_row + e_idx, mask=mask)
+    tl.store(dst_row + offsets, vals, mask=mask)
 
 
 @triton.jit
@@ -80,6 +92,8 @@ def _fused_scatter_from_staging_kernel(
     PAGE_SIZE: tl.constexpr,
     NUM_LAYERS_X2: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    ELEMS_PER_16B: tl.constexpr,
+    ALIGNED_16: tl.constexpr,
 ):
     prog_id = tl.program_id(0)
     block_id = tl.program_id(1)
@@ -102,17 +116,94 @@ def _fused_scatter_from_staging_kernel(
     pool_token = page_val * PAGE_SIZE + intra_page
 
     per_rank_elems = per_layer_elems.to(tl.int64) * NUM_LAYERS_X2
-    src_offsets = (
+    src_row = staging + (
         writer_id.to(tl.int64) * per_rank_elems
         + layer_kv_id.to(tl.int64) * per_layer_elems.to(tl.int64)
-        + offsets
     )
-    vals = tl.load(staging + src_offsets, mask=mask)
+    dst_row = (
+        layer_ptr
+        + pool_token * stride_pool_token.to(tl.int64)
+        + head_offset.to(tl.int64)
+    )
+    if ALIGNED_16:
+        # See the gather kernel: the same proof covers both row bases here.
+        tl.static_assert(ELEMS_PER_TOKEN % ELEMS_PER_16B == 0)
+        tl.static_assert(BLOCK_SIZE % ELEMS_PER_16B == 0)
+        src_row = tl.multiple_of(src_row, 16)
+        dst_row = tl.multiple_of(dst_row, 16)
+    vals = tl.load(src_row + offsets, mask=mask)
+    tl.store(dst_row + e_idx, vals, mask=mask)
 
-    dst_offsets = (
-        pool_token * stride_pool_token.to(tl.int64) + head_offset.to(tl.int64) + e_idx
+
+def kv_buffers_preserve_16_byte_alignment(
+    buffers: list[torch.Tensor],
+    *,
+    stride_pool_token: int,
+    head_dim: int,
+) -> bool:
+    """Validate the stable KV-buffer terms of the 16-byte row-base proof."""
+    if not buffers:
+        return False
+
+    dtype = buffers[0].dtype
+    dtype_size = buffers[0].element_size()
+    return 16 % dtype_size == 0 and all(
+        buf.dtype == dtype
+        and buf.ndim == 3
+        and buf.shape[-1] == head_dim
+        and buf.stride(0) == stride_pool_token
+        and buf.stride(1) == head_dim
+        and buf.stride(2) == 1
+        and buf.data_ptr() % 16 == 0
+        for buf in buffers
     )
-    tl.store(layer_ptr + dst_offsets, vals, mask=mask)
+
+
+def _can_use_aligned_staging_copy(
+    buffers: list[torch.Tensor],
+    staging: torch.Tensor,
+    *,
+    stride_pool_token: int,
+    head_dim: int,
+    head_offsets: list[int],
+    elems_per_token: int,
+    per_layer_elems: int,
+    buffers_aligned_16: Optional[bool] = None,
+) -> bool:
+    """Whether every staging row base is 16-byte aligned on both sides.
+
+    The kernels reach the KV pool through a device pointer table and reach staging
+    through a layer/writer offset, so both bases have to be proven: each KV
+    buffer's own pointer and the three strides that reach a row inside it, plus the
+    staging allocation and the per-layer stride that indexes into it. Stable KV
+    terms may be validated once at buffer registration and passed through
+        ``buffers_aligned_16``; request-dependent terms are always checked here.
+        Keep each term explicit so future slicing or layout callers cannot weaken the
+        proof by relying on today's shape relationships. One failed term keeps the
+        whole launch on the generic path.
+    """
+    dtype_size = staging.element_size()
+    # ELEMS_PER_16B = 16 // dtype_size must be exact for the kernel's static asserts.
+    if 16 % dtype_size != 0:
+        return False
+
+    if buffers_aligned_16 is None:
+        buffers_aligned_16 = kv_buffers_preserve_16_byte_alignment(
+            buffers,
+            stride_pool_token=stride_pool_token,
+            head_dim=head_dim,
+        )
+
+    return (
+        buffers_aligned_16
+        and staging.is_contiguous()
+        and staging.data_ptr() % 16 == 0
+        and stride_pool_token * dtype_size % 16 == 0
+        and head_dim * dtype_size % 16 == 0
+        and elems_per_token * dtype_size % 16 == 0
+        and per_layer_elems * dtype_size % 16 == 0
+        and all(offset * dtype_size % 16 == 0 for offset in head_offsets)
+    )
 
 
 class StagingBuffer:
@@ -408,6 +499,7 @@ def _gather_all_layers_triton(
     num_heads: int,
     page_size: int,
     gpu_id: int,
+    buffers_aligned_16: Optional[bool] = None,
 ) -> int:
     """Triton fused kernel path: single kernel launch for all layers."""
     import numpy as np
@@ -421,13 +513,16 @@ def _gather_all_layers_triton(
     per_layer_elems = num_tokens * elems_per_token
     per_layer_bytes = per_layer_elems * dtype_size
     total_bytes = per_layer_bytes * num_layers * 2
+    stride_pool_token = total_heads * head_dim
+    head_offset = src_head_start * head_dim
+    buffers = k_buffers + v_buffers
 
     device = f"cuda:{gpu_id}"
     torch.cuda.set_device(gpu_id)
     page_idx_tensor = torch.from_numpy(page_indices_np.astype(np.int64)).to(device)
 
     layer_ptrs = torch.tensor(
-        [buf.data_ptr() for buf in k_buffers] + [buf.data_ptr() for buf in v_buffers],
+        [buf.data_ptr() for buf in buffers],
         dtype=torch.int64,
         device=device,
     )
@@ -435,6 +530,16 @@ def _gather_all_layers_triton(
     int_dtype_map = {1: torch.int8, 2: torch.int16, 4: torch.int32}
     int_dtype = int_dtype_map.get(dtype_size, torch.int16)
     staging_typed = staging_buffer.buffer[:total_bytes].view(int_dtype)
+    aligned_16 = _can_use_aligned_staging_copy(
+        buffers,
+        staging_typed,
+        stride_pool_token=stride_pool_token,
+        head_dim=head_dim,
+        head_offsets=[head_offset],
+        elems_per_token=elems_per_token,
+        per_layer_elems=per_layer_elems,
+        buffers_aligned_16=buffers_aligned_16,
+    )
 
     gather_stream = staging_buffer.get_gather_stream()
     gather_stream.wait_stream(torch.cuda.default_stream(torch.device(device)))
@@ -448,12 +553,14 @@ def _gather_all_layers_triton(
             page_idx_tensor,
             staging_typed,
             num_tokens,
-            total_heads * head_dim,
-            src_head_start * head_dim,
+            stride_pool_token,
+            head_offset,
             per_layer_elems,
             elems_per_token,
             page_size,
             BLOCK_SIZE,
+            16 // dtype_size,
+            aligned_16,
         )
 
     gather_stream.synchronize()
@@ -469,6 +576,7 @@ def gather_all_layers_to_staging(
     num_heads: int,
     page_size: int,
     gpu_id: int,
+    buffers_aligned_16: Optional[bool] = None,
 ) -> int:
     """Gather all layers' K and V head slices into a staging buffer.
 
@@ -485,6 +593,7 @@ def gather_all_layers_to_staging(
             num_heads,
             page_size,
             gpu_id,
+            buffers_aligned_16,
         )
     return _gather_all_layers_torch(
         k_buffers,
@@ -575,6 +684,7 @@ def _scatter_staging_to_kv_triton(
     decode_attn_tp_size: int,
     dst_tp_rank: int,
     total_kv_heads: int,
+    buffers_aligned_16: Optional[bool] = None,
 ) -> None:
     """Triton fused kernel path for scatter."""
     num_layers = len(k_buffers)
@@ -599,25 +709,28 @@ def _scatter_staging_to_kv_triton(
     )
     elems_per_token = num_heads * head_dim
     per_layer_elems = num_tokens * elems_per_token
+    stride_pool_token = total_heads * head_dim
+    buffers = k_buffers + v_buffers
 
     layer_ptrs = torch.tensor(
-        [buf.data_ptr() for buf in k_buffers] + [buf.data_ptr() for buf in v_buffers],
+        [buf.data_ptr() for buf in buffers],
         dtype=torch.int64,
         device=device,
     )
 
+    writer_head_offsets_host = [
+        compute_head_slice_params(
+            prefill_attn_tp_size,
+            decode_attn_tp_size,
+            wr,
+            dst_tp_rank,
+            total_kv_heads,
+        )[2]
+        * head_dim
+        for wr in range(num_writers)
+    ]
     writer_head_offsets = torch.tensor(
-        [
-            compute_head_slice_params(
-                prefill_attn_tp_size,
-                decode_attn_tp_size,
-                wr,
-                dst_tp_rank,
-                total_kv_heads,
-            )[2]
-            * head_dim
-            for wr in range(num_writers)
-        ],
+        writer_head_offsets_host,
         dtype=torch.int64,
         device=device,
     )
@@ -628,6 +741,16 @@ def _scatter_staging_to_kv_triton(
         num_tokens * elems_per_token * dtype_size * num_layers * 2 * num_writers
     )
     staging_typed = staging_buffer_view[:total_staging_bytes].view(int_dtype)
+    aligned_16 = _can_use_aligned_staging_copy(
+        buffers,
+        staging_typed,
+        stride_pool_token=stride_pool_token,
+        head_dim=head_dim,
+        head_offsets=writer_head_offsets_host,
+        elems_per_token=elems_per_token,
+        per_layer_elems=per_layer_elems,
+        buffers_aligned_16=buffers_aligned_16,
+    )
 
     BLOCK_SIZE = 1024
     num_layers_x2 = 2 * num_layers
@@ -639,12 +762,14 @@ def _scatter_staging_to_kv_triton(
         staging_typed,
         writer_head_offsets,
         num_tokens,
-        total_heads * head_dim,
+        stride_pool_token,
         per_layer_elems,
         elems_per_token,
         page_size,
         num_layers_x2,
         BLOCK_SIZE,
+        16 // dtype_size,
+        aligned_16,
     )
 
 
@@ -658,6 +783,7 @@ def scatter_staging_to_kv(
     decode_attn_tp_size: int,
     dst_tp_rank: int,
     total_kv_heads: int,
+    buffers_aligned_16: Optional[bool] = None,
 ) -> None:
     """Scatter data from a contiguous staging region into KV cache buffers."""
     if _USE_TRITON_STAGING:
@@ -671,6 +797,7 @@ def scatter_staging_to_kv(
             decode_attn_tp_size,
             dst_tp_rank,
             total_kv_heads,
+            buffers_aligned_16,
         )
     return _scatter_staging_to_kv_torch(
         staging_buffer_view,

--- a/python/sglang/srt/disaggregation/common/staging_handler.py
+++ b/python/sglang/srt/disaggregation/common/staging_handler.py
@@ -23,6 +23,8 @@ from sglang.srt.runtime_context import (
 
 logger = logging.getLogger(__name__)
 
+STAGING_COPY_BUFFERS_ALIGNED_16_KEY = "staging_copy_buffers_aligned_16"
+
 # Bounded wait for a watermark advance before re-enqueueing a deferred staging
 # chunk, so the re-enqueue retry does not busy-spin a core.
 STAGING_WATERMARK_WAIT_S = 0.001
@@ -60,6 +62,39 @@ class PrefillStagingContext:
     # to short-circuit per-room prefetch entry on every chunk after the first.
     prefetched_rooms: set = dataclasses.field(default_factory=set)
     prefetch_sockets: dict = dataclasses.field(default_factory=dict)
+
+
+def build_staging_kv_buffer_info(
+    k_buffers: list,
+    v_buffers: list,
+    page_size: int,
+    slot_layer_ids: Optional[List[int]] = None,
+) -> dict:
+    """Snapshot KV-buffer metadata and cache its stable alignment proof."""
+    from sglang.srt.disaggregation.common.staging_buffer import (
+        kv_buffers_preserve_16_byte_alignment,
+    )
+
+    k_buffers = list(k_buffers)
+    v_buffers = list(v_buffers)
+    buffers = k_buffers + v_buffers
+    buffers_aligned_16 = False
+    if buffers:
+        head_dim = buffers[0].shape[-1]
+        stride_pool_token = buffers[0].shape[1] * head_dim
+        buffers_aligned_16 = kv_buffers_preserve_16_byte_alignment(
+            buffers,
+            stride_pool_token=stride_pool_token,
+            head_dim=head_dim,
+        )
+
+    return {
+        "k_buffers": k_buffers,
+        "v_buffers": v_buffers,
+        "page_size": page_size,
+        "slot_layer_ids": list(slot_layer_ids or []),
+        STAGING_COPY_BUFFERS_ALIGNED_16_KEY: buffers_aligned_16,
+    }
 
 
 class DecodeStagingHandler:
@@ -447,6 +482,9 @@ class DecodeStagingHandler:
                 self.decode_tp,
                 dst_tp_rank,
                 self.total_kv_heads,
+                buffers_aligned_16=self.kv_buffer_info.get(
+                    STAGING_COPY_BUFFERS_ALIGNED_16_KEY
+                ),
             )
 
         return True

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -24,12 +24,14 @@ from sglang.srt.disaggregation.common.conn import (
     KVTransferError,
 )
 from sglang.srt.disaggregation.common.staging_handler import (
+    STAGING_COPY_BUFFERS_ALIGNED_16_KEY,
     STAGING_WATERMARK_WAIT_S,
     DecodeStagingContext,
     PrefillStagingContext,
     StagingManagerMixin,
     StagingRegisterInfo,
     StagingTransferInfo,
+    build_staging_kv_buffer_info,
     handle_staging_rsp,
     handle_watermark_msg,
 )
@@ -355,12 +357,12 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
     ):
         # slot_layer_ids follows the staging slot order (every k_buffer, then
         # every v_buffer), which is not kv_args.kv_layer_ids once a draft exists.
-        self.kv_buffer_tensors = {
-            "k_buffers": k_buffers,
-            "v_buffers": v_buffers,
-            "page_size": page_size,
-            "slot_layer_ids": list(slot_layer_ids or []),
-        }
+        self.kv_buffer_tensors = build_staging_kv_buffer_info(
+            k_buffers=k_buffers,
+            v_buffers=v_buffers,
+            page_size=page_size,
+            slot_layer_ids=slot_layer_ids,
+        )
 
     def _register_staging_memory(self, ptr: int, size: int) -> None:
         self.engine.batch_register([ptr], [size])
@@ -609,6 +611,9 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             num_heads_to_send,
             page_size,
             self.kv_args.gpu_id,
+            buffers_aligned_16=self.kv_buffer_tensors.get(
+                STAGING_COPY_BUFFERS_ALIGNED_16_KEY
+            ),
         )
 
         if pairs is None:

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -26,8 +26,10 @@ from sglang.srt.disaggregation.common.conn import (
     KVTransferError,
 )
 from sglang.srt.disaggregation.common.staging_handler import (
+    STAGING_COPY_BUFFERS_ALIGNED_16_KEY,
     STAGING_WATERMARK_WAIT_S,
     StagingManagerMixin,
+    build_staging_kv_buffer_info,
     handle_staging_rsp,
     handle_watermark_msg,
 )
@@ -590,16 +592,23 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 f"(ptr=0x{ptr:x}, size={size})"
             )
 
-    def set_kv_buffer_tensors(self, k_buffers: list, v_buffers: list, page_size: int):
+    def set_kv_buffer_tensors(
+        self,
+        k_buffers: list,
+        v_buffers: list,
+        page_size: int,
+        slot_layer_ids: Optional[List[int]] = None,
+    ):
         # NOTE: matches mooncake behavior -- staging buffers are now
         # created in __init__ (per-worker), independent of the kv
         # tensors. This setter only stashes the tensor metadata used by
         # send_kvcache_staged().
-        self.kv_buffer_tensors = {
-            "k_buffers": k_buffers,
-            "v_buffers": v_buffers,
-            "page_size": page_size,
-        }
+        self.kv_buffer_tensors = build_staging_kv_buffer_info(
+            k_buffers=k_buffers,
+            v_buffers=v_buffers,
+            page_size=page_size,
+            slot_layer_ids=slot_layer_ids,
+        )
 
     def register_staging_room_bootstrap(self, room, bootstrap_infos, receiver):
         self._staging_ctx.room_bootstrap[room] = bootstrap_infos
@@ -2066,6 +2075,9 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
             num_heads_to_send,
             page_size,
             self.kv_args.gpu_id,
+            buffers_aligned_16=self.kv_buffer_tensors.get(
+                STAGING_COPY_BUFFERS_ALIGNED_16_KEY
+            ),
         )
 
         dst_write_ptr = dst_staging_ptr + rank_offset

--- a/test/registered/kernel/ops/kvcache/test_disaggregation_staging_buffer.py
+++ b/test/registered/kernel/ops/kvcache/test_disaggregation_staging_buffer.py
@@ -1,0 +1,347 @@
+"""Correctness tests for disaggregation staging-buffer alignment dispatch."""
+
+import unittest
+
+import numpy as np
+import torch
+
+from sglang.srt.disaggregation.common.staging_buffer import (
+    StagingBuffer,
+    _can_use_aligned_staging_copy,
+    _gather_all_layers_triton,
+    _scatter_staging_to_kv_triton,
+    kv_buffers_preserve_16_byte_alignment,
+)
+from sglang.srt.disaggregation.common.staging_handler import (
+    STAGING_COPY_BUFFERS_ALIGNED_16_KEY,
+    build_staging_kv_buffer_info,
+)
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
+from sglang.srt.disaggregation.nixl.conn import NixlKVManager
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=15, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestDisaggregationStagingBuffer(CustomTestCase):
+    NUM_LAYERS = 2
+    PAGE_SIZE = 4
+    POOL_TOKENS = 32
+    TOTAL_HEADS = 8
+    HEAD_DIM = 128
+
+    def _buffers(self, *, storage_offset: int = 0, head_dim: int = HEAD_DIM):
+        stride_pool_token = self.TOTAL_HEADS * head_dim
+        raw = [
+            torch.empty(
+                storage_offset + self.POOL_TOKENS * stride_pool_token,
+                dtype=torch.bfloat16,
+                device="cuda",
+            )
+            for _ in range(2 * self.NUM_LAYERS)
+        ]
+        for tensor in raw:
+            tensor.random_(-100, 100)
+        buffers = [
+            torch.as_strided(
+                tensor,
+                (self.POOL_TOKENS, self.TOTAL_HEADS, head_dim),
+                (stride_pool_token, head_dim, 1),
+                storage_offset=storage_offset,
+            )
+            for tensor in raw
+        ]
+        return raw, buffers
+
+    def _alignment_gate(
+        self,
+        buffers,
+        staging,
+        *,
+        head_dim=HEAD_DIM,
+        head_offsets=None,
+        elems_per_token=None,
+        per_layer_elems=None,
+    ):
+        head_offsets = [0] if head_offsets is None else head_offsets
+        elems_per_token = 2 * head_dim if elems_per_token is None else elems_per_token
+        per_layer_elems = (
+            8 * elems_per_token if per_layer_elems is None else per_layer_elems
+        )
+        return _can_use_aligned_staging_copy(
+            buffers,
+            staging,
+            stride_pool_token=self.TOTAL_HEADS * head_dim,
+            head_dim=head_dim,
+            head_offsets=head_offsets,
+            elems_per_token=elems_per_token,
+            per_layer_elems=per_layer_elems,
+        )
+
+    def test_alignment_gate_covers_every_row_base_term(self):
+        _, buffers = self._buffers()
+        staging = torch.empty(4096, dtype=torch.int16, device="cuda")
+        self.assertTrue(self._alignment_gate(buffers, staging))
+
+        _, misaligned_buffers = self._buffers(storage_offset=1)
+        self.assertFalse(self._alignment_gate(misaligned_buffers, staging))
+        self.assertFalse(self._alignment_gate(buffers, staging[1:]))
+        self.assertFalse(
+            _can_use_aligned_staging_copy(
+                buffers,
+                staging,
+                stride_pool_token=self.TOTAL_HEADS * self.HEAD_DIM + 1,
+                head_dim=self.HEAD_DIM,
+                head_offsets=[0],
+                elems_per_token=2 * self.HEAD_DIM,
+                per_layer_elems=8 * 2 * self.HEAD_DIM,
+            )
+        )
+        self.assertFalse(self._alignment_gate(buffers, staging, head_offsets=[1]))
+        self.assertFalse(
+            self._alignment_gate(
+                buffers, staging, elems_per_token=2 * self.HEAD_DIM + 1
+            )
+        )
+        self.assertFalse(self._alignment_gate(buffers, staging, per_layer_elems=1025))
+
+        _, odd_head_buffers = self._buffers(head_dim=65)
+        self.assertFalse(self._alignment_gate(odd_head_buffers, staging, head_dim=65))
+
+    def test_prevalidated_buffer_alignment_avoids_hot_path_rescan(self):
+        _, buffers = self._buffers()
+        staging = torch.empty(4096, dtype=torch.int16, device="cuda")
+        buffers_aligned_16 = kv_buffers_preserve_16_byte_alignment(
+            buffers,
+            stride_pool_token=self.TOTAL_HEADS * self.HEAD_DIM,
+            head_dim=self.HEAD_DIM,
+        )
+        self.assertTrue(buffers_aligned_16)
+
+        # Buffer metadata is stable after pool registration. The hot path only
+        # rechecks request-dependent staging and geometry terms.
+        self.assertTrue(
+            _can_use_aligned_staging_copy(
+                [],
+                staging,
+                stride_pool_token=self.TOTAL_HEADS * self.HEAD_DIM,
+                head_dim=self.HEAD_DIM,
+                head_offsets=[0],
+                elems_per_token=2 * self.HEAD_DIM,
+                per_layer_elems=8 * 2 * self.HEAD_DIM,
+                buffers_aligned_16=buffers_aligned_16,
+            )
+        )
+        self.assertFalse(
+            _can_use_aligned_staging_copy(
+                [],
+                staging,
+                stride_pool_token=self.TOTAL_HEADS * self.HEAD_DIM,
+                head_dim=self.HEAD_DIM,
+                head_offsets=[0],
+                elems_per_token=2 * self.HEAD_DIM,
+                per_layer_elems=8 * 2 * self.HEAD_DIM,
+                buffers_aligned_16=False,
+            )
+        )
+
+    def test_manager_registration_snapshots_cached_alignment(self):
+        _, buffers = self._buffers()
+        k_buffers = buffers[: self.NUM_LAYERS]
+        v_buffers = buffers[self.NUM_LAYERS :]
+        slot_layer_ids = list(range(2 * self.NUM_LAYERS))
+
+        infos = []
+        for manager_cls in (MooncakeKVManager, NixlKVManager):
+            with self.subTest(manager=manager_cls.__name__):
+                manager = object.__new__(manager_cls)
+                manager.set_kv_buffer_tensors(
+                    k_buffers=k_buffers,
+                    v_buffers=v_buffers,
+                    page_size=self.PAGE_SIZE,
+                    slot_layer_ids=slot_layer_ids,
+                )
+                info = manager.kv_buffer_tensors
+                infos.append(info)
+                self.assertTrue(info[STAGING_COPY_BUFFERS_ALIGNED_16_KEY])
+                self.assertEqual(info["page_size"], self.PAGE_SIZE)
+                self.assertEqual(info["slot_layer_ids"], slot_layer_ids)
+                self.assertIsNot(info["k_buffers"], k_buffers)
+                self.assertIsNot(info["v_buffers"], v_buffers)
+
+        k_buffers.clear()
+        v_buffers.clear()
+        slot_layer_ids.clear()
+        for info in infos:
+            self.assertEqual(len(info["k_buffers"]), self.NUM_LAYERS)
+            self.assertEqual(len(info["v_buffers"]), self.NUM_LAYERS)
+            self.assertEqual(len(info["slot_layer_ids"]), 2 * self.NUM_LAYERS)
+
+        empty_info = build_staging_kv_buffer_info([], [], self.PAGE_SIZE)
+        self.assertFalse(empty_info[STAGING_COPY_BUFFERS_ALIGNED_16_KEY])
+
+    def test_gather_aligned_and_generic_paths_are_bit_exact(self):
+        page_indices = np.array([1, 3], dtype=np.int64)
+        token_indices = torch.tensor(
+            [4, 5, 6, 7, 12, 13, 14, 15], dtype=torch.int64, device="cuda"
+        )
+        num_heads = 2
+        src_head_start = 1
+        num_tokens = len(page_indices) * self.PAGE_SIZE
+        per_layer_elems = num_tokens * num_heads * self.HEAD_DIM
+        total_bytes = per_layer_elems * self.NUM_LAYERS * 2 * 2
+
+        for storage_offset in (0, 1):
+            with self.subTest(storage_offset=storage_offset):
+                _, buffers = self._buffers(storage_offset=storage_offset)
+                k_buffers = buffers[: self.NUM_LAYERS]
+                v_buffers = buffers[self.NUM_LAYERS :]
+                kv_buffer_info = build_staging_kv_buffer_info(
+                    k_buffers=k_buffers,
+                    v_buffers=v_buffers,
+                    page_size=self.PAGE_SIZE,
+                )
+                staging = StagingBuffer(
+                    size_bytes=total_bytes,
+                    device="cuda:0",
+                    gpu_id=0,
+                )
+                # Offset 0 must take the aligned path and offset 1 the generic one;
+                # without this the loop could silently measure one path twice.
+                self.assertEqual(
+                    self._alignment_gate(
+                        buffers,
+                        staging.buffer[:total_bytes].view(torch.int16),
+                        head_offsets=[src_head_start * self.HEAD_DIM],
+                        elems_per_token=num_heads * self.HEAD_DIM,
+                        per_layer_elems=per_layer_elems,
+                    ),
+                    storage_offset == 0,
+                )
+
+                written = _gather_all_layers_triton(
+                    k_buffers,
+                    v_buffers,
+                    page_indices,
+                    staging,
+                    src_head_start,
+                    num_heads,
+                    self.PAGE_SIZE,
+                    0,
+                    buffers_aligned_16=kv_buffer_info[
+                        STAGING_COPY_BUFFERS_ALIGNED_16_KEY
+                    ],
+                )
+
+                expected = torch.cat(
+                    [
+                        buf[
+                            token_indices,
+                            src_head_start : src_head_start + num_heads,
+                            :,
+                        ]
+                        .contiguous()
+                        .view(torch.int16)
+                        .reshape(-1)
+                        for buf in buffers
+                    ]
+                )
+                actual = staging.buffer[:written].view(torch.int16)
+                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_scatter_aligned_and_generic_paths_are_bit_exact(self):
+        page_indices = torch.tensor([1, 3], dtype=torch.int64, device="cuda")
+        token_indices = torch.tensor(
+            [4, 5, 6, 7, 12, 13, 14, 15], dtype=torch.int64, device="cuda"
+        )
+        prefill_attn_tp_size = 4
+        decode_attn_tp_size = 1
+        num_writers = 4
+        num_heads = 2
+        num_tokens = page_indices.numel() * self.PAGE_SIZE
+        per_layer_elems = num_tokens * num_heads * self.HEAD_DIM
+        total_elems = per_layer_elems * self.NUM_LAYERS * 2 * num_writers
+
+        for storage_offset in (0, 1):
+            with self.subTest(storage_offset=storage_offset):
+                raw, buffers = self._buffers(storage_offset=storage_offset)
+                k_buffers = buffers[: self.NUM_LAYERS]
+                v_buffers = buffers[self.NUM_LAYERS :]
+                kv_buffer_info = build_staging_kv_buffer_info(
+                    k_buffers=k_buffers,
+                    v_buffers=v_buffers,
+                    page_size=self.PAGE_SIZE,
+                )
+                staging = torch.randint(
+                    -32768,
+                    32767,
+                    (total_elems,),
+                    dtype=torch.int16,
+                    device="cuda",
+                ).view(torch.uint8)
+                expected = [tensor.clone() for tensor in raw]
+                expected_views = [
+                    torch.as_strided(
+                        tensor,
+                        buffer.shape,
+                        buffer.stride(),
+                        storage_offset=buffer.storage_offset(),
+                    )
+                    for tensor, buffer in zip(expected, buffers)
+                ]
+                staging_typed = staging.view(torch.int16)
+                # Offset 0 must take the aligned path and offset 1 the generic one.
+                self.assertEqual(
+                    self._alignment_gate(
+                        buffers,
+                        staging_typed,
+                        head_offsets=[
+                            w * num_heads * self.HEAD_DIM for w in range(num_writers)
+                        ],
+                        elems_per_token=num_heads * self.HEAD_DIM,
+                        per_layer_elems=per_layer_elems,
+                    ),
+                    storage_offset == 0,
+                )
+
+                for writer_id in range(num_writers):
+                    head_start = writer_id * num_heads
+                    rank_base = writer_id * per_layer_elems * 2 * self.NUM_LAYERS
+                    for layer_kv_id, expected_view in enumerate(expected_views):
+                        start = rank_base + layer_kv_id * per_layer_elems
+                        values = staging_typed[start : start + per_layer_elems]
+                        expected_view[
+                            token_indices, head_start : head_start + num_heads, :
+                        ] = values.view(torch.bfloat16).view(
+                            num_tokens, num_heads, self.HEAD_DIM
+                        )
+
+                _scatter_staging_to_kv_triton(
+                    staging,
+                    k_buffers,
+                    v_buffers,
+                    page_indices,
+                    self.PAGE_SIZE,
+                    prefill_attn_tp_size,
+                    decode_attn_tp_size,
+                    0,
+                    self.TOTAL_HEADS,
+                    buffers_aligned_16=kv_buffer_info[
+                        STAGING_COPY_BUFFERS_ALIGNED_16_KEY
+                    ],
+                )
+                torch.cuda.synchronize()
+
+                for actual, reference in zip(raw, expected):
+                    torch.testing.assert_close(
+                        actual.view(torch.int16),
+                        reference.view(torch.int16),
+                        rtol=0,
+                        atol=0,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The disaggregation staging gather and scatter kernels load KV-buffer base pointers through a device pointer table. Triton consequently loses their divisibility information and emits scalar payload accesses even when the complete row addresses are 16-byte aligned.

## Modifications

- Form source and destination row bases separately, then apply `tl.multiple_of(..., 16)` after pointer materialization.
- Validate every pointer, stride, dimension, and head-offset term before selecting the aligned specialization; retain the generic specialization as the fallback.
- Validate stable KV-buffer terms once during shared Mooncake/NIXL registration, snapshot the registered buffer lists, and only check request-dependent staging geometry on the hot path.
- Accept and preserve staging slot-layer IDs in the NIXL registration path.
- Add CUDA regression coverage for aligned and deliberately misaligned storage, registration metadata, dispatch selection, and bit-exact gather/scatter behavior.

The staging-buffer feature remains opt-in and default-off.

## Accuracy Tests

```text
TRITON_DEBUG=1 pytest focused CUDA suite
5 passed, 6 subtests passed

pytest related disaggregation suites
130 passed, 24 subtests passed

GB300 matched benchmark correctness
8/8 ranks bit-exact for gather and scatter
```

## Speed Tests and Profiling

GB300, 1 host × 4 ranks, BF16, 80 layers, 1,024 tokens, page size 1, prefill attention TP4 → decode attention TP1. Two opposite-order runs, 8 paired rank replicas total:

| Operation | Baseline mean | Candidate mean | Reduction | Paired speedup median (95% CI) |
| --- | ---: | ---: | ---: | ---: |
| Gather kernel | 51.660 µs | 49.887 µs | 3.43% | 1.036x (1.034–1.038x) |
| Scatter kernel | 166.575 µs | 120.565 µs | 27.62% | 1.381x (1.380–1.385x) |

The original per-call alignment scan cost about 127.1 µs for 160 buffers. Moving stable validation to registration reduced the request hot-path check to 1.22 µs on the local H100 host benchmark.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No public API or configuration change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

Suggested merge oncalls: `@ByronHsu`, `@cctry`, `@ShangmingCai`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34942694035](https://github.com/sgl-project/sglang/actions/runs/34942694035)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34942693571](https://github.com/sgl-project/sglang/actions/runs/34942693571)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34942693826](https://github.com/sgl-project/sglang/actions/runs/34942693826)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->