### PR TITLE
[AMD][SPEC]Fix DeepSeek-V4 benchmark accuracy gap by supporting temperature sampling in EAGLE verify

### DIFF
--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -21,6 +21,7 @@ from sglang.srt.mem_cache.allocation_sizing import (
 )
 from sglang.srt.runtime_context import get_parallel, get_spec
 from sglang.srt.utils import (
+    get_bool_env_var,
     is_cpu,
     is_cuda,
     is_hip,
@@ -42,6 +43,7 @@ if TYPE_CHECKING:
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
+_SPEC_MATCH_SAMPLE = get_bool_env_var("SGLANG_SPEC_MATCH_SAMPLE") and _is_hip
 _is_npu = is_npu()
 _is_musa = is_musa()
 _is_xpu = is_xpu()
@@ -372,6 +374,28 @@ def verify_tree_greedy_triton(
         num_speculative_tokens=num_speculative_tokens,
         num_draft_tokens=num_draft_tokens,
     )
+
+
+def select_target_predict(
+    next_token_logits: torch.Tensor,
+    sampling_info: SamplingBatchInfo,
+    draft_token_num: int,
+) -> torch.Tensor:
+    if not _SPEC_MATCH_SAMPLE or sampling_info.is_all_greedy:
+        return torch.argmax(next_token_logits, dim=-1)
+
+    if sampling_info.need_top_p_sampling or sampling_info.need_top_k_sampling:
+        logger.warning_once(
+            "SGLANG_SPEC_MATCH_SAMPLE: top_p/top_k truncation has no ROCm kernel; "
+            "falling back to greedy verify."
+        )
+        return torch.argmax(next_token_logits, dim=-1)
+
+    temperatures = torch.repeat_interleave(
+        sampling_info.temperatures, draft_token_num, dim=0
+    )
+    probs = torch.softmax(next_token_logits / temperatures, dim=-1)
+    return torch.multinomial(probs, num_samples=1).flatten()
 
 
 def verify_tree_greedy_func(
@@ -782,7 +806,9 @@ def eagle_sample(
     # Sample tokens
     target_predict = None
     if sampling_info.is_all_greedy or _is_cpu or _is_hip or _is_xpu:
-        target_predict = torch.argmax(next_token_logits, dim=-1)
+        target_predict = select_target_predict(
+            next_token_logits, sampling_info, verify_input.draft_token_num
+        )
         target_predict = target_predict.reshape(bs, verify_input.draft_token_num)
         predict, accept_index, num_correct_drafts = verify_tree_greedy_func(
             predicts=predict,  # mutable


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

This PR co-work with @yuttian1 and @amd-danli103

## Motivation

On ROCm, EAGLE verify silently ignores the requested temperature. 

In `eagle_sample`, `_is_hip` and `is_all_greedy` use the same path, so every HIP request takes the argmax branch — a workaround for the unregistered `tree_speculative_sampling_target_only` kernel that became a behaviour change with no error or warning.

Greedy then falls into repetition loops on open-ended tasks: on Simple-QA 1323 of 4326 requests (30.6%) end without a parseable answer, versus 39 (0.9%) once temperature is honoured — most of the 8.97-point gap below.

## Modifications

Add `select_target_predict()`, which returns the target model's own token at each verify position:
- feature disabled by default, or the request is greedy → `argmax(logits)` (unchanged behaviour)
- otherwise(enable by `SGLANG_SPEC_TEMPERATURE_SAMPLING_TARGET_VERIFY`, **hip gated**) → `y ~ softmax(logits / temperature)`

`verify_tree_greedy_func` accepts a draft token only when it equals this choice, so the committed token is always the target's own — argmax reproduces greedy exactly, sampling reproduces temperature sampling exactly. Draft probabilities are never used. 

Gated by `SGLANG_SPEC_TEMPERATURE_SAMPLING_TARGET_VERIFY` (default off) and `_is_hip`; other backends(nv) unchanged. `top_p`/`top_k` fall back to argmax with a warning (renorm ops unregistered on ROCm). Accept length stays at 2.5+/4.


## Accuracy Tests

| Benchmark | Official | MTP314 (target greedy) | Gap to official (target greedy) | MTP314 (target temp sampling) | Gap to official (target temp sampling) | Gain |
|---|---:|---:|---:|---:|---:|---:|
| GSM8K (1319) | 92.6 | 96.51 | −3.91 | 96.97 | −4.37 | +0.46 |
| AA-LCR (100) | 66.3 | 70.00 | −3.70 | 75.00 | −8.70 | +5.00 |
| GPQA-Diamond (198) | 90.1 | 84.34 | 5.76 | 87.88 | 2.22 | +3.54 |
| Simple-QA (4326) | 57.9 | 48.61 | 9.29 | 57.58 | 0.32 | **+8.97** |
| LiveCodeBench (1055) | 93.5 | 87.20 | 6.30 | 91.09 | 2.41 | +3.89 |
| MMLU-Pro (12032) | 87.5 | 86.34 | 1.16 | 87.41 | 0.09 | +1.07 |
| HLE (2158) | 37.7 | 30.26 | 7.44 | 33.78 | 3.92 | +3.52 |

Official data copy from: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro
Gap to official (target greedy) = Official - MTP314 (target greedy)
Gap to official (target temp sampling) = Official - MTP314 (target temp sampling)
These data measured on gfx950.

## Speed Tests and Profiling

No significant performance difference between two different sampling way.
metric | greedy sample by default | enable this PR by `SGLANG_SPEC_TEMPERATURE_SAMPLING_TARGET_VERIFY=1` | Δ
-- | -- | -- | --
Total token throughput (tok/s) | 14199.94 | 14090.88 | −0.77%
Accept length | 2.8633 | 2.8485 | −0.52%
Mean TTFT (ms) | 1994.81 | 1994.83 | +0.00%
Mean TPOT (ms) | 17.76 | 17.90 | +0.79%
Mean ITL (ms) | 17.76 | 17.90 | +0.79%

## Server command
```
SPEC=${SPEC:-MTP}
case "${SPEC}" in
    DSPARK)
        echo "SPEC=DSPARK: DSpark is enabled"
        MODEL=${MODEL:-/mnt/raid0/pretrained_model/deepseek-ai/DeepSeek-V4-Pro-DSpark}
        export SGLANG_RAGGED_VERIFY_MODE=${SGLANG_RAGGED_VERIFY_MODE:-static}
        export SGLANG_DSPARK_ENABLE_SPS_ONLINE_PROFILE=${SGLANG_DSPARK_ENABLE_SPS_ONLINE_PROFILE:-0}
        SPEC_ARGS="--speculative-algorithm DSPARK --speculative-dspark-block-size 5"
        if [ -n "${SPS_TABLE}" ]; then
            SPEC_ARGS="${SPEC_ARGS} --speculative-dspark-sps-table-path ${SPS_TABLE}"
        fi
        ;;
    MTP)
        echo "SPEC=MTP: MTP is enabled"
        MODEL=${MODEL:-/mnt/data/pretrained_model/deepseek-ai/DeepSeek-V4-Pro}
        MTP_NUM_STEPS=${MTP_NUM_STEPS:-3}
        MTP_TOPK=${MTP_TOPK:-1}
        MTP_NUM_DRAFT_TOKENS=${MTP_NUM_DRAFT_TOKENS:-4}
        SPEC_ARGS="--speculative-algorithm EAGLE --speculative-num-steps ${MTP_NUM_STEPS} --speculative-eagle-topk ${MTP_TOPK} --speculative-num-draft-tokens ${MTP_NUM_DRAFT_TOKENS}"
        ;;
    None|NONE|none)
        echo "SPEC=None: speculative decoding is disabled"
        MODEL=${MODEL:-/mnt/data/pretrained_model/deepseek-ai/DeepSeek-V4-Pro}
        unset SGLANG_RAGGED_VERIFY_MODE
        SPEC_ARGS=""
        ;;
    *)
        echo "Unsupported SPEC=${SPEC}. Expected one of: DSPARK, MTP, None"
        exit 1
        ;;
esac

TBO_ARGS=""
[ "${TBO:-0}" = "1" ] && TBO_ARGS="--enable-two-batch-overlap"

echo "MODEL: ${MODEL}"
echo "SPEC: ${SPEC}"
echo "SPEC_ARGS: ${SPEC_ARGS}"
echo "SGLANG_RAGGED_VERIFY_MODE: ${SGLANG_RAGGED_VERIFY_MODE}"
echo "SGLANG_SPEC_TEMPERATURE_SAMPLING_TARGET_VERIFY: ${SGLANG_SPEC_TEMPERATURE_SAMPLING_TARGET_VERIFY:-<unset>}"
echo "TBO_ARGS: ${TBO_ARGS}"

SGLANG_USE_ROCM700A=0 \
TORCH_BLAS_PREFER_HIPBLASLT=1 \
SGLANG_SHARED_EXPERT_TP1=1 \
SGLANG_DP_SHARED_EXPERT_LOCAL=1 \
SGLANG_DP_USE_GATHERV=1 \
SGLANG_DP_USE_REDUCE_SCATTER=1 \
SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton \
AITER_BF16_FP8_MOE_BOUND=0 \
SGLANG_OPT_USE_AITER_BATCHED_GEMM=true \
sglang serve \
  --trust-remote-code \
  --model-path ${MODEL} \
  --tp 8 \
  --dp 8 \
  --enable-dp-attention \
  --enable-dp-attention-local-control-broadcast \
  --tokenizer-worker-num 8 \
  --stream-interval 20 \
  --prefill-decode-interval 10 \
  ${TBO_ARGS} \
  --attention-backend dsv4 \
  --page-size 256 \
  --mem-fraction-static 0.9 \
  --swa-full-tokens-ratio 0.15 \
  --enforce-shared-experts-fusion \
  --kv-cache-dtype fp8_e4m3 \
  --chunked-prefill-size 65536 \
  --enable-dp-lm-head \
  --tool-call-parser deepseekv4 \
  --reasoning-parser deepseek-v4 \
  --disable-radix-cache \
  --disable-custom-all-reduce \
  ${SPEC_ARGS} \
  --host 0.0.0.0 \
  --port 30000 \
  ${EXTRA_ARGS:-}

```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.






<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34818468430](https://github.com/sgl-project/sglang/actions/runs/34818468430)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34818468496](https://github.com/sgl-project/sglang/actions/runs/34818468496)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34818468812](https://github.com/sgl-project/sglang/actions/runs/34818468812)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->