### PR TITLE
[Bug fix] gemma4_detector: handle string arguments whose opening delimiter is omitted

### DIFF
--- a/python/sglang/srt/function_call/gemma4_detector.py
+++ b/python/sglang/srt/function_call/gemma4_detector.py
@@ -70,7 +70,7 @@ def _parse_gemma4_array(arr_str: str) -> list:
     n = len(arr_str)
 
     while i < n:
-        while i < n and arr_str[i] in (" ", ",", "\n", "\t"):
+        while i < n and arr_str[i] in (" ", ",", "\n", "\t", "]"):
             i += 1
         if i >= n:
             break

--- a/python/sglang/srt/function_call/gemma4_detector.py
+++ b/python/sglang/srt/function_call/gemma4_detector.py
@@ -18,6 +18,23 @@ TOOL_CALL_END = "<tool_call|>"
 STRING_DELIM = '<|"|>'
 
 
+def _skip_string(text: str, pos: int) -> int:
+    """Return the index just past the ``STRING_DELIM`` at ``pos``.
+
+    A delimiter after ``:``, ``[``, ``,`` or ``{`` opens a string, which is skipped
+    whole (up to ``len(text)`` if unterminated). Any other delimiter closes a string
+    whose opening delimiter the model omitted, and only that delimiter is skipped.
+    """
+    j = pos - 1
+    while j >= 0 and text[j] in " \n\t":
+        j -= 1
+    end = pos + len(STRING_DELIM)
+    if j >= 0 and text[j] not in ":[,{":
+        return end
+    close = text.find(STRING_DELIM, end)
+    return len(text) if close == -1 else close + len(STRING_DELIM)
+
+
 def _parse_gemma4_value(value_str: str) -> object:
     """Parse a single Gemma4 value (after key:) into a Python object."""
     value_str = value_str.strip()
@@ -37,6 +54,10 @@ def _parse_gemma4_value(value_str: str) -> object:
         return int(value_str)
     except ValueError:
         pass
+
+    # String whose opening delimiter was omitted
+    if value_str.endswith(STRING_DELIM):
+        return value_str[: -len(STRING_DELIM)]
 
     # Bare string (no <|"|> delimiters)
     return value_str
@@ -71,9 +92,7 @@ def _parse_gemma4_array(arr_str: str) -> list:
             i += 1
             while i < n and depth > 0:
                 if arr_str[i : i + len(STRING_DELIM)] == STRING_DELIM:
-                    i += len(STRING_DELIM)
-                    next_delim = arr_str.find(STRING_DELIM, i)
-                    i = next_delim + len(STRING_DELIM) if next_delim != -1 else n
+                    i = _skip_string(arr_str, i)
                     continue
                 if arr_str[i] == "{":
                     depth += 1
@@ -161,13 +180,7 @@ def _parse_gemma4_args(args_str: str) -> dict:
             i += 1
             while i < n and depth > 0:
                 if args_str[i : i + len(STRING_DELIM)] == STRING_DELIM:
-                    # Skip over string contents
-                    i += len(STRING_DELIM)
-                    next_delim = args_str.find(STRING_DELIM, i)
-                    if next_delim == -1:
-                        i = n
-                    else:
-                        i = next_delim + len(STRING_DELIM)
+                    i = _skip_string(args_str, i)
                     continue
                 if args_str[i] == "{":
                     depth += 1
@@ -183,12 +196,7 @@ def _parse_gemma4_args(args_str: str) -> dict:
             i += 1
             while i < n and depth > 0:
                 if args_str[i : i + len(STRING_DELIM)] == STRING_DELIM:
-                    i += len(STRING_DELIM)
-                    next_delim = args_str.find(STRING_DELIM, i)
-                    if next_delim == -1:
-                        i = n
-                    else:
-                        i = next_delim + len(STRING_DELIM)
+                    i = _skip_string(args_str, i)
                     continue
                 if args_str[i] == "[":
                     depth += 1
@@ -198,9 +206,15 @@ def _parse_gemma4_args(args_str: str) -> dict:
             arr_content = args_str[arr_start : i - 1]
             result[key] = _parse_gemma4_array(arr_content)
 
-        # Bare value (number, boolean, etc.)
+        # Bare value (number, boolean, etc.), or a string whose opening
+        # delimiter was omitted: city:Paris, France<|"|>
         else:
             val_start = i
