### PR TITLE
[GLM] Fuse KDA projections excluded from FP8 quantization

### DIFF
--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -49,6 +49,7 @@ from sglang.srt.layers.moe.utils import (
     is_shared_experts_fusion_disabled,
 )
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.utils import is_layer_skipped
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.layers.rotary_embedding import get_rope
 from sglang.srt.layers.utils.common import PPMissingLayer
@@ -303,6 +304,32 @@ class Glm5NextVisionModel(GlmOcrVisionModel):
         )
 
 
+def _kda_projections_are_unquantized(quant_config, prefix):
+    if quant_config is None:
+        return True
+    if quant_config.get_name() != "fp8":
+        return False
+    # The checkpoint may be FP8 while every KDA projection is explicitly BF16.
+    # Check original names: the new fused name is not in checkpoint exclusions.
+    return all(
+        is_layer_skipped(
+            f"{prefix}.{name}",
+            quant_config.ignored_layers,
+            fused_mapping=quant_config.packed_modules_mapping,
+        )
+        for name in (
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "b_proj",
+            "f_a_proj",
+            "f_b_proj",
+            "g_a_proj",
+            "g_b_proj",
+        )
+    )
+
+
 class Glm5NextLinearAttention(nn.Module):
     def __init__(
         self,
@@ -337,7 +364,10 @@ class Glm5NextLinearAttention(nn.Module):
         projection_size = self.head_dim * self.num_heads
         self.conv_size = config.linear_attn_config["short_conv_kernel_size"]
 
-        self.do_fuse_qkvbfg = quant_config is None and head_shard_size == self.tp_size
+        self.do_fuse_qkvbfg = (
+            head_shard_size == self.tp_size
+            and _kda_projections_are_unquantized(quant_config, prefix)
+        )
         if self.do_fuse_qkvbfg:
             self.qkvb_sizes = [
                 projection_size,
@@ -351,7 +381,7 @@ class Glm5NextLinearAttention(nn.Module):
                 self.hidden_size,
                 self.qkvb_sizes,
                 self.fg_sizes,
-                quant_config=quant_config,
+                quant_config=None,
                 prefix=f"{prefix}.fused_qkvbfg_a_proj",
             )
             self.split_sizes = [

--- a/test/manual/check_glm_kda_checkpoint_gpu.py
+++ b/test/manual/check_glm_kda_checkpoint_gpu.py
@@ -1,0 +1,185 @@
+"""Checkpoint-backed KDA projection/shard check; not whole-model qualification."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+import torch.distributed as dist
+from safetensors import safe_open
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("model")
+    parser.add_argument("--layers", nargs="+", type=int, default=[0, 22, 44])
+    parser.add_argument("--fp32-diagnostic", action="store_true")
+    args = parser.parse_args()
+    rank = int(os.environ.get("LOCAL_RANK", "0"))
+    world = int(os.environ.get("WORLD_SIZE", "1"))
+    torch.cuda.set_device(rank)
+    torch.set_default_dtype(torch.bfloat16)
+    torch.manual_seed(20260913)
+    dist.init_process_group("nccl")
+    from sglang.srt.runtime_context import get_parallel, publish
+    from sglang.srt.server_args import ServerArgs
+
+    publish(ServerArgs(model_path=args.model, device="cuda"), role="test")
+    from sglang.srt.layers.quantization.fp8 import Fp8Config
+    from sglang.srt.models import glm5_next as model
+
+    root = Path(args.model)
+    config = json.loads((root / "config.json").read_text())
+    index = json.loads((root / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    cfg = SimpleNamespace(**config["text_config"])
+    cfg.dtype = torch.bfloat16
+    quant = Fp8Config.from_config(config["quantization_config"])
+    names = [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "b_proj",
+        "f_a_proj",
+        "g_a_proj",
+        "f_b_proj",
+        "g_b_proj",
+    ]
+    with (
+        get_parallel().override(
+            tp_rank=rank, tp_size=world, attn_tp_rank=rank, attn_tp_size=world
+        ),
+        torch.device("cuda"),
+        torch.inference_mode(),
+    ):
+        for layer in args.layers:
+            prefix = f"model.layers.{layer}.self_attn"
+            weights = []
+            hashes = {}
+            for name in names:
+                key = f"model.language_model.layers.{layer}.self_attn.{name}.weight"
+                with safe_open(root / index[key], framework="pt", device="cpu") as f:
+                    weight = f.get_tensor(key)
+                assert weight.dtype == torch.bfloat16, (key, weight.dtype)
+                hashes[key] = hashlib.sha256(
+                    weight.view(torch.uint8).numpy().tobytes()
+                ).hexdigest()
+                weights.append(weight.cuda())
+            module = model.Glm5NextLinearAttention(
+                layer, cfg.hidden_size, cfg, quant_config=quant, prefix=prefix
+            )
+            assert module.do_fuse_qkvbfg
+            for i, w in enumerate(weights[:6]):
+                module.fused_qkvbfg_a_proj.weight_loader(
+                    module.fused_qkvbfg_a_proj.weight, w, i
+                )
+            for i, w in enumerate(weights[6:]):
+                module.fused_fg_b_proj.weight_loader(
+                    module.fused_fg_b_proj.weight, w, i
+                )
+            # Check rank slices independently of the production loader.
+            local = [
+                w.chunk(world, dim=0)[rank] if i < 4 or i >= 6 else w
+                for i, w in enumerate(weights)
+            ]
+            torch.testing.assert_close(
+                module.fused_qkvbfg_a_proj.weight, torch.cat(local[:6]), rtol=0, atol=0
+            )
+            torch.testing.assert_close(
+                module.fused_fg_b_proj.weight, torch.stack(local[6:]), rtol=0, atol=0
+            )
+            if rank == 0:
+                print(
+                    json.dumps(
+                        {
+                            "layer": layer,
+                            "checkpoint_tensor_sha256": hashes,
+                            "world_size": world,
+                            "source": model.__file__,
+                        }
+                    ),
+                    flush=True,
+                )
+            for count in (1, 8, 16, 257):
+                x = torch.randn(count, cfg.hidden_size, device="cuda")
+                dist.broadcast(x, 0)
+                reference = (
+                    torch.cat([x @ w.T for w in local[:3]], -1),
+                    x @ local[3].T,
+                    (x @ local[4].T) @ local[6].T,
+                    (x @ local[5].T) @ local[7].T,
+                )
+                actual = module.forward_qkvbfg_fused(x, None)
+                if args.fp32_diagnostic:
+                    xf = x.float()
+                    wf = [w.float() for w in local]
+                    oracle = (
+                        torch.cat([xf @ w.T for w in wf[:3]], -1),
+                        xf @ wf[3].T,
+                        (xf @ wf[4].T) @ wf[6].T,
+                        (xf @ wf[5].T) @ wf[7].T,
+                    )
+                    for component, (a, b, gold) in enumerate(
+                        zip(actual, reference, oracle)
+                    ):
+                        scale = gold.square().mean().sqrt().clamp_min(1e-8)
+                        ae = ((a.float() - gold).square().mean().sqrt() / scale).item()
+                        be = ((b.float() - gold).square().mean().sqrt() / scale).item()
+                        mismatch = ((a - b).abs() > 0.003 + 0.02 * b.abs()).sum().item()
+                        print(
+                            json.dumps(
+                                {
+                                    "rank": rank,
+                                    "layer": layer,
+                                    "tokens": count,
+                                    "component": component,
+                                    "fused_nrmse": ae,
+                                    "unfused_nrmse": be,
+                                    "strict_mismatches": mismatch,
+                                }
+                            ),
+                            flush=True,
+                        )
+                        assert torch.isfinite(a).all()
+                        assert ae <= max(1.10 * be, be + 0.0001), (ae, be)
+                else:
+                    for a, b in zip(actual, reference):
+                        torch.testing.assert_close(a, b, atol=0.003, rtol=0.02)
+                if count <= 16:
+                    stream = torch.cuda.Stream()
+                    stream.wait_stream(torch.cuda.current_stream())
+                    with torch.cuda.stream(stream):
+                        for _ in range(3):
+                            module.forward_qkvbfg_fused(x, None)
+                    torch.cuda.current_stream().wait_stream(stream)
+                    graph = torch.cuda.CUDAGraph()
+                    with torch.cuda.graph(graph):
+                        captured = module.forward_qkvbfg_fused(x, None)
+                    for _ in range(5):
+                        graph.replay()
+                    torch.cuda.synchronize()
+                    for a, b in zip(captured, actual):
+                        torch.testing.assert_close(a, b, atol=0, rtol=0)
+                dist.barrier()
+                print(
+                    json.dumps(
+                        {
+                            "rank": rank,
+                            "layer": layer,
+                            "tokens": count,
+                            "checkpoint_shard_projection_graph": "pass",
+                        }
+                    ),
+                    flush=True,
+                )
+            del module, weights, local
+    dist.destroy_process_group()
+    print(f"KDA_CHECKPOINT_TP{world}_PASS rank={rank}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/manual/check_glm_kda_projection_gpu.py
+++ b/test/manual/check_glm_kda_projection_gpu.py
@@ -1,0 +1,111 @@
+"""Manual ROCm KDA loader/projection/graph check; not endpoint qualification."""
+
+import json
+from types import SimpleNamespace
+
+import torch
+
+
+def main():
+    from sglang.srt.runtime_context import get_parallel, publish
+    from sglang.srt.server_args import ServerArgs
+
+    publish(ServerArgs(model_path="dummy", device="cuda"), role="test")
+    from sglang.srt.layers.quantization.fp8 import Fp8Config
+    from sglang.srt.models import glm5_next as model
+
+    print(
+        json.dumps(
+            {
+                "source": model.__file__,
+                "torch": torch.__version__,
+                "hip": torch.version.hip,
+            }
+        ),
+        flush=True,
+    )
+    torch.set_default_dtype(torch.bfloat16)
+    torch.manual_seed(20260913)
+
+    names = [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "b_proj",
+        "f_a_proj",
+        "f_b_proj",
+        "g_a_proj",
+        "g_b_proj",
+    ]
+    prefix = "model.layers.1.self_attn"
+    quant = Fp8Config(
+        is_checkpoint_fp8_serialized=True,
+        weight_block_size=[128, 128],
+        ignored_layers=[f"{prefix}.{n}" for n in names],
+    )
+    cfg = SimpleNamespace(
+        linear_attn_config={
+            "head_dim": 128,
+            "num_heads": 4,
+            "short_conv_kernel_size": 4,
+        },
+        dtype=torch.bfloat16,
+    )
+    with (
+        get_parallel().override(tp_rank=0, tp_size=1, attn_tp_rank=0, attn_tp_size=1),
+        torch.device("cuda"),
+        torch.inference_mode(),
+    ):
+        module = model.Glm5NextLinearAttention(
+            1, 512, cfg, quant_config=quant, prefix=prefix
+        )
+        assert module.do_fuse_qkvbfg
+        assert module.fused_qkvbfg_a_proj.weight.dtype == torch.bfloat16
+        assert module.fused_fg_b_proj.weight.dtype == torch.bfloat16
+        weights = [
+            torch.randn(n, 512, device="cuda") * 0.01
+            for n in (512, 512, 512, 4, 128, 128)
+        ]
+        bweights = [torch.randn(512, 128, device="cuda") * 0.01 for _ in range(2)]
+        # Use the real shard loader, including repeated f/g-a rows and batched b projections.
+        for shard, weight in enumerate(weights):
+            layer = module.fused_qkvbfg_a_proj
+            layer.weight_loader(layer.weight, weight, shard)
+        for shard, weight in enumerate(bweights):
+            layer = module.fused_fg_b_proj
+            layer.weight_loader(layer.weight, weight, shard)
+        for count in (1, 8, 16, 257):
+            x = torch.randn(count, 512, device="cuda")
+            expected = (
+                torch.cat([x @ w.T for w in weights[:3]], -1),
+                x @ weights[3].T,
+                (x @ weights[4].T) @ bweights[0].T,
+                (x @ weights[5].T) @ bweights[1].T,
+            )
+            actual = module.forward_qkvbfg_fused(x, None)
+            for a, b in zip(actual, expected):
+                torch.testing.assert_close(a, b, atol=0.003, rtol=0.02)
+            if count <= 16:
+                stream = torch.cuda.Stream()
+                stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(stream):
+                    for _ in range(3):
+                        module.forward_qkvbfg_fused(x, None)
+                torch.cuda.current_stream().wait_stream(stream)
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    captured = module.forward_qkvbfg_fused(x, None)
+                for _ in range(10):
+                    graph.replay()
+                torch.cuda.synchronize()
+                for a, b in zip(captured, expected):
+                    torch.testing.assert_close(a, b, atol=0.003, rtol=0.02)
+            print(
+                json.dumps({"tokens": count, "loader_projection_graph": "pass"}),
+                flush=True,
+            )
+        print("G03_REAL_MODULE_LOADER_GRAPH_PASS_NO_ENDPOINT_QUALIFICATION", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/manual/test_glm_kda_quantization_fusion.py
+++ b/test/manual/test_glm_kda_quantization_fusion.py
@@ -1,0 +1,106 @@
+"""CPU checks of exact production eligibility; GPU loading tested separately."""
+
+import ast
+import copy
+from pathlib import Path
+from types import MappingProxyType, SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+MODEL = ROOT / "python/sglang/srt/models/glm5_next.py"
+UTILS = ROOT / "python/sglang/srt/layers/quantization/utils.py"
+PREFIX = "model.layers.1.self_attn"
+NAMES = [
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "b_proj",
+    "f_a_proj",
+    "f_b_proj",
+    "g_a_proj",
+    "g_b_proj",
+]
+
+
+def production_gate():
+    ns = {"MappingProxyType": MappingProxyType, "_FALLBACK_FUSED_SHARDS": {}}
+    for path, name in (
+        (UTILS, "_module_path_match"),
+        (UTILS, "is_layer_skipped"),
+        (MODEL, "_kda_projections_are_unquantized"),
+    ):
+        nodes = [
+            n
+            for n in ast.walk(ast.parse(path.read_text()))
+            if isinstance(n, ast.FunctionDef) and n.name == name
+        ]
+        assert len(nodes) == 1
+        node = copy.deepcopy(nodes[0])
+        node.decorator_list = []
+        module = ast.Module(
+            body=[
+                ast.ImportFrom(
+                    module="__future__", names=[ast.alias(name="annotations")], level=0
+                ),
+                node,
+            ],
+            type_ignores=[],
+        )
+        exec(compile(ast.fix_missing_locations(module), str(path), "exec"), ns)
+    return ns["_kda_projections_are_unquantized"]
+
+
+def config(ignored, name="fp8"):
+    return SimpleNamespace(
+        get_name=lambda: name, ignored_layers=ignored, packed_modules_mapping={}
+    )
+
+
+def test_no_quantization():
+    assert production_gate()(None, PREFIX)
+
+
+@pytest.mark.parametrize("ignored", [NAMES, [PREFIX], [f"{PREFIX}.{x}" for x in NAMES]])
+def test_all_original_projections_excluded(ignored):
+    assert production_gate()(config(ignored), PREFIX)
+
+
+@pytest.mark.parametrize("missing", NAMES)
+def test_each_partially_quantized_projection_disables_fusion(missing):
+    assert not production_gate()(config([x for x in NAMES if x != missing]), PREFIX)
+
+
+@pytest.mark.parametrize(
+    "ignored,name",
+    [([], "fp8"), (NAMES, "awq"), ([f"other.{n}" for n in NAMES], "fp8")],
+)
+def test_unsupported_quantization_stays_unfused(ignored, name):
+    assert not production_gate()(config(ignored, name), PREFIX)
+
+
+def test_fused_linear_cannot_requantize_unrecognized_fused_name():
+    calls = [
+        n
+        for n in ast.walk(ast.parse(MODEL.read_text()))
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "MergedColumnParallelRepeatedLinear"
+    ]
+    assert len(calls) == 1
+    quant = next(k.value for k in calls[0].keywords if k.arg == "quant_config")
+    assert isinstance(quant, ast.Constant) and quant.value is None
+
+
+def test_head_sharding_guard_remains():
+    assignments = [
+        n
+        for n in ast.walk(ast.parse(MODEL.read_text()))
+        if isinstance(n, ast.Assign)
+        and any(
+            isinstance(t, ast.Attribute) and t.attr == "do_fuse_qkvbfg"
+            for t in n.targets
+        )
+    ]
+    assert len(assignments) == 1
+    assert "head_shard_size == self.tp_size" in ast.unparse(assignments[0].value)


### PR DESCRIPTION
## Summary

GLM's KDA projections can be BF16 even when the checkpoint uses FP8 elsewhere. Today, the merged-projection path rejects any checkpoint with a non-null `quant_config`, so it misses the case where **all eight original KDA projections are explicitly excluded from quantization**.

This PR makes the fusion decision from those original projection names instead of the checkpoint-wide quantization flag. When all eight are excluded, the merged projection is created with `quant_config=None`. Partial exclusions and unsupported quantizers keep the existing unfused path.

No quantized GEMM implementation is added, and the existing attention-head sharding condition is unchanged.

## Validation

- 17 production-gate CPU tests cover all/partial/no exclusions, unsupported quantizers and head-shard compatibility.
- Real MI300X module checks pass at M=1/8/16/257, including graph replay at M=1/8/16.
- Actual checkpoint layers 0/22/44 pass TP8 projection-shard loading and graph replay with the merged weights verified as BF16.
- The independently registered FP32 diagnostic passes on the tested ranks/shapes.

I do not have a supported current-stack whole-model A/B yet. On the exact parent, the AMD model path stops earlier in unrelated CUDA-only DeepGEMM/KPool paths, so this remains a draft and makes no serving-performance claim.

## Review question

Is using the existing per-layer quantization-exclusion matching on the original KDA projection names the right abstraction for this gate? I am happy to adapt this to a maintainer-preferred loader or quantization helper before endpoint qualification.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34872474369](https://github.com/sgl-project/sglang/actions/runs/34872474369)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34872474030](https://github.com/sgl-project/sglang/actions/runs/34872474030)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34872474270](https://github.com/sgl-project/sglang/actions/runs/34872474270)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
