### PR TITLE
[MLX] Release finished requests' caches at every launch, not only on decode

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/tp_worker.py
+++ b/python/sglang/srt/hardware_backend/mlx/tp_worker.py
@@ -119,6 +119,7 @@ class MlxTpModelWorker(TpModelWorker):
         )
 
         self._mlx_active_rids: set[str] = set()
+        self._mlx_finished_rids: set[str] = set()
         self._mlx_pool_initialized = False
 
     def get_pad_input_ids_func(self):
@@ -157,7 +158,15 @@ class MlxTpModelWorker(TpModelWorker):
         )
 
     def _cleanup_stale_rids(self, forward_mode, current_rids: set[str]) -> None:
-        """Remove MLX state for decode-mode requests that dropped out of the batch."""
+        """Remove MLX state for requests that are no longer running."""
+        # If a batch drains completely the cache won't clear until the next decode,
+        # after the prefill
+        finished = self._mlx_finished_rids & self._mlx_active_rids
+        for rid in finished:
+            self._mlx_runner.remove_request(rid)
+        self._mlx_active_rids -= finished
+        self._mlx_finished_rids.clear()
+
         if forward_mode.is_decode():
             stale_rids = self._mlx_active_rids - current_rids
             for rid in stale_rids:
@@ -169,6 +178,7 @@ class MlxTpModelWorker(TpModelWorker):
     def prepare_for_kv_cache_release(self, req) -> None:
         """Snapshot MLX auxiliary state at the scheduler's radix insert point."""
         if self._mlx_runner.has_request(req.rid):
+            self._mlx_finished_rids.add(req.rid)
             self._mlx_runner.store_auxiliary_state_for_request(req.rid)
             # Prefer the just-snapshotted live auxiliary state for the final
             # insert. Any older tracked slot is released during component cleanup.

--- a/test/registered/unit/hardware_backend/mlx/test_tp_worker_routing.py
+++ b/test/registered/unit/hardware_backend/mlx/test_tp_worker_routing.py
@@ -71,6 +71,14 @@ class _FakeRunner:
     def has_request(self, rid):
         return rid in self._known
 
+    def remove_request(self, rid):
+        self.calls.append(("remove_request", rid))
+        self._known.discard(rid)
+        self._req_caches.pop(rid, None)
+
+    def store_auxiliary_state_for_request(self, rid):
+        pass
+
     def flush_all_decode_kv(self):
         pass
 
@@ -214,6 +222,7 @@ class TestMlxExtendRouting(CustomTestCase):
         worker = MlxTpModelWorker.__new__(MlxTpModelWorker)
         worker._mlx_runner = _FakeRunner(known_rids)
         worker._mlx_active_rids = set()
+        worker._mlx_finished_rids = set()
         # The sync entry point delegates to the async launch, which guards
         # pool creation behind this flag; forward_batch_generation has
         # already run it for real by the time either path is reached.
@@ -325,6 +334,80 @@ class TestMlxExtendRouting(CustomTestCase):
         self.assertEqual(runner.ops_for("p1"), ["prefill_start"])
         self.assertEqual(runner.ops_for("d1"), ["decode_start"])
         self.assertIsNotNone(launch.decode)  # pending mixed decode present
