### PR TITLE
[Diffusion] Opt in to guarded gfx942 AITER varlen strides per call

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib
+import inspect
 import logging
 import os
+from functools import cache
 
 import aiter
 import torch
@@ -24,6 +26,9 @@ from sglang.multimodal_gen.runtime.platforms.aiter import (
 logger = logging.getLogger(__name__)
 
 _use_fp8_attn = os.environ.get("SGLANG_DIFFUSION_AITER_FP8_ATTN", "0") == "1"
+_use_int32_varlen_strides = (
+    os.environ.get("SGLANG_DIFFUSION_AITER_INT32_VARLEN_STRIDES", "0") == "1"
+)
 _fp8_dtype = torch.float8_e4m3fn
 
 # fmha_fwd_hd128_fp8_gfx950 ASM kernel. Support full MHA with q/k/v head_dim == 128 -- e.g., Wan 2.2 self- and cross-attention.
@@ -87,6 +92,21 @@ def _fmha_fp8_prefill_attention(
         softmax_scale=softmax_scale,
         window_size=(-1, -1, 0),
     )
+
+
+@cache
+def _supports_int32_varlen_strides(attention_func):
+    try:
+        supported = (
+            "prefer_int32_strides" in inspect.signature(attention_func).parameters
+        )
+    except (TypeError, ValueError):
+        supported = False
+    if not supported:
+        logger.warning(
+            "Installed AITER lacks per-call stride selection; keeping its default."
+        )
+    return supported
 
 
 class AITerBackend(AttentionBackend):
@@ -236,6 +256,15 @@ class AITerImpl(AttentionImpl):
         else:
             attention_func = aiter.flash_attn_varlen_func
 
+        stride_options = {}
+        if (
+            USE_AITER_GFX942
+            and _use_int32_varlen_strides
+            and _supports_int32_varlen_strides(attention_func)
+        ):
+            # AITER checks all tensors, outputs and masked tile offsets. Never
+            # toggle its global stride flag: other calls may run concurrently.
+            stride_options["prefer_int32_strides"] = True
         cu_seqlens = cu_seqlens.to(device=query.device, dtype=torch.int32).contiguous()
         output = attention_func(
             q=query.contiguous(),
@@ -247,5 +276,6 @@ class AITerImpl(AttentionImpl):
             max_seqlen_k=max_seqlen,
             softmax_scale=self.softmax_scale,
             causal=self.causal,
+            **stride_options,
         )
         return output[0] if isinstance(output, tuple) else output

--- a/test/manual/check_h3_varlen_adapter_gpu.py
+++ b/test/manual/check_h3_varlen_adapter_gpu.py
@@ -1,0 +1,78 @@
+"""Actual SGLang AITER varlen adapter, new/old API and graph parity."""
+
+import json
+from unittest.mock import patch
+
+import torch
+from aiter.ops.triton.attention import mha
+
+from sglang.multimodal_gen.runtime.layers.attention.backends import aiter as backend
+
+assert backend.USE_AITER_GFX942
+assert backend._use_int32_varlen_strides
+original = mha.flash_attn_varlen_func
+torch.manual_seed(20260913)
+impl = backend.AITerImpl(4, 128, 128**-0.5)
+with torch.inference_mode():
+    for length in (129, 1024):
+        q, k, v = [
+            torch.randn(length, 4, 128, device="cuda", dtype=torch.bfloat16)
+            for _ in range(3)
+        ]
+        cu = torch.tensor([0, length], device="cuda", dtype=torch.int32)
+        control = original(q, k, v, cu, cu, length, length)
+        actual = impl.forward_varlen(q, k, v, cu_seqlens=cu, max_seqlen=length)
+        torch.testing.assert_close(actual, control, rtol=0, atol=0)
+
+        # A genuine old callable must never receive the new keyword.
+        def old_api(
+            q,
+            k,
+            v,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            softmax_scale,
+            causal,
+        ):
+            return original(
+                q,
+                k,
+                v,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                max_seqlen_q,
+                max_seqlen_k,
+                softmax_scale=softmax_scale,
+                causal=causal,
+            )
+
+        with patch.object(mha, "flash_attn_varlen_func", old_api):
+            fallback = impl.forward_varlen(q, k, v, cu_seqlens=cu, max_seqlen=length)
+        torch.testing.assert_close(fallback, control, rtol=0, atol=0)
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            for _ in range(3):
+                impl.forward_varlen(q, k, v, cu_seqlens=cu, max_seqlen=length)
+        torch.cuda.current_stream().wait_stream(stream)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            captured = impl.forward_varlen(q, k, v, cu_seqlens=cu, max_seqlen=length)
+        for _ in range(5):
+            graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(captured, control, rtol=0, atol=0)
+        assert mha._USE_INT64_STRIDES is True
+        print(
+            json.dumps(
+                {
+                    "length": length,
+                    "real_sglang_adapter_new_old_graph": "pass",
+                    "source": backend.__file__,
+                }
+            ),
+            flush=True,
+        )
+print("H3_ENGINE_ADAPTER_PASS_NO_VIDEO_ENDPOINT", flush=True)

--- a/test/manual/test_h3_varlen_stride_dispatch.py
+++ b/test/manual/test_h3_varlen_stride_dispatch.py
@@ -1,0 +1,100 @@
+"""CPU dispatch checks; real attention parity is a separate GPU test."""
+
+import ast
+import inspect
+import logging
+from functools import cache
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+SOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py"
+)
+
+
+def namespace():
+    ns = dict(inspect=inspect, cache=cache, logger=logging.getLogger(__name__))
+    helper = next(
+        n
+        for n in ast.parse(SOURCE.read_text()).body
+        if isinstance(n, ast.FunctionDef) and n.name == "_supports_int32_varlen_strides"
+    )
+    exec(compile(ast.Module(body=[helper], type_ignores=[]), str(SOURCE), "exec"), ns)
+    return ns
+
+
+def test_capability_detects_old_and_new_apis():
+    ns = namespace()
+    assert ns["_supports_int32_varlen_strides"](lambda q, prefer_int32_strides=False: q)
+    assert not ns["_supports_int32_varlen_strides"](lambda q: q)
+
+
+class TensorStub:
+    device = "cuda"
+
+    def contiguous(self):
+        return self
+
+    def to(self, **kwargs):
+        return self
+
+
+@pytest.mark.parametrize(
+    "gfx942,enabled,supported",
+    [(True, True, True), (True, True, False), (True, False, True), (False, True, True)],
+)
+def test_only_supported_opted_in_gfx942_calls_receive_keyword(
+    gfx942, enabled, supported
+):
+    def attention_func(**kwargs):
+        return kwargs
+
+    ns = namespace()
+    ns.update(
+        USE_AITER_GFX942=gfx942,
+        _use_int32_varlen_strides=enabled,
+        _supports_int32_varlen_strides=lambda fn: supported,
+        importlib=SimpleNamespace(
+            import_module=lambda name: SimpleNamespace(
+                flash_attn_varlen_func=attention_func
+            )
+        ),
+        aiter=SimpleNamespace(flash_attn_varlen_func=attention_func),
+        torch=SimpleNamespace(int32="int32"),
+    )
+    method = next(
+        n
+        for n in ast.walk(ast.parse(SOURCE.read_text()))
+        if isinstance(n, ast.FunctionDef) and n.name == "forward_varlen"
+    )
+    method.decorator_list = []
+    module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__", names=[ast.alias(name="annotations")], level=0
+            ),
+            method,
+        ],
+        type_ignores=[],
+    )
+    exec(compile(ast.fix_missing_locations(module), str(SOURCE), "exec"), ns)
+    tensor = TensorStub()
+    result = ns["forward_varlen"](
+        SimpleNamespace(softmax_scale=0.125, causal=False),
+        tensor,
+        tensor,
+        tensor,
+        cu_seqlens=tensor,
+        max_seqlen=65536,
+    )
+    assert result.get("prefer_int32_strides", False) == (
+        gfx942 and enabled and supported
+    )
+    assert result["max_seqlen_q"] == result["max_seqlen_k"] == 65536
+
+
+def test_no_global_stride_mutation():
+    assert "mha_set_use_int64_strides" not in SOURCE.read_text()


