### PR TITLE
[CI] Make diffusion GT generation usable without the publish token, and cover the 5090 lane

### DIFF
--- a/.github/workflows/diffusion-ci-gt-gen.yml
+++ b/.github/workflows/diffusion-ci-gt-gen.yml
@@ -604,3 +604,73 @@ jobs:
           python scripts/ci/utils/diffusion/publish_diffusion_gt.py \
             --source-dir python/${{ env.OUTPUT_NAME }} \
             --target-dir "${{ env.PUBLISH_TARGET_DIR }}"
+
+  multimodal-diffusion-gen-5090:
+    # The 5090 canary suite is six cases; it is generated whole rather than
+    # partitioned, so it needs no entry in the partition plan.
+    needs: compute-diffusion-partitions
+    if: needs.compute-diffusion-partitions.result == 'success'
+    runs-on: 1-gpu-5090
+    timeout-minutes: 150
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Prepare AOT dist for prebuilt wheel
+        if: inputs.kernel_artifact_run_id != ''
+        run: |
+          ls -alh python/sglang/kernels/aot/dist || true
+          rm -rf python/sglang/kernels/aot/dist/* || true
+
+      - name: Download prebuilt sgl-kernel wheel
+        if: inputs.kernel_artifact_run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          path: python/sglang/kernels/aot/dist/
+          merge-multiple: true
+          name: wheel-python3.10-cuda13.0
+          run-id: ${{ inputs.kernel_artifact_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: |
+          CUSTOM_BUILD_SGL_KERNEL="${{ inputs.kernel_artifact_run_id != '' && 'true' || 'false' }}" \
+            bash scripts/ci/cuda/ci_install_dependency.sh diffusion
+
+      - name: Generate outputs
+        env:
+          RUNAI_STREAMER_MEMORY_LIMIT: 0
+        run: |
+          cd python
+          python -m sglang.multimodal_gen.test.scripts.gen_diffusion_ci_outputs \
+            --suite 1-gpu-5090 \
+            --out-dir ./${{ env.OUTPUT_NAME }} \
+            ${{ inputs.case_ids != '' && format('--case-ids {0}', inputs.case_ids) || '' }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.OUTPUT_NAME }}-5090
+          path: python/${{ env.OUTPUT_NAME }}
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Validate generated GT images
+        env:
+          GITHUB_TOKEN: ${{ inputs.publish && secrets.GH_PAT_FOR_NIGHTLY_CI_DATA || github.token }}
+        run: |
+          python scripts/ci/utils/diffusion/publish_diffusion_gt.py \
+            --source-dir python/${{ env.OUTPUT_NAME }} \
+            --target-dir "${{ env.PUBLISH_TARGET_DIR }}" \
+            --check-only
+
+      - name: Publish GT images to sgl-project/ci-data-diffusion
+        if: ${{ inputs.publish }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+        run: |
+          python scripts/ci/utils/diffusion/publish_diffusion_gt.py \
+            --source-dir python/${{ env.OUTPUT_NAME }} \
+            --target-dir "${{ env.PUBLISH_TARGET_DIR }}"

--- a/.github/workflows/diffusion-ci-gt-gen.yml
+++ b/.github/workflows/diffusion-ci-gt-gen.yml
@@ -48,6 +48,11 @@ on:
         required: false
         default: 'main'
         type: string
+      publish:
+        description: 'Publish the generated GT to sgl-project/ci-data-diffusion. false only uploads the run artifacts, which needs no GH_PAT_FOR_NIGHTLY_CI_DATA.'
+        required: false
+        default: true
+        type: boolean
 
 concurrency:
   group: diffusion-ci-gt-gen-${{ github.ref }}-${{ inputs.output_name || inputs.case_ids || inputs.official_case_ids || inputs.official_source_group || inputs.run_official_cases || 'default' }}
@@ -73,6 +78,7 @@ jobs:
       case-count: ${{ steps.compute.outputs.case-count }}
     steps:
       - name: Verify write access to sgl-project/ci-data-diffusion
+        if: ${{ inputs.publish }}
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
         run: |
@@ -307,7 +313,7 @@ jobs:
 
       - name: Validate generated GT images
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_TOKEN: ${{ inputs.publish && secrets.GH_PAT_FOR_NIGHTLY_CI_DATA || github.token }}
         run: |
           python scripts/ci/utils/diffusion/publish_diffusion_gt.py \
             --source-dir python/${{ env.OUTPUT_NAME }} \
@@ -315,6 +321,7 @@ jobs:
             --check-only
 
       - name: Publish official GT images to sgl-project/ci-data-diffusion
+        if: ${{ inputs.publish }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
         run: |
@@ -347,6 +354,7 @@ jobs:
           python-version: '3.10'
 
       - name: Verify write access to sgl-project/ci-data-diffusion
+        if: ${{ inputs.publish }}
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
         run: |
@@ -427,7 +435,7 @@ jobs:
 
       - name: Validate generated GT images
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_TOKEN: ${{ inputs.publish && secrets.GH_PAT_FOR_NIGHTLY_CI_DATA || github.token }}
         run: |
           python scripts/ci/utils/diffusion/publish_diffusion_gt.py \
             --source-dir python/${{ env.OUTPUT_NAME }} \
@@ -435,6 +443,7 @@ jobs:
             --check-only
 
       - name: Publish GT images to sgl-project/ci-data-diffusion
+        if: ${{ inputs.publish }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
         run: |
@@ -504,7 +513,7 @@ jobs:
 
       - name: Validate generated GT images
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_TOKEN: ${{ inputs.publish && secrets.GH_PAT_FOR_NIGHTLY_CI_DATA || github.token }}
         run: |
           python scripts/ci/utils/diffusion/publish_diffusion_gt.py \
             --source-dir python/${{ env.OUTPUT_NAME }} \
@@ -512,6 +521,7 @@ jobs:
             --check-only
 
       - name: Publish GT images to sgl-project/ci-data-diffusion
+        if: ${{ inputs.publish }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
         run: |
@@ -579,7 +589,7 @@ jobs:
 
       - name: Validate generated GT images
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_TOKEN: ${{ inputs.publish && secrets.GH_PAT_FOR_NIGHTLY_CI_DATA || github.token }}
         run: |
           python scripts/ci/utils/diffusion/publish_diffusion_gt.py \
             --source-dir python/${{ env.OUTPUT_NAME }} \
@@ -587,6 +597,7 @@ jobs:
             --check-only
 
       - name: Publish GT images to sgl-project/ci-data-diffusion
+        if: ${{ inputs.publish }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
         run: |


### PR DESCRIPTION
## Motivation

Two gaps in `diffusion-ci-gt-gen.yml` that both showed up while regenerating video references for #38657.

**1. Generation is gated on push access.** The workflow starts by requiring `GH_PAT_FOR_NIGHTLY_CI_DATA` to have push access to `sgl-project/ci-data-diffusion`, otherwise the run fails before a single case is generated. That token currently returns `401 Bad credentials` ([run 34732343241](https://github.com/sgl-project/sglang/actions/runs/34732343241); the last run to get past the gate was 2026-09-01), so no reference can be produced at all — even though every generated image is already uploaded as a run artifact and a maintainer with write access can commit those directly. The same secret is used by `nightly-test-nvidia.yml`, `ci-auto-bisect.yml` and `ci-failure-monitor.yml`, so it needs rotating regardless; this just stops generation from depending on it.

**2. The 5090 lane has no generator.** `pr-test` runs a six-case canary suite on a 5090 (`multimodal-gen-test-1-5090`, suite `1-gpu-5090`) and compares it against references under `consistency_gt/sglang_generated/5090/`, which `get_consistency_platform()` and the per-platform publish path already resolve. But no job generated them, so that directory could only be filled by hand.

## Modifications

- New `workflow_dispatch` input `publish` (boolean, default `true`). With `publish=false` the two "Verify write access" steps and all four "Publish … to sgl-project/ci-data-diffusion" steps are skipped; generation, artifact upload and validation run unchanged. "Validate generated GT images" reads the remote tree to compare against existing references, so it uses `github.token` when not publishing and the PAT as before when publishing.
- New `multimodal-diffusion-gen-5090` job on `1-gpu-5090`. The suite is six cases, so it generates whole instead of through the partition plan — the partitioner and its AST case parser are untouched (they cannot enumerate `ONE_GPU_5090_CASES`, which is built by `_select_5090_canary_cases(...)` plus two factory appends rather than literals). `--case-ids` filtering still applies, and the generator exits cleanly when none of the requested cases belong to this suite.

Default behaviour (`publish=true`, no `case_ids`) is unchanged apart from the added lane.

## Usage

```bash
gh workflow run diffusion-ci-gt-gen.yml --ref main -f publish=false \
  -f ref=refs/pull/<N>/head -f output_name=<short-name> -f case_ids="case_a case_b"
```

then download the `<short-name>-{1gpu,2gpu,b200,5090}` artifacts and commit them to `ci-data-diffusion`.

`output_name` is worth passing whenever `case_ids` is long: the concurrency group is `output_name || case_ids || …`, and a long case list makes the run fail at the workflow level with "workflow file issue" — that is what [run 34732271282](https://github.com/sgl-project/sglang/actions/runs/34732271282) was.

## Tests

Exercised end to end by [run 34732920643](https://github.com/sgl-project/sglang/actions/runs/34732920643) (`publish=false`, 38 cases): the write-access check was skipped, all nine generation jobs produced and uploaded their artifacts, and validation ran against the remote with the workflow token. The 5090 job is new in this PR and has not run yet.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34735623418](https://github.com/sgl-project/sglang/actions/runs/34735623418)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34735623171](https://github.com/sgl-project/sglang/actions/runs/34735623171)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->