### PR TITLE
w4afp8 read ignored_layers  in from_config

### DIFF
--- a/python/sglang/srt/layers/quantization/w4afp8.py
+++ b/python/sglang/srt/layers/quantization/w4afp8.py
@@ -82,11 +82,15 @@ class W4AFp8Config(QuantizationConfig):
         linear_activation_scheme = "dynamic"
         moe_activation_scheme = "static"
         weight_block_size = [128, 128]
+        ignored_layers = cls.get_from_keys_or(
+            config, ["ignored_layers", "modules_to_not_convert"], None
+        )
         return cls(
             is_checkpoint_fp8_serialized=is_checkpoint_fp8_serialized,
             is_checkpoint_w4afp8_serialized=is_checkpoint_w4afp8_serialized,
             linear_activation_scheme=linear_activation_scheme,
             moe_activation_scheme=moe_activation_scheme,
+            ignored_layers=ignored_layers,
             weight_block_size=weight_block_size,
         )
 


### PR DESCRIPTION
## Motivation

`W4AFp8Config.from_config` never passes `ignored_layers` to the constructor, so it's always empty even though `__init__` accepts it and `get_quant_method` already calls `is_layer_skipped(prefix, self.ignored_layers)`. so w4afp8 is just out of sync.

The result is that every non-MoE Linear gets `Fp8LinearMethod`, and block-FP8 validation rejects any output dim that isn't a multiple of `block_n=128`

GLM-5.2 never hits this (all linears ≥128 wide). GLM-5.3-Flash does, mlp.gate (288), KDA b_proj (64), indexer weights_proj (32). So it fails to load despite config.json listing them in `modules_to_not_convert`.

## Modifications

Read `ignored_layers / modules_to_not_convert` from the quantization config and pass it to the constructor, exactly matching `Fp8Config.from_config`.

## Accuracy Tests

`W4AFP8` GLM-5.3-Flash on 2×H200, TP=2. GPQA-Diamond 90.9% vs 91.2% reported for the BF16 by zai. Without the patch the server wont start so no baseline. Model weights here - https://huggingface.co/graphistry/GLM-5.3-Flash-W4AFP8

## Speed Tests and Profiling

No impact, config parsing only, runs once at load.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34731277168](https://github.com/sgl-project/sglang/actions/runs/34731277168)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34731277098](https://github.com/sgl-project/sglang/actions/runs/34731277098)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34731277194](https://github.com/sgl-project/sglang/actions/runs/34731277194)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->