### PR TITLE
[AMD] Add guarded gfx942 GLM shared-expert fusion opt-in

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -833,6 +833,7 @@ class Envs:
     # AMD, ROCm, and AITER
     # ===================================================================
     SGLANG_USE_AITER = EnvBool(False)
+    SGLANG_ROCM_GLM_SHARED_EXPERTS_FUSION = EnvBool(False)
     SGLANG_USE_AITER_AG = EnvBool(True)
     # Use reduce_scatter (instead of all_reduce + dp_scatter) for the equal-chunk
     # MAX_LEN DP-MoE combine. Default ON for ROCm/HIP (uses the aiter custom

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -1235,6 +1235,7 @@ class Glm5NextForConditionalGeneration(nn.Module):
                 quant_config.get_name() != "fp8"
                 or getattr(quant_config, "weight_block_size", None) != [128, 128]
                 or getattr(quant_config, "use_mxfp8", False)
+                or getattr(quant_config, "is_fp4_experts", False)
             ):
                 return "The gfx942 path supports BF16 or 128x128 block FP8 only."
             if quant_config is not None and any(

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -49,6 +49,7 @@ from sglang.srt.layers.moe.utils import (
     is_shared_experts_fusion_disabled,
 )
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.utils import is_layer_skipped
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.layers.rotary_embedding import get_rope
 from sglang.srt.layers.utils.common import PPMissingLayer
@@ -81,6 +82,7 @@ from sglang.srt.models.deepseek_common.deepseek_weight_loader import (
 from sglang.srt.models.deepseek_common.utils import (
     _device_sm,
     _is_cuda,
+    _use_aiter,
     _use_aiter_gfx95,
 )
 from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
@@ -105,6 +107,7 @@ from sglang.srt.utils.common import (
     BumpAllocator,
     LazyValue,
     add_prefix,
+    is_gfx942_supported,
     log_info_on_rank0,
     make_layers,
     set_weight_attrs,
@@ -1220,7 +1223,35 @@ class Glm5NextForConditionalGeneration(nn.Module):
                         "experts are quantized."
                     )
         if not _is_cuda:
-            return "Shared experts fusion currently requires CUDA devices."
+            if not (
+                _use_aiter
+                and is_gfx942_supported()
+                and envs.SGLANG_ROCM_GLM_SHARED_EXPERTS_FUSION.get()
+            ):
+                return "Shared experts fusion requires CUDA or opted-in gfx942 AITER."
+            if text_config.n_shared_experts != 1:
+                return "The gfx942 path supports exactly one fused shared expert."
+            if quant_config is not None and (
+                quant_config.get_name() != "fp8"
+                or getattr(quant_config, "weight_block_size", None) != [128, 128]
+                or getattr(quant_config, "use_mxfp8", False)
+            ):
+                return "The gfx942 path supports BF16 or 128x128 block FP8 only."
+            if quant_config is not None and any(
+                is_layer_skipped(
+                    f"model.layers.{i}.mlp.{part}",
+                    quant_config.ignored_layers,
+                    fused_mapping=quant_config.packed_modules_mapping,
+                )
+                for i in range(
+                    getattr(text_config, "first_k_dense_replace", 0),
+                    text_config.num_hidden_layers,
+                )
+                for part in ("shared_experts", "experts")
+            ):
+                return (
+                    "The gfx942 FP8 path does not fuse quantization-excluded experts."
+                )
         if _device_sm is not None and _device_sm < 80:
             return "Shared experts fusion requires SM80 or newer GPUs."
         if get_parallel().moe_ep_size > 1:

--- a/test/manual/check_glm_shared_experts_runner_gpu.py
+++ b/test/manual/check_glm_shared_experts_runner_gpu.py
@@ -1,0 +1,139 @@
+"""Current SGLang AITER routed+shared math; not loader/endpoint qualification."""
+
+import json
+import os
+
+import torch
+
+os.environ["SGLANG_USE_AITER_MOE_GU_ITLV"] = "0"
+from sglang.srt.runtime_context import publish
+from sglang.srt.server_args import ServerArgs
+
+publish(ServerArgs(model_path="dummy", device="cuda"), role="test")
+from aiter.ops.shuffle import shuffle_weight
+
+from sglang.srt.layers.moe.moe_runner.aiter import (
+    AiterMoeQuantInfo,
+    AiterQuantType,
+    AiterRunnerCore,
+    AiterRunnerInput,
+)
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+
+
+def quantize(w):
+    e, n, k = w.shape
+    blocks = w.float().reshape(e, n // 128, 128, k // 128, 128)
+    scale = blocks.abs().amax((2, 4)).clamp_min(1e-8) / 448
+    q = (
+        (blocks / scale[:, :, None, :, None])
+        .clamp(-448, 448)
+        .to(torch.float8_e4m3fn)
+        .reshape_as(w)
+    )
+    dequant = (q.float().reshape_as(blocks) * scale[:, :, None, :, None]).reshape_as(w)
+    return q, scale.contiguous(), dequant
+
+
+def oracle(x, w1, w2, ids, scores, limit):
+    out = torch.zeros_like(x, dtype=torch.float32)
+    for e in range(w1.shape[0]):
+        gu = x.float() @ w1[e].float().T
+        gate, up = gu.chunk(2, -1)
+        if limit:
+            gate, up = gate.clamp(max=limit), up.clamp(-limit, limit)
+        yy = (torch.nn.functional.silu(gate) * up) @ w2[e].float().T
+        weight = ((ids == e) * scores).sum(-1, keepdim=True)
+        out += yy * weight
+    return out
+
+
+torch.manual_seed(20260913)
+with torch.inference_mode():
+    e, hidden, inter = 9, 512, 256
+    originals = [
+        torch.randn(shape, device="cuda", dtype=torch.bfloat16) * 0.05
+        for shape in ((e, 2 * inter, hidden), (e, hidden, inter))
+    ]
+    for precision in ("bf16", "fp8"):
+        if precision == "fp8":
+            w1, s1, ref1 = quantize(originals[0])
+            w2, s2, ref2 = quantize(originals[1])
+            quant_type = AiterQuantType.PER_128X128
+        else:
+            w1, w2 = originals
+            ref1, ref2, s1, s2 = w1, w2, None, None
+            quant_type = AiterQuantType.NONE
+        packed1, packed2 = shuffle_weight(w1, (16, 16)), shuffle_weight(w2, (16, 16))
+        packed1.is_shuffled = packed2.is_shuffled = True
+        for n in (1, 8, 16, 65):
+            for limit in (0.0, 10.0):
+                x = torch.randn(n, hidden, device="cuda", dtype=torch.bfloat16)
+                if limit:
+                    x *= 12
+                ids = torch.stack(
+                    (
+                        torch.arange(n, device="cuda") % 8,
+                        (torch.arange(n, device="cuda") + 3) % 8,
+                        torch.full((n,), 8, device="cuda"),
+                    ),
+                    -1,
+                ).int()
+                scores = (
+                    torch.tensor([0.4, 0.6, 1.0], device="cuda", dtype=torch.float32)
+                    .expand(n, -1)
+                    .contiguous()
+                )
+                core = AiterRunnerCore(
+                    MoeRunnerConfig(
+                        activation="silu",
+                        top_k=3,
+                        num_experts=e,
+                        hidden_size=hidden,
+                        intermediate_size_per_partition=inter,
+                        num_fused_shared_experts=1,
+                    )
+                )
+                info = AiterMoeQuantInfo(
+                    packed1,
+                    packed2,
+                    quant_type=quant_type,
+                    w13_scale=s1,
+                    w2_scale=s2,
+                    swiglu_limit=limit,
+                )
+                inputs = AiterRunnerInput(x, ids, scores, quant_type)
+                actual = core.run(inputs, info, {}).hidden_states
+                gold = oracle(x, ref1, ref2, ids, scores, limit)
+                err = (
+                    (actual.float() - gold).square().mean().sqrt()
+                    / gold.square().mean().sqrt().clamp_min(1e-8)
+                ).item()
+                print(
+                    json.dumps(
+                        {
+                            "precision": precision,
+                            "tokens": n,
+                            "clamp": limit,
+                            "nrmse": err,
+                        }
+                    ),
+                    flush=True,
+                )
+                assert torch.isfinite(actual).all()
+                assert err < (0.06 if precision == "fp8" else 0.02), err
+                if n in (8, 16):
+                    stream = torch.cuda.Stream()
+                    stream.wait_stream(torch.cuda.current_stream())
+                    with torch.cuda.stream(stream):
+                        for _ in range(3):
+                            core.run(inputs, info, {})
+                    torch.cuda.current_stream().wait_stream(stream)
+                    graph = torch.cuda.CUDAGraph()
+                    with torch.cuda.graph(graph):
+                        captured = core.run(inputs, info, {}).hidden_states
+                    for _ in range(5):
+                        graph.replay()
+                    torch.cuda.synchronize()
+                    torch.testing.assert_close(actual, captured, atol=0.02, rtol=0.02)
+print("SHARED_MOE_RUNNER_PASS_NO_CHECKPOINT_OR_ENDPOINT", flush=True)

--- a/test/manual/diagnose_glm_shared_clamp_gpu.py
+++ b/test/manual/diagnose_glm_shared_clamp_gpu.py
@@ -1,0 +1,226 @@
+"""Diagnose clamp dispatch against independent clamped/unclamped MoE math."""
+
+import hashlib
+import importlib
+import inspect
+import json
+import os
+from pathlib import Path
+
+import torch
+
+os.environ["SGLANG_USE_AITER_MOE_GU_ITLV"] = "0"
+from sglang.srt.runtime_context import publish
+from sglang.srt.server_args import ServerArgs
+
+publish(ServerArgs(model_path="dummy", device="cuda"), role="test")
+import aiter
+from aiter.ops.shuffle import shuffle_weight
+
+from sglang.srt.layers.moe.moe_runner.aiter import (
+    AiterMoeQuantInfo,
+    AiterQuantType,
+    AiterRunnerCore,
+    AiterRunnerInput,
+)
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+
+
+def emit(value):
+    print(json.dumps(value), flush=True)
+
+
+def quantize(w):
+    e, n, k = w.shape
+    blocks = w.float().reshape(e, n // 128, 128, k // 128, 128)
+    maximum = torch.finfo(aiter.dtypes.fp8).max
+    scale = blocks.abs().amax((2, 4)).clamp_min(1e-8) / maximum
+    q = (blocks / scale[:, :, None, :, None]).clamp(-maximum, maximum)
+    q = q.to(aiter.dtypes.fp8).reshape_as(w)
+    ref = (q.float().reshape_as(blocks) * scale[:, :, None, :, None]).reshape_as(w)
+    return q, scale.contiguous(), ref
+
+
+def oracle(x, w1, w2, ids, weights, clamp):
+    result = torch.zeros_like(x, dtype=torch.float32)
+    for expert in range(w1.shape[0]):
+        gate, up = (x.float() @ w1[expert].float().T).chunk(2, -1)
+        if clamp:
+            gate, up = gate.clamp(max=clamp), up.clamp(-clamp, clamp)
+        y = (torch.nn.functional.silu(gate) * up) @ w2[expert].float().T
+        result += y * ((ids == expert) * weights).sum(-1, keepdim=True)
+    return result
+
+
+def error(actual, gold):
+    return (
+        (actual.float() - gold).square().mean().sqrt()
+        / gold.square().mean().sqrt().clamp_min(1e-8)
+    ).item()
+
+
+module = importlib.import_module("aiter.fused_moe")
+emit(
+    {
+        "kind": "source",
+        "path": module.__file__,
+        "sha256": hashlib.sha256(Path(module.__file__).read_bytes()).hexdigest(),
+        "fp8_dtype": str(aiter.dtypes.fp8),
+        "torch": torch.__version__,
+        "hip": torch.version.hip,
+        "ck_stage1_signature": str(inspect.signature(module.ck_moe_stage1)),
+    }
+)
+original_metadata = module.get_2stage_cfgs
+
+
+def report_metadata(*args, **kwargs):
+    value = original_metadata(*args, **kwargs)
+    emit({"kind": "dispatch", "metadata": str(value)})
+    return value
+
+
+module.get_2stage_cfgs = report_metadata
+torch.manual_seed(20260913)
+rows = []
+with torch.inference_mode():
+    experts, hidden, inter = 9, 512, 256
+    original = [
+        torch.randn(shape, device="cuda", dtype=torch.bfloat16) * 0.05
+        for shape in ((experts, inter * 2, hidden), (experts, hidden, inter))
+    ]
+    for precision in ("bf16", "native_fp8"):
+        if precision == "bf16":
+            w1, w2 = original
+            ref1, ref2, s1, s2 = w1, w2, None, None
+            quant_type = AiterQuantType.NONE
+        else:
+            w1, s1, ref1 = quantize(original[0])
+            w2, s2, ref2 = quantize(original[1])
+            quant_type = AiterQuantType.PER_128X128
+        p1, p2 = shuffle_weight(w1, (16, 16)), shuffle_weight(w2, (16, 16))
+        p1.is_shuffled = p2.is_shuffled = True
+        for n in (1, 8, 16):
+            ids = torch.stack(
+                (
+                    torch.arange(n, device="cuda") % 8,
+                    (torch.arange(n, device="cuda") + 3) % 8,
+                    torch.full((n,), 8, device="cuda"),
+                ),
+                -1,
+            ).int()
+            weights = (
+                torch.tensor([0.4, 0.6, 1.0], device="cuda").expand(n, -1).contiguous()
+            )
+            for clamp in (0.0, 10.0):
+                x = torch.randn(n, hidden, device="cuda", dtype=torch.bfloat16)
+                if clamp:
+                    x *= 12
+                gold = oracle(x, ref1, ref2, ids, weights, clamp)
+                unclamped = oracle(x, ref1, ref2, ids, weights, 0)
+                config = MoeRunnerConfig(
+                    activation="silu",
+                    top_k=3,
+                    num_experts=experts,
+                    num_local_experts=experts,
+                    hidden_size=hidden,
+                    intermediate_size_per_partition=inter,
+                    num_fused_shared_experts=1,
+                    swiglu_limit=clamp or None,
+                    gate_up_interleaved=False,
+                )
+                for backend in os.environ.get("CLAMP_BACKENDS", "aiter").split(","):
+                    assert backend in ("aiter", "triton")
+                    if backend == "aiter":
+                        core = AiterRunnerCore(config)
+                        info = AiterMoeQuantInfo(
+                            p1,
+                            p2,
+                            quant_type=quant_type,
+                            w13_scale=s1,
+                            w2_scale=s2,
+                            swiglu_limit=clamp,
+                        )
+
+                        def run():
+                            return core.run(
+                                AiterRunnerInput(x, ids, weights, quant_type), info, {}
+                            ).hidden_states
+
+                    else:
+                        from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import (
+                            fused_experts,
+                        )
+
+                        def run():
+                            return fused_experts(
+                                x.clone(),
+                                w1,
+                                w2,
+                                (weights, ids, None),
+                                config,
+                                use_fp8_w8a8=precision != "bf16",
+                                w1_scale=s1,
+                                w2_scale=s2,
+                                block_shape=[128, 128] if precision != "bf16" else None,
+                            )
+
+                    try:
+                        actual = run()
+                        torch.cuda.synchronize()
+                        finite = bool(torch.isfinite(actual).all())
+                        err = error(actual, gold)
+                        passed = finite and err < (
+                            0.06 if precision != "bf16" else 0.02
+                        )
+                        row = dict(
+                            backend=backend,
+                            precision=precision,
+                            n=n,
+                            clamp=clamp,
+                            nrmse=err,
+                            unclamped_nrmse=error(actual, unclamped),
+                            passed=passed,
+                        )
+                        if passed and n == 8:
+                            stream = torch.cuda.Stream()
+                            stream.wait_stream(torch.cuda.current_stream())
+                            with torch.cuda.stream(stream):
+                                for _ in range(3):
+                                    run()
+                            torch.cuda.current_stream().wait_stream(stream)
+                            graph = torch.cuda.CUDAGraph()
+                            with torch.cuda.graph(graph):
+                                captured = run()
+                            for _ in range(5):
+                                graph.replay()
+                            torch.cuda.synchronize()
+                            row["graph_nrmse"] = error(captured, gold)
+                            row["graph_passed"] = row["graph_nrmse"] < (
+                                0.06 if precision != "bf16" else 0.02
+                            )
+                    except (
+                        ImportError,
+                        AttributeError,
+                        NotImplementedError,
+                        AssertionError,
+                    ) as exc:
+                        row = dict(
+                            backend=backend,
+                            precision=precision,
+                            n=n,
+                            clamp=clamp,
+                            passed=False,
+                            error=repr(exc),
+                        )
+                    # Runtime GPU faults are intentionally not swallowed.
+                    rows.append(row)
+                    emit(row)
+emit(
+    {
+        "kind": "summary",
+        "cases": len(rows),
+        "passed": sum(r.get("passed", False) for r in rows),
+        "scope": "primitive diagnosis only, not shared-expert loader or serving qualification",
+    }
+)

--- a/test/manual/test_glm_gfx942_shared_experts.py
+++ b/test/manual/test_glm_gfx942_shared_experts.py
@@ -71,13 +71,14 @@ def gate(
     )
 
 
-def fp8(ignored=(), block=(128, 128), name="fp8", mxfp8=False):
+def fp8(ignored=(), block=(128, 128), name="fp8", mxfp8=False, fp4_experts=False):
     return SimpleNamespace(
         get_name=lambda: name,
         weight_block_size=list(block),
         ignored_layers=list(ignored),
         packed_modules_mapping={},
         use_mxfp8=mxfp8,
+        is_fp4_experts=fp4_experts,
     )
 
 
@@ -107,6 +108,7 @@ def test_supported_paths(kwargs):
         {"deepep": True},
         {"quant": fp8(name="awq")},
         {"quant": fp8(block=(1, 32), mxfp8=True)},
+        {"quant": fp8(fp4_experts=True)},
         {"quant": fp8(["model.layers.1.mlp.shared_experts"])},
         {"quant": fp8(["model.layers.1.mlp.shared_experts.gate_proj"])},
         {"quant": fp8(["model.layers.1.mlp.experts.0.gate_proj"])},

--- a/test/manual/test_glm_gfx942_shared_experts.py
+++ b/test/manual/test_glm_gfx942_shared_experts.py
@@ -1,0 +1,134 @@
+"""CPU gate tests. GPU MoE/loader/endpoint qualification is separate."""
+
+import ast
+import copy
+from pathlib import Path
+from types import MappingProxyType, SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+MODEL = ROOT / "python/sglang/srt/models/glm5_next.py"
+UTILS = ROOT / "python/sglang/srt/layers/quantization/utils.py"
+
+
+def extract(path, name, namespace):
+    functions = [
+        n
+        for n in ast.walk(ast.parse(path.read_text()))
+        if isinstance(n, ast.FunctionDef) and n.name == name
+    ]
+    assert len(functions) == 1
+    node = copy.deepcopy(functions[0])
+    node.decorator_list = []
+    module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__", names=[ast.alias(name="annotations")], level=0
+            ),
+            node,
+        ],
+        type_ignores=[],
+    )
+    exec(compile(ast.fix_missing_locations(module), str(path), "exec"), namespace)
+    return namespace[name]
+
+
+def gate(
+    cuda=False,
+    aiter=True,
+    gfx942=True,
+    enabled=True,
+    shared=1,
+    ep=1,
+    deepep=False,
+    sm=None,
+    quant=None,
+    wrapped=False,
+):
+    ns = dict(
+        _is_cuda=cuda,
+        _use_aiter=aiter,
+        _device_sm=sm,
+        is_gfx942_supported=lambda: gfx942,
+        envs=SimpleNamespace(
+            SGLANG_ROCM_GLM_SHARED_EXPERTS_FUSION=SimpleNamespace(get=lambda: enabled)
+        ),
+        get_parallel=lambda: SimpleNamespace(moe_ep_size=ep),
+        get_moe_a2a_backend=lambda: SimpleNamespace(is_deepep=lambda: deepep),
+        MappingProxyType=MappingProxyType,
+        _FALLBACK_FUSED_SHARDS={},
+    )
+    extract(UTILS, "_module_path_match", ns)
+    extract(UTILS, "is_layer_skipped", ns)
+    config = SimpleNamespace(
+        n_shared_experts=shared, num_hidden_layers=3, first_k_dense_replace=1
+    )
+    if wrapped:
+        config = SimpleNamespace(text_config=config)
+    return extract(MODEL, "shared_experts_fusion_disable_reason", ns)(
+        None, config, quant
+    )
+
+
+def fp8(ignored=(), block=(128, 128), name="fp8", mxfp8=False):
+    return SimpleNamespace(
+        get_name=lambda: name,
+        weight_block_size=list(block),
+        ignored_layers=list(ignored),
+        packed_modules_mapping={},
+        use_mxfp8=mxfp8,
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"quant": fp8()},
+        {"wrapped": True},
+        {"quant": fp8(["model.layers.1.mlp.gate"])},
+        {"cuda": True, "enabled": False, "aiter": False, "gfx942": False, "sm": 90},
+    ],
+)
+def test_supported_paths(kwargs):
+    assert gate(**kwargs) is None
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"aiter": False},
+        {"gfx942": False},
+        {"enabled": False},
+        {"shared": 0},
+        {"shared": 2},
+        {"ep": 8},
+        {"deepep": True},
+        {"quant": fp8(name="awq")},
+        {"quant": fp8(block=(1, 32), mxfp8=True)},
+        {"quant": fp8(["model.layers.1.mlp.shared_experts"])},
+        {"quant": fp8(["model.layers.1.mlp.shared_experts.gate_proj"])},
+        {"quant": fp8(["model.layers.1.mlp.experts.0.gate_proj"])},
+        {"quant": fp8(["model.layers.2.mlp"])},
+        {"cuda": True, "sm": 70},
+    ],
+)
+def test_unsupported_paths_keep_unfused(kwargs):
+    assert gate(**kwargs) is not None
+
+
+def test_weight_loader_and_wrapper_read_one_published_decision():
+    wrapper = ROOT / "python/sglang/srt/models/deepseek_v2.py"
+    for path, method in (
+        (MODEL, "determine_num_fused_shared_experts"),
+        (wrapper, "__init__"),
+    ):
+        calls = [
+            n
+            for n in ast.walk(ast.parse(path.read_text()))
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Name)
+            and n.func.id == "is_shared_experts_fusion_disabled"
+        ]
+        assert calls, (path, method)