+            close = args_str.find(STRING_DELIM, i)
+            if close != -1 and not any(c in args_str[i:close] for c in ":{[]}"):
+                result[key] = args_str[i:close].strip()
+                i = close + len(STRING_DELIM)
+                continue
             while i < n and args_str[i] not in (",", "}", "]"):
                 i += 1
             result[key] = _parse_gemma4_value(args_str[val_start:i])
@@ -220,11 +234,7 @@ def _find_matching_brace(text: str) -> int:
     delim_len = len(STRING_DELIM)
     while i < n and depth > 0:
         if text[i : i + delim_len] == STRING_DELIM:
-            i += delim_len
-            next_delim = text.find(STRING_DELIM, i)
-            if next_delim == -1:
-                return -1
-            i = next_delim + delim_len
+            i = _skip_string(text, i)
             continue
         if text[i] == "{":
             depth += 1

--- a/test/registered/unit/function_call/test_gemma4_detector_string_delimiters.py
+++ b/test/registered/unit/function_call/test_gemma4_detector_string_delimiters.py
@@ -1,0 +1,133 @@
+"""Unit tests for Gemma4Detector string arguments — no server, no model loading.
+
+Gemma 4 wraps string arguments in ``<|"|>``, but sometimes omits the opening
+delimiter and still emits the closing one, e.g. ``query:weather in Tokyo<|"|>``.
+"""
+
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.gemma4_detector import Gemma4Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+Q = '<|"|>'
+
+
+class TestGemma4StringDelimiters(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="web_search",
+                    description="Search the web",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                            "limit": {"type": "integer"},
+                        },
+                        "required": ["query"],
+                    },
+                ),
+            )
+        ]
+
+    def _parse(self, args: str) -> dict:
+        text = f"<|tool_call>call:web_search{{{args}}}<tool_call|>"
+        result = Gemma4Detector().detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "web_search")
+        return json.loads(result.calls[0].parameters)
+
+    def _stream(self, chunks: list) -> tuple:
+        detector, name, params = Gemma4Detector(), None, ""
+        for chunk in chunks:
+            for call in detector.parse_streaming_increment(chunk, self.tools).calls:
+                name = call.name or name
+                params += call.parameters or ""
+        return name, json.loads(params) if params else None
+
+    def test_well_formed_string(self):
+        self.assertEqual(
+            self._parse(f"query:{Q}weather in Tokyo{Q}"), {"query": "weather in Tokyo"}
+        )
+
+    def test_omitted_opening_delimiter(self):
+        self.assertEqual(
+            self._parse(f"query:weather in Tokyo{Q}"), {"query": "weather in Tokyo"}
+        )
+
+    def test_omitted_opening_delimiter_with_comma(self):
+        self.assertEqual(
+            self._parse(f"query:Paris, France{Q},limit:5"),
+            {"query": "Paris, France", "limit": 5},
+        )
+
+    def test_omitted_opening_delimiter_in_nested_object(self):
+        self.assertEqual(
+            self._parse(f"filters:{{city:Tokyo{Q}}},query:{Q}x{Q}"),
+            {"filters": {"city": "Tokyo"}, "query": "x"},
+        )
+
+    def test_omitted_opening_delimiter_in_array(self):
+        self.assertEqual(self._parse(f"query:[{Q}a{Q},b{Q}]"), {"query": ["a", "b"]})
+
+    def test_other_values_unchanged(self):
+        self.assertEqual(
+            self._parse(f"limit:5,exact:true,query:{Q}Note: a, b{Q}"),
+            {"limit": 5, "exact": True, "query": "Note: a, b"},
+        )
+
+    def test_streaming_omitted_opening_delimiter(self):
+        chunks = [
+            "<|tool_call>",
+            "call",
+            ":",
+            "web",
+            "_",
+            "search",
+            "{",
+            "query",
+            ":",
+            "weather",
+            " in",
+            " Tokyo",
+            Q,
+            "}",
+            "<tool_call|>",
+        ]
+        self.assertEqual(
+            self._stream(chunks), ("web_search", {"query": "weather in Tokyo"})
+        )
+
+    def test_streaming_well_formed(self):
+        chunks = [
+            "<|tool_call>",
+            "call",
+            ":",
+            "web",
+            "_",
+            "search",
+            "{",
+            "query",
+            ":",
+            Q,
+            "weather",
+            " in",
+            " Tokyo",
+            Q,
+            "}",
+            "<tool_call|>",
+        ]
+        self.assertEqual(
+            self._stream(chunks), ("web_search", {"query": "weather in Tokyo"})
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/function_call/test_gemma4_detector_string_delimiters.py
+++ b/test/registered/unit/function_call/test_gemma4_detector_string_delimiters.py
@@ -83,6 +83,11 @@ class TestGemma4StringDelimiters(CustomTestCase):
             {"limit": 5, "exact": True, "query": "Note: a, b"},
         )
 