+
+
+def _finished_req(rid):
+    """Minimal Req stand-in for prepare_for_kv_cache_release."""
+    return SimpleNamespace(rid=rid, kv=SimpleNamespace(mamba_last_track_seqlen=None))
+
+
+@unittest.skipUnless(_IS_APPLE_SILICON and _HAS_MLX, _SKIP_REASON)
+class TestMlxFinishedRequestRelease(CustomTestCase):
+    """Finished requests must release their MLX caches at the next launch,
+    whatever that launch's forward mode is.
+
+    A batch that drains completely is followed by an EXTEND batch for the
+    next wave. The old cleanup only released on DECODE launches, so every
+    dead request kept its full contiguous KV buffer allocated alongside the
+    new prefills' -- the per-request footprint doubled at exactly the
+    moment a new wave was admitted (Metal OOM at 16 concurrent requests on
+    a 24 GB machine with the pool capped).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls._config = get_context().override_server_args(mlx_enable_sampling=False)
+        cls._config.install()
+        cls.addClassCleanup(cls._config.restore)
+
+    @staticmethod
+    def _worker(active_rids):
+        from sglang.srt.hardware_backend.mlx.tp_worker import MlxTpModelWorker
+
+        worker = MlxTpModelWorker.__new__(MlxTpModelWorker)
+        worker._mlx_runner = _FakeRunner(active_rids)
+        worker._mlx_active_rids = set(active_rids)
+        worker._mlx_finished_rids = set()
+        worker._mlx_pool_initialized = True
+        return worker
+
+    def test_finished_requests_released_on_extend_launch(self):
+        worker = self._worker({"a", "b"})
+        worker.prepare_for_kv_cache_release(_finished_req("a"))
+        worker.prepare_for_kv_cache_release(_finished_req("b"))
+
+        worker._cleanup_stale_rids(ForwardMode.EXTEND, {"c"})
+
+        self.assertFalse(worker._mlx_runner.has_request("a"))
+        self.assertFalse(worker._mlx_runner.has_request("b"))
+        self.assertEqual(worker._mlx_active_rids, {"c"})
+        self.assertEqual(worker._mlx_finished_rids, set())
+
+    def test_unfinished_requests_survive_extend_launch(self):
+        worker = self._worker({"a", "b"})
+        worker.prepare_for_kv_cache_release(_finished_req("a"))
+
+        worker._cleanup_stale_rids(ForwardMode.EXTEND, {"c"})
+
+        self.assertFalse(worker._mlx_runner.has_request("a"))
+        self.assertTrue(worker._mlx_runner.has_request("b"))
+        self.assertEqual(worker._mlx_active_rids, {"b", "c"})
+
+    def test_decode_launch_still_drops_silently_departed_requests(self):
+        # An abort leaves the batch without a finish notification; the
+        # decode-mode set difference must keep catching it.
+        worker = self._worker({"a", "b"})
+
+        worker._cleanup_stale_rids(ForwardMode.DECODE, {"b"})
+
+        self.assertFalse(worker._mlx_runner.has_request("a"))
+        self.assertTrue(worker._mlx_runner.has_request("b"))
+        self.assertEqual(worker._mlx_active_rids, {"b"})
+
+    def test_unknown_request_is_not_marked(self):
+        worker = self._worker({"a"})
+        worker.prepare_for_kv_cache_release(_finished_req("ghost"))
+        self.assertEqual(worker._mlx_finished_rids, set())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

On the MLX backend, every running request owns worker-side state (a contiguous per-layer KV buffer, token list, bookkeeping) that the scheduler's `release_kv_cache` knows nothing about. `MlxTpModelWorker._cleanup_stale_rids` released that state only on **decode** launches, as the difference between the worker's active set and the batch. On an **extend** launch it released nothing.

So when every request in a batch finishes on the same step, the next launch is a prefill for the waiting wave, the cleanup frees nothing, and the dead requests' buffers stay allocated alongside the new wave's until the following decode launch. The per-request footprint doubles at exactly the moment new requests are admitted.

Measured on an M4 Pro (24 GB), Qwen3-0.6B, `--max-total-tokens 32768`, `sglang.benchmark.serving` with 64 x (256 in / 64 out) at concurrency 16: at the drain, the worker held 16 dead caches plus 16 new ones (32 live, ~470 MB each for this model) and Metal returned `Insufficient Memory` on the next prefill.

## Modifications

`python/sglang/srt/hardware_backend/mlx/tp_worker.py`:

- Record the rid in `prepare_for_kv_cache_release`. The scheduler already calls this hook for every finished request, immediately before `release_kv_cache`; the MLX worker already implemented it for auxiliary-state snapshots.
- In `_cleanup_stale_rids`, release the recorded rids on **every** launch (any forward mode) before the existing logic runs. The decode-mode set difference is kept unchanged for requests that leave without the hook (aborts, retractions).

The release stays deferred to the next launch rather than done in the hook: under the overlap loop a chained decode step built on the finished request's cache may still be in flight, and its finalize needs the request's state. At launch time both in-flight jobs have been finalized, which is the same point the old decode-mode path used.

With the fix, the same run shows all 16 dead caches released at the prefill launch and 14 of them reused by the new wave from the pool.

Tests (`test/registered/unit/hardware_backend/mlx/test_tp_worker_routing.py`, `stage-a-unit-test-mlx`): finished rids are released on an EXTEND launch, and an unfinished rid survives that launch (both fail on `main`); a DECODE launch still drops a rid that departed without the hook, and an unknown rid is not marked (regression guards for the existing behavior, pass on `main`).

Scope note: this fixes the leak only. It does not by itself make concurrency 16 fit on a 24 GB machine, because the per-request buffer preallocation is the larger term; that is a separate discussion. Routing aborts/retractions through the same mark (so MLX state tracks every scheduler release) is a natural follow-up, also out of scope here.

## Accuracy Tests

No change to model forward code. `test_mlx_reference_correctness.py` (greedy vs raw mlx_lm, batched vs solo) passes with `SGLANG_MLX_TEST_MODEL=Qwen/Qwen3-0.6B`; all other `test/registered/unit/hardware_backend/mlx/` files pass except `test_scheduler_mixin.py`, whose two errors are pre-existing on `main`.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not needed.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34898607182](https://github.com/sgl-project/sglang/actions/runs/34898607182)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34898606238](https://github.com/sgl-project/sglang/actions/runs/34898606238)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34898606509](https://github.com/sgl-project/sglang/actions/runs/34898606509)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->