### PR DESCRIPTION
## Summary

This is a conservative gfx942 eligibility change for GLM shared-expert fusion.

The existing fused shared-expert path is correct only for a subset of the configurations GLM can request on ROCm. In particular, the current AITER/CK path does not preserve GLM's clamp semantics, and the FP8 decode path still has an unresolved one-token correctness failure.

This PR therefore adds a default-off gfx942 opt-in, but only admits the configuration we have qualified: **unclamped BF16 with exactly one shared expert**. Clamp-active and FP8 cases stay on the existing unfused path.

No serving speedup is claimed by this draft.

## What changes

- Add `SGLANG_ROCM_GLM_SHARED_EXPERTS_FUSION`, default off.
- Reuse the existing shared-expert fusion decision rather than creating a second loader/runtime policy.
- Require AITER + gfx942 + exactly one shared expert.
- Reject any configured clamp.
- Keep FP8 disabled until the decode dispatcher is qualified.
- Preserve the existing CUDA path and the current EP/DeepEP restrictions.

This is a gating change. It does not modify CK arithmetic.

## Validation

- 34 production-gate CPU tests cover clamp, quantization, wrapped configs and unchanged CUDA behavior.
- Real MI300X eligibility/import checks pass.
- The current AITER diagnostic confirms why the gate is narrow: unclamped BF16 M=1/8/16 passes, while clamp-active cases do not match the clamped reference and the FP8 M=1 case still fails.

## Draft status / review question

I am keeping this as a draft until a broader serving path is qualified.

The useful review now is architectural: is `shared_experts_fusion_disable_reason` the right place to encode this ROCm capability boundary, or should gfx942 shared-expert eligibility be represented elsewhere in SGLang?

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34872162200](https://github.com/sgl-project/sglang/actions/runs/34872162200)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34872161574](https://github.com/sgl-project/sglang/actions/runs/34872161574)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34872162212](https://github.com/sgl-project/sglang/actions/runs/34872162212)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
