### PR TITLE
Fix DeepGEMM release MegaMoE validation without RDMA

### DIFF
--- a/.github/workflows/release-whl-deepgemm.yml
+++ b/.github/workflows/release-whl-deepgemm.yml
@@ -204,6 +204,9 @@ jobs:
           echo "COMPUTE_SANITIZER=${sanitizer}" >> "${GITHUB_ENV}"
 
       - name: Run DeepGEMM test suite
+        env:
+          # Each runner is a single NVLink domain; DeepEP references do not need RDMA/GIN.
+          EP_DISABLE_GIN: "1"
         run: |
           chmod +x "${{ github.workspace }}/DeepGEMM/sgl_deep_gemm/run_tests.sh"
           "${{ github.workspace }}/DeepGEMM/sgl_deep_gemm/run_tests.sh" --release


### PR DESCRIPTION
The [DeepGEMM release B200 job](https://github.com/sgl-project/sglang/actions/runs/34726899652/job/103643335128) fails three MegaMoE invocations when DeepEP requests NCCL GIN on a runner without usable RDMA. Each release test runner uses one NVLink domain, so its reference dispatch/combine only needs intra-node communication.

Set DeepEP's supported `EP_DISABLE_GIN=1` only on the GPU test step. This lets the existing reference comparisons and graph checks run through the NVLink path. No kernels, assertions, test counts, or dependency versions change.

Validated on `baizhou-dev-b200` using the exact wheel artifact from the failing run and DeepGEMM `1ff3932f0f9d9187b92afb476da4e3ade10a6575`:

- Without the setting: the BF16 case reproduces the same GIN initialization failure in 10 seconds.
- With the setting: 2-rank BF16 correctness plus 24 changing-input graph replays passes in 13 seconds.
- 4-rank default MegaMoE passes in 38 seconds; 4-rank MegaMoE-SGL passes in 17 seconds, including their original reference comparisons and benchmarks.
- Workflow pre-commit, actionlint syntax/expression checks, and diff checks pass.

The devbox has four B200 GPUs; the 8-GPU B200 and GB300 CI jobs have not been rerun with this fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34728783607](https://github.com/sgl-project/sglang/actions/runs/34728783607)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34728783410](https://github.com/sgl-project/sglang/actions/runs/34728783410)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->