### PR DESCRIPTION
## Summary

This is the SGLang adapter for ROCm/AITER #5478.

On gfx942, the existing MiniMax H3 AITER varlen-attention path can opt into AITER's guarded per-call int32 stride arithmetic. The adapter feature-detects the new AITER keyword before passing it, so older AITER packages keep their existing behavior. It never mutates AITER's process-global stride setting.

The feature is default off through `SGLANG_DIFFUSION_AITER_INT32_VARLEN_STRIDES=1`.

This PR also adds ROCm to MiniMax H3's existing full-loop platform guard so the tested path is reachable.

## Validation

The adapter has CPU coverage for opt-in/off behavior, old/new AITER signatures and the platform boundary. Real MI300X checks cover the new API, old-package fallback and graph replay.

In the matched 8x MI300X MiniMax H3 test with Cache-DiT off, full generation time improved from **208.17 s to 142.12 s**, or **46.48% more serial clips/hour**. All three measured decoded video/audio outputs were identical between control and candidate.

Only the per-call guarded stride opt-in differs between the two arms. Short attention can regress, so there is no unconditional enabling or universal speedup claim.

## Compatibility

If the installed AITER does not expose `prefer_int32_strides`, SGLang keeps the existing call signature and logs one cached warning. Other platforms and the previous non-ROCm H3 platform decisions are unchanged.

## Review question

The main review question is whether this capability check belongs in the AITER backend at this boundary, and whether the explicit CUDA-or-ROCm H3 platform guard is the preferred way to expose the existing ROCm path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34843907708](https://github.com/sgl-project/sglang/actions/runs/34843907708)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34843907493](https://github.com/sgl-project/sglang/actions/runs/34843907493)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34843907713](https://github.com/sgl-project/sglang/actions/runs/34843907713)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

