### PR TITLE
[CI] Use chat evaluation for SWA decode radix cache

### DIFF
--- a/test/registered/disaggregation/test_disaggregation_decode_radix_cache.py
+++ b/test/registered/disaggregation/test_disaggregation_decode_radix_cache.py
@@ -50,6 +50,7 @@ class DisaggregationDecodeRadixCacheTestMixin:
     transfer_backend_name = None
     model_name = DEFAULT_MODEL_NAME_FOR_TEST
     gsm8k_min_score = 0.80
+    gsm8k_eval_args = {"api": "completion", "max_tokens": 512}
 
     @classmethod
     def setUpClass(cls):
@@ -106,11 +107,10 @@ class DisaggregationDecodeRadixCacheTestMixin:
             base_url=self.base_url,
             model=self.model,
             eval_name="gsm8k",
-            api="completion",
-            max_tokens=512,
             num_examples=500,
             num_threads=100,
             num_shots=6,
+            **self.gsm8k_eval_args,
         )
 
         metrics_first = run_eval(args)

--- a/test/registered/disaggregation/test_disaggregation_decode_radix_cache_swa.py
+++ b/test/registered/disaggregation/test_disaggregation_decode_radix_cache_swa.py
@@ -32,11 +32,13 @@ class TestDisaggregationDecodeRadixCacheSWANixl(
 ):
     transfer_backend_name = "nixl"
     model_name = DEFAULT_MODEL_NAME_FOR_TEST_MXFP4_WITH_MOE
-    # The 512-token eval cap truncates mxfp4 gpt-oss reasoning. On the fixed
-    # 500-question H200 sample, the score has a roughly 2-point standard error,
-    # so keep the original 0.45 absolute floor and rely on the two-pass
-    # non-regression check below to catch decode-cache corruption.
     gsm8k_min_score = 0.45
+    # GPT-OSS needs chat formatting to avoid repetitive raw completions.
+    gsm8k_eval_args = {
+        "api": "chat",
+        "reasoning_effort": "low",
+        "max_tokens": 2048,
+    }
     # SWA + decode-side radix cache is gated to the unified radix tree.
     extra_prefill_env = {"SGLANG_ENABLE_UNIFIED_RADIX_TREE": "1"}
     extra_decode_env = {"SGLANG_ENABLE_UNIFIED_RADIX_TREE": "1"}


### PR DESCRIPTION
Use chat evaluation with low reasoning effort and a 2,048-token budget for the SWA decode-radix GSM8K test. Raw GPT-OSS completions were repetitive and truncated roughly 75% of outputs during investigation of [this CI failure](https://github.com/sgl-project/sglang/actions/runs/34656929618/job/103451489174).

Two-file change: allow per-class eval settings and override them for SWA. Other tests retain their defaults; the 0.45 score floor and 3-point drop limit are unchanged.

Validation:

- Modified test: **2/2 passed** on two H100s, GSM8K **93.4% → 91.8%**, no retry.
- Ruff, isort, codespell, Python compilation, and CI registration checks passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34811350715](https://github.com/sgl-project/sglang/actions/runs/34811350715)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34811350443](https://github.com/sgl-project/sglang/actions/runs/34811350443)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34811350823](https://github.com/sgl-project/sglang/actions/runs/34811350823)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->