### PR TITLE
fix: derive compact ragged CUDA graph slots from request width

### DIFF
--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -582,9 +582,13 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         return not draft_is_deepseek_v4()
 
     def _ragged_capture_slots(self, num_tokens: int) -> int:
-        if envs.SGLANG_TEST_RAGGED_VERIFY_FORCE_UNIFORM_CAPTURE.get():
-            return num_tokens // self.captured_req_width
-        return min(num_tokens, self.max_bs)
+        # Token tiers are built as capture_bs * captured_req_width. Preserve
+        # that request geometry for capture, replay padding and admission.
+        assert num_tokens % self.captured_req_width == 0, (
+            f"ragged token tier {num_tokens} is not divisible by "
+            f"captured request width {self.captured_req_width}"
+        )
+        return num_tokens // self.captured_req_width
 
     def _capture_ragged_verify_layout(self, num_tokens: int):
         if not self.ragged_verify_mode:

--- a/test/registered/unit/model_executor/runner/test_decode_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/runner/test_decode_cuda_graph_runner.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``DecodeCudaGraphRunner`` capture-phase profiling — CPU-only.
+"""CPU tests for ``DecodeCudaGraphRunner`` profiling and ragged capture geometry.
 
 Two capture-trace modes plus their precedence:
 
@@ -28,10 +28,13 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
+import torch
+
 from sglang.srt.model_executor.runner import decode_cuda_graph_runner as mod
 from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
     DecodeCudaGraphRunner,
 )
+from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
 from sglang.srt.utils import profile_utils as putils
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -291,6 +294,111 @@ class TestOriginalTraceExport(CustomTestCase):
                     putils.graph_capture_profile_dir(),
                     os.path.join(tmp, "graph_capture_profile"),
                 )
+
+
+class TestRaggedVerifyCaptureGeometry(CustomTestCase):
+    """Capture, admission and staging must agree on each token tier's rows."""
+
+    def setUp(self):
+        super().setUp()
+        patcher = mock.patch.dict(
+            os.environ, {"SGLANG_TEST_RAGGED_VERIFY_FORCE_UNIFORM_CAPTURE": "0"}
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _runner(self, capture_bs, width):
+        runner = SimpleNamespace(
+            capture_bs=capture_bs,
+            captured_req_width=width,
+            max_bs=max(capture_bs),
+            ragged_verify_mode=True,
+            device=torch.device("cpu"),
+            _captured_ragged_layouts={},
+            attn_backend=SimpleNamespace(supports_ragged_verify_graph=True),
+            require_mlp_sync=False,
+            is_encoder_decoder=False,
+            capture_hidden_mode=0,
+        )
+        for name in (
+            "_build_ragged_verify_token_buckets",
+            "_ragged_capture_slots",
+            "_capture_ragged_verify_layout",
+            "_stage_ragged_verify_layout",
+            "_can_run_ragged_verify_graph",
+        ):
+            setattr(runner, name, getattr(DecodeCudaGraphRunner, name).__get__(runner))
+        runner.capture_num_tokens = runner._build_ragged_verify_token_buckets()
+        return runner
+
+    def _admitted(self, runner, layout):
+        batch = SimpleNamespace(batch_size=layout.bs, capture_hidden_mode=0)
+        return runner._can_run_ragged_verify_graph(batch, layout)
+
+    def test_42_token_tier_has_seven_complete_requests(self):
+        runner = self._runner([1, 2, 4, 7, 8], width=6)
+        layout = runner._capture_ragged_verify_layout(42)
+        self.assertIsNotNone(layout)
+        self.assertEqual(layout.verify_lens.tolist(), [6] * 7)
+        self.assertEqual(layout.bs, 7)
+        self.assertEqual(layout.total_verify_tokens, 42)
+        self.assertEqual(layout.qo_indptr_device.tolist(), list(range(0, 43, 6)))
+
+    def test_capture_tiers_preserve_request_geometry(self):
+        for width in (1, 2, 6, 8):
+            runner = self._runner([1, 2, 4, 7, 8], width=width)
+            for bs, tier in zip(runner.capture_bs, runner.capture_num_tokens):
+                with self.subTest(bs=bs, width=width, tier=tier):
+                    layout = runner._capture_ragged_verify_layout(tier)
+                    self.assertEqual(layout.bs, bs)
+                    self.assertEqual(layout.verify_lens.tolist(), [width] * bs)
+                    self.assertEqual(int(layout.verify_lens.sum()), tier)
+                    self.assertEqual(int(layout.qo_indptr_device[-1]), tier)
+
+    def test_historical_192_token_capture_matches_uniform_replay(self):
+        runner = self._runner([1, 32, 192], width=6)
+        capture = runner._capture_ragged_verify_layout(192)
+        live = RaggedVerifyLayout.from_verify_lens(
+            verify_lens_cpu=[6] * 32,
+            device=runner.device,
+            grid=runner.capture_num_tokens,
+        )
+        self.assertTrue(self._admitted(runner, live))
+        captured_lens = capture.verify_lens.clone()
+        runner._stage_ragged_verify_layout(live, live.graph_num_tokens)
+        self.assertEqual(capture.verify_lens.tolist(), captured_lens.tolist())
+        self.assertEqual(capture.verify_lens.tolist(), [6] * 32)
+
+    def test_rejects_more_requests_than_captured_tier_can_hold(self):
+        runner = self._runner([1, 32, 192], width=6)
+        live = RaggedVerifyLayout.from_verify_lens(
+            verify_lens_cpu=[5] * 33,
+            device=runner.device,
+            grid=runner.capture_num_tokens,
+        )
+        self.assertEqual(live.graph_num_tokens, 192)
+        self.assertFalse(self._admitted(runner, live))
+
+    def test_replay_padding_preserves_capture_buffers(self):
+        runner = self._runner([1, 2, 4, 8], width=6)
+        capture = runner._capture_ragged_verify_layout(48)
+        lens_ptr = capture.verify_lens.data_ptr()
+        indptr_ptr = capture.qo_indptr_device.data_ptr()
+        for lens in ([6] * 7, [6, 6, 6, 6, 6, 6, 1, 6]):
+            with self.subTest(verify_lens=lens):
+                live = RaggedVerifyLayout.from_verify_lens(
+                    verify_lens_cpu=lens,
+                    device=runner.device,
+                    grid=runner.capture_num_tokens,
+                )
+                self.assertEqual(live.graph_num_tokens, 48)
+                self.assertTrue(self._admitted(runner, live))
+                runner._stage_ragged_verify_layout(live, 48)
+                expected = lens + [6] * (8 - len(lens))
+                self.assertEqual(capture.verify_lens.tolist(), expected)
+                self.assertEqual(int(capture.qo_indptr_device[-1]), sum(expected))
+                self.assertEqual(capture.verify_lens.data_ptr(), lens_ptr)
+                self.assertEqual(capture.qo_indptr_device.data_ptr(), indptr_ptr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Compact ragged target-verify capture uses the wrong request geometry below the largest CUDA graph tier. Reproduced on upstream main `18cc55dc0b2f6a5133bdde61f0ac8c02c8e3d17d`:

```text
42 tokens, captured_req_width=6, max_bs=8
expected: 7 requests, verify_lens=[6,6,6,6,6,6,6]
actual:   8 requests, verify_lens=[6,6,5,5,5,5,5,5]
```

Buckets are generated as `capture_bs * captured_req_width`, but `_ragged_capture_slots` currently uses `min(num_tokens, max_bs)`. This also reproduces the historical 192-token capture/replay mismatch in #34384.

## Modifications

Derive each tier's slots from its captured request width and assert divisibility. The constructor's positive bucket check already requires a positive width. Current compact layout producers select from the runner's width-based grid; non-ragged graph paths do not use this helper.

Keep the ragged capture layout and existing replay padding/staging. Physical buffer capacities are unchanged. The existing admission gate rejects batches exceeding the selected tier's request capacity; low-fraction, high-request-count workloads can consequently fall back to eager. Supporting additional request geometries per token tier is outside this correction. There are no model-specific branches, allocations or device synchronizations in the fix.

CPU regressions exercise the actual capture layout, admission and staging methods: the 42-token case, batch sizes 1/2/4/7/8 at widths 1/2/6/8, the historical 32×6 tier, rejection of 33×5 requests at that tier, and padding with stable capture-buffer addresses.

## Accuracy Tests

Python 3.12.13, PyTorch 2.13.0+cpu, Linux/WSL:

```bash
export PYTHONPATH=python
python -m pytest -q --tb=short test/registered/unit/model_executor/runner/test_decode_cuda_graph_runner.py -k RaggedVerifyCaptureGeometry
# Before fix: 15 failed (including subtest failures), 2 passed;
# the 42-token case produces exactly the eight-row list above.

python -m pytest -q --tb=short test/registered/unit/model_executor/runner/test_decode_cuda_graph_runner.py test/registered/spec/dspark/test_ragged_verify.py test/registered/unit/model_executor/runner/test_decode_cuda_graph_shared_read_fence.py
# After fix: 31 passed, 22 subtests passed.

python -m pytest -q --tb=short test/registered/unit/model_executor/runner test/registered/spec/dspark \
  --ignore=test/registered/spec/dspark/test_ragged_verify_backend_capability.py \
  --ignore=test/registered/spec/dspark/test_dspark_kernel_parity.py \
  --ignore=test/registered/spec/dspark/test_dspark_stacked_ctx_kv_parity.py
# 190 passed, 2 CUDA-dependent skips, 54 subtests passed.

python -m pytest -q --tb=short test/registered/unit/layers/test_dsv4_nonpaged_indexer.py test/registered/unit/mem_cache/test_dsv4_compress_write_pad.py
# 13 passed, 20 subtests passed.
```

A model-free CPU probe using the imported DSV4 metadata methods succeeds on the corrected normal path. Request/sequence buffers are exact-range aliases; existing `copy_` handles them. A forced-uniform negative control reproduces partial overlap through request-keyed capture versus token-keyed replay. No metadata change is included.

A separate RTX A4500 probe (PyTorch 2.8.0+cu128, CUDA 12.8) passed six CUDA graph captures and seven replays, including mixed lengths and bucket padding, using the real ragged Triton kernels and isolated source units for runner/DSV4 metadata methods. It reproduced the same forced-uniform negative control. This is a buffer/layout micro-test, not full attention or model validation. Current main lacks the reporter's Engram implementation; DeepSeek-V4.1 / TP4 / EP4 / DGX Spark validation remains outstanding.

Ruff formatting and F401/F821/UP037 checks, isort, registered-test validation, the pytest-entrypoint check, and `git diff --check` pass for the changed files.

## Speed Tests and Profiling

No throughput benchmark or full-model accuracy run. The narrower admission capacity and potential eager fallback are described above.

## Related

Addresses #39173. Related: #34384. Revives the geometry correction previously proposed in the closed, unmerged #34636, with regressions using real layout/padding code rather than a padding mirror.