+    def test_malformed_array_terminates(self):
+        text = f"<|tool_call>call:web_search{{query:[ k:{Q}1]]}}<tool_call|>"
+        result = Gemma4Detector().detect_and_parse(text, self.tools)
+        self.assertEqual([call.name for call in result.calls], ["web_search"])
+
     def test_streaming_omitted_opening_delimiter(self):
         chunks = [
             "<|tool_call>",


### PR DESCRIPTION
## Motivation

Gemma 4 wraps string tool-call arguments in `<|"|>...<|"|>`, but it sometimes omits the opening delimiter and still emits the closing one:

```
<|tool_call>call:web_search{query:weather in Tokyo<|"|>}<tool_call|>
```

This is the model, not the server: on `google/gemma-4-26B-A4B-it`, the HF reference implementation (bf16) puts only p≈0.48 on the opening `<|"|>` at that position. With the model's default sampling (temperature 1.0, top_p 0.95, top_k 64) it shows up on a sizeable share of calls; against a server running `--tool-call-parser gemma4` we saw it on 6/20 calls at temperature 0.8, 4/20 at 0.5 and 3/20 at 0.3.

`Gemma4Detector` reads that lone closing delimiter as the start of a string that never ends:

- **Streaming** (`parse_streaming_increment`): `_find_matching_brace` never finds the closing brace, so the call is emitted with its name and **empty arguments**.
- **Non-streaming** (`detect_and_parse`): the delimiter stays in the value (`{"query": "weather in Tokyo<|\"|>"}`), and a value containing a comma is split into bogus keys (`query:Paris, France<|"|>,limit:5` → `{"query": "Paris", "France<|\"|>,limit": 5}`).
- **Hang:** when an array scan ends unbalanced, `_parse_gemma4_array` can be handed a stray `]`. Its bare-value branch stops on `]` without consuming it, so the loop never advances and keeps appending empty values. An omitted delimiter in the last element of a string array is enough (`query:[<|"|>a<|"|>,b<|"|>]`). Fuzzing both entry points with 8,000 random malformed calls found 6 that never return.

## Modifications

- `_skip_string(text, pos)`: a `<|"|>` that follows `:`, `[`, `,` or `{` opens a string and is skipped whole, as before; any other one closes a string whose opening delimiter was omitted, and only that delimiter is skipped. `_find_matching_brace` and the nested object/array scans use it.
- `_parse_gemma4_args`: a bare value that reaches a `<|"|>` before any `:`, `{`, `[`, `]` or `}` is a string that runs to that delimiter, commas included.
- `_parse_gemma4_value`: drops a trailing stray delimiter (array elements).
- `_parse_gemma4_array`: skips a stray `]` like the other separators, so the loop always advances.

Well-formed calls parse exactly as before.

Tests: `test/registered/unit/function_call/test_gemma4_detector_string_delimiters.py`, through `detect_and_parse` and `parse_streaming_increment` only. It is a separate file so it does not conflict with #37305, which adds broader `gemma4_detector` tests. All 9 pass with this change. Against the current detector, 4 return wrong or missing arguments and the array case never returns. The same fuzz on this change: 0 hangs and 0 exceptions in 20,000 parses.

## Accuracy Tests

Parsing only; no model forward changes. End to end on a Gemma 4 26B-A4B server with `--tool-call-parser gemma4`: before, a streamed call whose opening delimiter was omitted arrived with empty arguments; after, 60/60 calls at temperature 0.3–0.5 (unary and streamed) carried intact arguments.

## Speed Tests and Profiling

N/A: string parsing of the tool-call block only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit) (all hooks pass).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations) (N/A).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed) (N/A: parser-only change).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34725030981](https://github.com/sgl-project/sglang/actions/runs/34725030981)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34725030927](https://github.com/sgl-project/sglang/actions/runs/34725030927)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34725031037](https://github.com/sgl-project/sglang/actions/runs/34725031037)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->