### PR TITLE
[Fix] Load pack-quantized fc weights for DFlash2 drafts (#39087)

### DIFF
--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -564,7 +564,9 @@ class DFlashDraftModel(nn.Module):
 
     The checkpoint provides:
       - transformer weights for `layers.*`
-      - `fc.weight`, `hidden_norm.weight` for projecting target context features
+      - `fc` weights (dense `fc.weight`, or pack-quantized `fc.weight_packed` /
+        `fc.weight_scale` / `fc.weight_shape`) and `hidden_norm.weight` for
+        projecting target context features
       - `norm.weight` for final normalization
     """
 
@@ -638,19 +640,20 @@ class DFlashDraftModel(nn.Module):
         num_context_features = len(target_layer_ids)
 
         self.num_context_features = int(num_context_features)
-        if self.is_nemotron_35_draft:
-            fc_prefix = f"{prefix}.fc" if prefix else "fc"
-            self.fc = ReplicatedLinear(
-                self.num_context_features * hidden_size,
-                hidden_size,
-                bias=False,
-                quant_config=quant_config,
-                prefix=fc_prefix,
-            )
-        else:
-            self.fc = nn.Linear(
-                self.num_context_features * hidden_size, hidden_size, bias=False
-            )
+        # fc is replicated across TP ranks: its input (the concatenated target
+        # context features) and output (the draft hidden state) are both full
+        # tensors. Use a quantization-aware linear so pack-quantized checkpoints
+        # (e.g. compressed-tensors W4A16, which stores fc.weight_packed /
+        # fc.weight_scale / fc.weight_shape) are loadable; a plain nn.Linear only
+        # exposes fc.weight and silently drops those keys.
+        fc_prefix = f"{prefix}.fc" if prefix else "fc"
+        self.fc = ReplicatedLinear(
+            self.num_context_features * hidden_size,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=fc_prefix,
+        )
         self.hidden_norm = RMSNorm(hidden_size, eps=rms_norm_eps)
 
         # The model loader calls load_weights() before set_block_size(). Build
@@ -708,9 +711,7 @@ class DFlashDraftModel(nn.Module):
 
     def project_target_hidden(self, target_hidden: torch.Tensor) -> torch.Tensor:
         """Project concatenated target-layer hidden states into draft hidden_size."""
-        expected = int(
-            self.fc.input_size if self.is_nemotron_35_draft else self.fc.in_features
-        )
+        expected = int(self.fc.input_size)
         if target_hidden.ndim != 2 or int(target_hidden.shape[-1]) != expected:
             raise ValueError(
                 "DFLASH target_hidden feature dim mismatch. "
@@ -720,9 +721,7 @@ class DFlashDraftModel(nn.Module):
                 "This usually means the target model is capturing a different number of layer features than "
                 "the draft checkpoint/config expects."
             )
-        projected = self.fc(target_hidden)
-        if self.is_nemotron_35_draft:
-            projected = projected[0]
+        projected = self.fc(target_hidden)[0]
         return self.hidden_norm(projected)
 
     @torch.no_grad()
@@ -827,24 +826,19 @@ class DFlashDraftModel(nn.Module):
                     continue
                 param = params_dict[resolved_name]
                 if resolved_name.endswith("fc.weight"):
-                    if self.is_nemotron_35_draft:
-                        expected_shape = (
-                            int(self.config.hidden_size),
-                            int(self.num_context_features * self.config.hidden_size),
-                        )
-                        loaded_shape = _logical_linear_weight_shape(
-                            param,
-                            loaded_weight,
-                            output_features=expected_shape[0],
-                        )
-                        shape_matches = loaded_shape == expected_shape or (
-                            getattr(param, "pack_factor", None) is None
-                            and tuple(loaded_weight.shape) == tuple(param.shape)
-                        )
-                    else:
-                        expected_shape = tuple(param.shape)
-                        loaded_shape = tuple(loaded_weight.shape)
-                        shape_matches = loaded_shape == expected_shape
+                    expected_shape = (
+                        int(self.config.hidden_size),
+                        int(self.num_context_features * self.config.hidden_size),
+                    )
+                    loaded_shape = _logical_linear_weight_shape(
+                        param,
+                        loaded_weight,
+                        output_features=expected_shape[0],
+                    )
+                    shape_matches = loaded_shape == expected_shape or (
+                        getattr(param, "pack_factor", None) is None
+                        and tuple(loaded_weight.shape) == tuple(param.shape)
+                    )
                     if not shape_matches:
                         raise ValueError(
                             "DFLASH fc.weight shape mismatch. This usually means the draft checkpoint's "
@@ -958,9 +952,7 @@ class DFlashLagunaForCausalLM(DFlashDraftModel):
         return layer.input_layernorm(ctx_hidden)
 
     def project_target_hidden(self, target_hidden: torch.Tensor) -> torch.Tensor:
-        expected = int(
-            self.fc.input_size if self.is_nemotron_35_draft else self.fc.in_features
-        )
+        expected = int(self.fc.input_size)
         if target_hidden.ndim != 2 or int(target_hidden.shape[-1]) != expected:
             raise ValueError(
                 "Laguna DFLASH target_hidden feature dim mismatch. "
@@ -972,16 +964,14 @@ class DFlashLagunaForCausalLM(DFlashDraftModel):
         num_slices = int(self.num_context_features)
         slice_size = int(target_hidden.shape[-1]) // num_slices
         slices = target_hidden.view(target_hidden.shape[0], num_slices, slice_size)
-        compute_dtype = self.fc.weight.dtype
+        compute_dtype = self.fc.params_dtype
         if slices.dtype != compute_dtype:
             slices = slices.to(compute_dtype)
         normed = torch.empty_like(slices)
         for i, norm in enumerate(self.aux_hidden_norms):
             normed[:, i, :] = norm(slices[:, i, :])
         fused = normed.reshape(target_hidden.shape[0], -1)
-        projected = self.fc(fused)
-        if self.is_nemotron_35_draft:
-            projected = projected[0]
+        projected = self.fc(fused)[0]
         return self.hidden_norm(projected)
 
 

--- a/test/registered/unit/models/test_dflash_quantized.py
+++ b/test/registered/unit/models/test_dflash_quantized.py
@@ -1,0 +1,192 @@
+"""Pack-quantized (compressed-tensors W4A16) DFlash drafts must load `fc`.
+
+The draft's target-context projection `fc` used to be a plain `nn.Linear`,
+whose only parameter is `fc.weight`. A checkpoint that stores `fc`
+pack-quantized (`fc.weight_packed` / `fc.weight_scale` / `fc.weight_shape`)
+dropped all three keys silently, leaving `fc` at random init; the draft then
+proposed near-random tokens and acceptance collapsed to the bonus token.
+
+These tests pin `fc` to a quantization-aware linear so both dense
+(`fc.weight`) and pack-quantized checkpoints load into it, and that a wrong
+number of context features still fails loudly instead of loading silently.
+"""
+
+import unittest
+
+import torch
+from transformers import PretrainedConfig
+
+from sglang.srt.layers.linear import ReplicatedLinear
+from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+    CompressedTensorsLinearMethod,
+)
+from sglang.srt.models.dflash import DFlash2DraftModel
+from sglang.srt.runtime_context import get_parallel
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+
+# Small stand-in for a real DFlash2 draft checkpoint (e.g. the 5-layer,
+# hidden-5120, 5-context-feature Qwen DFlash2 export): 2 layers, hidden 128,
+# 4 target-layer features, packed 4-bit group-128 symmetric weights.
+DRAFT_CONFIG = {
+    "architectures": ["DFlash2DraftModel"],
+    "attention_bias": False,
+    "attention_dropout": 0.0,
+    "is_causal": False,
+    "dflash_config": {
+        "block_size": 8,
+        "conv_group_size": 16,
+        "conv_kernel_size": 2,
+        "mask_token_id": 1,
+        "selector_rank": 16,
+        "selector_top_k": 4,
+        "target_layer_ids": [0, 1, 2, 3],
+    },
+    "dtype": "bfloat16",
+    "eos_token_id": 2,
+    "head_dim": 16,
+    "hidden_act": "silu",
+    "hidden_size": 128,
+    "initializer_range": 0.02,
+    "intermediate_size": 256,
+    "layer_types": ["sliding_attention", "sliding_attention"],
+    "max_position_embeddings": 262144,
+    "max_window_layers": 2,
+    "model_type": "qwen3",
+    "num_attention_heads": 8,
+    "num_hidden_layers": 2,
+    "num_key_value_heads": 2,
+    "num_target_layers": 4,
+    "pad_token_id": 2,
+    "rms_norm_eps": 1e-6,
+    "rope_parameters": {"rope_theta": 10000000, "rope_type": "default"},
+    "sliding_window": 2048,
+    "tie_word_embeddings": False,
+    "use_cache": True,
+    "use_sliding_window": True,
+    "vocab_size": 64,
+}
+
+# Mirrors the published pack-quantized W4A16 compressed-tensors config.
+QUANT_CONFIG = {
+    "config_groups": {
+        "group_0": {
+            "format": "pack-quantized",
+            "input_activations": None,
+            "output_activations": None,
+            "targets": ["Linear"],
+            "weights": {
+                "actorder": None,
+                "block_structure": None,
+                "dynamic": False,
+                "group_size": 128,
+                "num_bits": 4,
+                "observer": "memoryless_minmax",
+                "observer_kwargs": {},
+                "scale_dtype": None,
+                "strategy": "group",
+                "symmetric": True,
+                "type": "int",
+                "zp_dtype": None,
+            },
+        }
+    },
+    "format": "pack-quantized",
+    "global_compression_ratio": None,
+    "ignore": [
+        "re:.*kernel_projection$",
+        "re:.*candidate_selector.*",
+        "re:.*hidden_projection$",
+    ],
+    "kv_cache_scheme": None,
+    "quant_method": "compressed-tensors",
+    "quantization_status": "compressed",
+    "sparsity_config": {},
+    "transform_config": {},
+    "version": "0.17.0",
+}
+
+TP_OVERRIDE = dict(tp_size=1, tp_rank=0, attn_tp_size=1, attn_tp_rank=0)
+
+
+def _fc_in_out(model):
+    """(out_features, in_features) of the draft fc, for either a plain
+    nn.Linear (pre-quantization-support) or a quantization-aware linear."""
+    fc = model.fc
+    if isinstance(fc, torch.nn.Linear):
+        return fc.out_features, fc.in_features
+    return fc.output_size, fc.input_size
+
+
+class TestDFlashQuantizedFc(CustomTestCase):
+    def test_pack_quantized_fc_loads(self):
+        """The W4A16 regression: fc.weight_packed/_scale/_shape must land in fc."""
+        quant_config = CompressedTensorsConfig.from_config(dict(QUANT_CONFIG))
+        with get_parallel().override(**TP_OVERRIDE):
+            model = DFlash2DraftModel(
+                PretrainedConfig(**DRAFT_CONFIG),
+                quant_config=quant_config,
+                prefix="",
+            )
+
+        # fc must be quantization-aware; a plain nn.Linear has no packed
+        # parameters to receive the checkpoint's fc tensors.
+        self.assertIsInstance(model.fc, ReplicatedLinear)
+        self.assertIsInstance(model.fc.quant_method, CompressedTensorsLinearMethod)
+
+        out, inp = _fc_in_out(model)
+        packed = (torch.arange(out * (inp // 8), dtype=torch.int32) % 16).view(
+            out, inp // 8
+        )
+        # Scales ship fp16 in real checkpoints; loading must cast them in.
+        scale = (torch.rand(out, inp // 128, dtype=torch.float32) + 0.5).to(
+            torch.float16
+        )
+        shape = torch.tensor([out, inp], dtype=torch.int64)
+
+        model.load_weights(
+            iter(
+                [
+                    ("fc.weight_packed", packed),
+                    ("fc.weight_scale", scale),
+                    ("fc.weight_shape", shape),
+                ]
+            )
+        )
+
+        self.assertTrue(torch.equal(model.fc.weight_packed.data, packed))
+        self.assertTrue(torch.equal(model.fc.weight_scale.data.float(), scale.float()))
+        self.assertTrue(torch.equal(model.fc.weight_shape.data, shape))
+
+    def test_dense_fc_still_loads(self):
+        """BF16 drafts keep working: fc.weight loads unchanged."""
+        with get_parallel().override(**TP_OVERRIDE):
+            model = DFlash2DraftModel(
+                PretrainedConfig(**DRAFT_CONFIG),
+                quant_config=None,
+                prefix="",
+            )
+        out, inp = _fc_in_out(model)
+        weight = torch.randn(out, inp)
+        model.load_weights(iter([("fc.weight", weight)]))
+        self.assertTrue(torch.equal(model.fc.weight, weight))
+
+    def test_fc_shape_mismatch_raises(self):
+        """A wrong number of context features must fail loudly, not load."""
+        with get_parallel().override(**TP_OVERRIDE):
+            model = DFlash2DraftModel(
+                PretrainedConfig(**DRAFT_CONFIG),
+                quant_config=None,
+                prefix="",
+            )
+        out, inp = _fc_in_out(model)
+        bad = torch.randn(out, 3 * inp)
+        with self.assertRaisesRegex(ValueError, "fc.weight shape mismatch"):
+            model.load_weights(iter([("fc.weight", bad)]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #39087.

Pack-quantized DFlash2 draft checkpoints using `compressed-tensors` store the target-context projection `fc` as:

- `fc.weight_packed`
- `fc.weight_scale`
- `fc.weight_shape`

However, `DFlash2DraftModel` previously constructed `fc` as a plain `torch.nn.Linear`, which only exposes `fc.weight`.

As a result, the packed `fc` checkpoint tensors could not be resolved by `load_weights()` and were silently skipped. The `fc` layer therefore remained randomly initialized.

This does not prevent the model or server from starting, but causes the draft model to produce poor proposals. In the reported W4A16 DFlash2 case, speculative decoding acceptance collapses close to the bonus-token-only case.

## Modifications

This PR makes the DFlash2 target-context projection `fc` quantization-aware.

Main changes:

- Construct `fc` with SGLang's quantization-aware linear implementation when a quantization config is provided.
- Preserve the existing dense/BF16 loading path.
- Allow `compressed-tensors` pack-quantized checkpoints to correctly load:
  - `fc.weight_packed`
  - `fc.weight_scale`
  - `fc.weight_shape`
- Add explicit validation for incompatible dense `fc.weight` shapes instead of
  silently accepting an invalid checkpoint.
- Add CPU unit tests covering:
  - pack-quantized `fc` weight loading;
  - dense `fc.weight` loading;
  - invalid `fc.weight` shape handling.

The regression tests use small synthetic tensors and do not load real model checkpoints or launch a server.

## Accuracy Tests

The issue primarily affects speculative decoding acceptance rather than final target-model correctness. The target model still verifies generated tokens, but an incorrectly initialized draft `fc` causes most speculative tokens to be rejected.

The fixed W4A16 draft was compared with the BF16 reference draft under the same DFlash2 configuration:

- W4A16 draft: `syvai/Qwen3.8-27B-DFlash2-W4A16`
- BF16 reference draft: `incoai/Qwen3.8-27B-DFlash2`

| Metric | W4A16 Draft (After Fix) | incoai BF16 Draft |
| --- | ---: | ---: |
| Mean Accept Length | 3.23 | 3.25 |
| Median Accept Length | 3.36 | 3.30 |
| Accept Length Range | 2.27–4.10 | 2.12–4.05 |
| Mean Acceptance Rate | 0.32 | 0.31 |
| Median Acceptance Rate | 0.34 | 0.33 |
| Acceptance Rate Range | 0.18–0.44 | 0.16–0.44 |

After the fix, the W4A16 draft reaches essentially the same speculative acceptance behavior as the BF16 reference draft, indicating that the pack-quantized `fc` weights are now loaded correctly.

## Speed Tests and Profiling

Test hardware:
2 × NVIDIA RTX 3090
No NVLink

The fixed W4A16 draft was validated end-to-end with DFLASH speculative decoding enabled.
Runtime configuration:
Tensor parallel size:       2
Target model:               W4A16 AWQ / Marlin
Draft model:                W4A16 compressed-tensors
KV cache dtype:             FP8 E5M2
DFLASH block size:          8
Target verify CUDA graph:   enabled
Draft verify CUDA graph:    enabled
Max running requests:       2

After startup and warm-up, the quantized DFlash2 draft reached normal speculative acceptance. During sampled steady-state decode intervals for a code-generation workload, reported generation throughput ranged from approximately 86 to 260 tokens/s, depending strongly on the instantaneous acceptance length.
Example steady-state samples:
accept len: 3.45, accept rate: 0.35, gen throughput: 118.55 token/s
accept len: 5.10, accept rate: 0.59, gen throughput: 175.00 token/s
accept len: 6.88, accept rate: 0.84, gen throughput: 234.72 token/s
accept len: 7.72, accept rate: 0.96, gen throughput: 259.93 token/s

These values are sampled runtime statistics rather than a controlled before/after throughput benchmark. The primary performance regression criterion for this fix is the restoration of W4A16 speculative acceptance to the BF16 reference level.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations]  N/A — no user-facing behavior or API documentation changes. (https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34732620479](https://github.com/sgl-project/sglang/actions/runs/34732620479)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34732620367](https://github.com/sgl-project/sglang/actions/runs/34732620367)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34732620429](https://github.com/sgl-project/sglang/actions/runs/34732620429)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->