### PR TITLE
[NPU] L2 cache offload overlap

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
@@ -698,6 +698,7 @@ class NPUMLATokenToKVPool(MLATokenToKVPool):
     def get_kv_buffer(self, layer_id: int):
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
+            self.layer_transfer_counter.consume_layer(layer_id - self.start_layer)
         self._raise_if_native_kv_cache_disabled()
         return (
             self.k_buffer[layer_id - self.start_layer],

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -77,6 +77,10 @@ class LayerDoneCounter:
         self.events = [LayerLoadingEvent(num_layers) for _ in range(self.num_counters)]
         self.producer_index = -1
         self.consumer_index = -1
+        # Callback invoked after a layer's wait resolves, to trigger
+        # on-demand prefetch of the next layer on the load stream.
+        self.on_layer_consumed: Optional[Callable] = None
+        self._last_consumed_layer: int = -1
 
     def update_producer(self):
         self.producer_index = (self.producer_index + 1) % self.num_counters
@@ -87,15 +91,31 @@ class LayerDoneCounter:
 
     def set_consumer(self, index: int):
         self.consumer_index = index
+        self._last_consumed_layer = -1
 
     def wait_until(self, threshold: int):
         if self.consumer_index < 0:
             return
         self.events[self.consumer_index].wait(threshold)
 
+    def consume_layer(self, threshold: int):
+        if self.consumer_index < 0:
+            return
+        if self.on_layer_consumed is not None and threshold > self._last_consumed_layer:
+            self._last_consumed_layer = threshold
+            self.on_layer_consumed(threshold + 1)
+
+    def wait_for_prefetch(self, layer_id: int):
+        if self.consumer_index < 0:
+            return
+        if layer_id >= self.num_layers:
+            return
+        self.events[self.consumer_index].wait(layer_id)
+
     def reset(self):
         self.producer_index = -1
         self.consumer_index = -1
+        self._last_consumed_layer = -1
 
 
 class CacheOperation:
@@ -346,6 +366,7 @@ class HiCacheController:
         self.device = self.mem_pool_device.device
         self.layer_num = self.mem_pool_device.layer_num
         self.layer_done_counter = LayerDoneCounter(self.layer_num)
+        self.layer_done_counter.on_layer_consumed = self.trigger_layer_load
         self.mem_pool_device.register_layer_transfer_counter(self.layer_done_counter)
 
         if write_policy not in [
@@ -942,6 +963,8 @@ class HiCacheController:
         if len(self.load_queue) == 0:
             return -1
 
+        self._drain_pending_prefetch()
+
         producer_id = self.layer_done_counter.update_producer()
         op = CacheOperation.merge_ops(self.load_queue)
         host_indices, device_indices, pool_transfers = self._move_op_indices(op)
@@ -962,6 +985,7 @@ class HiCacheController:
             start_event=producer_event.start_event,
             on_layer_done=producer_event.complete,
             layer_num=self.layer_num,
+            on_demand=True,
         )
 
         self.ack_load_queue.append(
@@ -976,6 +1000,18 @@ class HiCacheController:
             )
         )
         return producer_id
+
+    def trigger_layer_load(self, layer_id: int) -> None:
+        handle = self.l2_transfer_engine.prefetch_handle
+        if handle is None:
+            return
+        handle.trigger_layer(layer_id)
+
+    def _drain_pending_prefetch(self) -> None:
+        handle = self.l2_transfer_engine.prefetch_handle
+        if handle is None:
+            return
+        handle.drain()
 
     def evict_device(self, device_indices: torch.Tensor) -> int:
         self.mem_pool_device_allocator.free(device_indices)

--- a/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
+++ b/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
@@ -377,6 +377,7 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
     def get_key_buffer(self, layer_id: int):
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
+            self.layer_transfer_counter.consume_layer(layer_id - self.start_layer)
 
         kv_buffer = self._get_broadcastable_kv_buffer(layer_id)
         if self.store_dtype != self.dtype:

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -137,6 +137,10 @@ class HybridCacheController(BaseHiCacheController):
         if transfer_layer_num is not None and transfer_layer_num != self.layer_num:
             self.layer_num = transfer_layer_num
             self.layer_done_counter = LayerDoneCounter(self.layer_num)
+            self.layer_done_counter.on_layer_consumed = self.trigger_layer_load
+            self.mem_pool_device.register_layer_transfer_counter(
+                self.layer_done_counter
+            )
 
         self.storage_host_pool = mem_pool_host.anchor_entry.host_pool
         if startup_storage_backend is not None:

--- a/python/sglang/srt/mem_cache/l2_transfer.py
+++ b/python/sglang/srt/mem_cache/l2_transfer.py
@@ -46,6 +46,74 @@ class TransferCompletion(NamedTuple):
     timing_enabled: bool
 
 
+class PrefetchHandle:
+    """Handle for on-demand per-layer H2D loading.
+
+    Only layer 0 is loaded in submit; subsequent layers are triggered
+    during forward via trigger_layer(), so H2D overlaps with attention
+    compute instead of being issued as a single bulk transfer.
+    """
+
+    def __init__(
+        self,
+        engine: "L2TransferEngine",
+        transfers: list[L2Transfer],
+        layer_num: int,
+        ack_finish_event,
+        on_layer_done,
+    ):
+        self._engine = engine
+        self._transfers = transfers
+        self._layer_num = layer_num
+        self._ack_finish_event = ack_finish_event
+        self._on_layer_done = on_layer_done
+        self._next_layer = 1  # layer 0 already loaded
+
+    def trigger_layer(self, layer_id: int) -> None:
+        if layer_id < self._next_layer:
+            return
+        if layer_id >= self._layer_num:
+            return
+        self._next_layer = layer_id + 1
+        primary = self._transfers[0] if self._transfers else None
+        with device_module.stream(self._engine.host_to_device_stream):
+            for transfer in self._transfers:
+                local_layer_id = (
+                    transfer.layer_mapper(layer_id)
+                    if transfer.layer_mapper is not None
+                    else layer_id
+                )
+                if local_layer_id is None or (
+                    transfer is not primary
+                    and transfer.layer_mapper is None
+                    and layer_id >= transfer.host_pool.layer_num
+                ):
+                    continue
+                transfer.host_pool.load_to_device_per_layer(
+                    transfer.device_pool,
+                    transfer.host_indices,
+                    transfer.device_indices,
+                    local_layer_id,
+                    self._engine.io_backend,
+                    is_draft=transfer.is_draft,
+                )
+            if self._on_layer_done is not None:
+                self._on_layer_done(layer_id)
+            if layer_id == self._layer_num - 1:
+                self._ack_finish_event.record()
+
+    def drain(self) -> None:
+        """Record completion events for any layers not yet triggered."""
+        if self._next_layer >= self._layer_num:
+            return
+        with device_module.stream(self._engine.host_to_device_stream):
+            for layer_id in range(self._next_layer, self._layer_num):
+                if self._on_layer_done is not None:
+                    self._on_layer_done(layer_id)
+            self._ack_finish_event.record()
+        self._next_layer = self._layer_num
+
+
 class L2TransferEngine:
     """Runs resolved device↔host transfers without owning cache state."""
 
@@ -53,6 +121,7 @@ class L2TransferEngine:
         self.io_backend = io_backend
         self.device_to_host_stream = device_module.Stream()
         self.host_to_device_stream = device_module.Stream()
+        self._prefetch_handle: Optional[PrefetchHandle] = None
 
     def submit_device_to_host(self, transfers: list[L2Transfer]) -> TransferCompletion:
         start_event = self._start_event(None)
@@ -78,10 +147,46 @@ class L2TransferEngine:
         layer_num: int,
         start_event=None,
         on_layer_done=None,
+        on_demand: bool = False,
     ) -> TransferCompletion:
         start_event = self._start_event(start_event)
         ack_start, ack_finish, timing_enabled = make_timing_event_pair()
         primary = transfers[0] if transfers else None
+
+        if on_demand:
+            with device_module.stream(self.host_to_device_stream):
+                start_event.wait(self.host_to_device_stream)
+                ack_start.record()
+                for transfer in transfers:
+                    local_layer_id = (
+                        transfer.layer_mapper(0)
+                        if transfer.layer_mapper is not None
+                        else 0
+                    )
+                    if local_layer_id is None or (
+                        transfer is not primary
+                        and transfer.layer_mapper is None
+                        and 0 >= transfer.host_pool.layer_num
+                    ):
+                        continue
+                    transfer.host_pool.load_to_device_per_layer(
+                        transfer.device_pool,
+                        transfer.host_indices,
+                        transfer.device_indices,
+                        local_layer_id,
+                        self.io_backend,
+                        is_draft=transfer.is_draft,
+                    )
+                if on_layer_done is not None:
+                    on_layer_done(0)
+                if layer_num <= 1:
+                    ack_finish.record()
+                self._record_stream(transfers, self.host_to_device_stream)
+            self._prefetch_handle = PrefetchHandle(
+                self, transfers, layer_num, ack_finish, on_layer_done
+            )
+            return TransferCompletion(ack_start, ack_finish, timing_enabled)
+
         with device_module.stream(self.host_to_device_stream):
             start_event.wait(self.host_to_device_stream)
             ack_start.record()
@@ -110,7 +215,12 @@ class L2TransferEngine:
                     on_layer_done(layer_id)
             ack_finish.record()
             self._record_stream(transfers, self.host_to_device_stream)
+        self._prefetch_handle = None
         return TransferCompletion(ack_start, ack_finish, timing_enabled)
+
+    @property
+    def prefetch_handle(self) -> Optional[PrefetchHandle]:
+        return self._prefetch_handle
 
     @staticmethod
     def _start_event(start_event):

--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+import os
 import abc
 import logging
 import threading
@@ -173,7 +173,8 @@ class HostKVCache(abc.ABC):
         # Verify there is enough available host memory.
         requested_bytes = self.size * self.size_per_token
         available_bytes = host_memory_budget_bytes()
-        if requested_bytes > available_bytes:
+        mf_backend = os.environ.get("SGLANG_HICACHE_HOST_MEM_BACKEND", "").lower() == ("memfabric")
+        if requested_bytes > available_bytes and not mf_backend:
             raise ValueError(
                 f"Not enough host memory available. Requesting "
                 f"{requested_bytes / 1e9:.2f} GB but only have "

--- a/python/sglang/srt/mem_cache/pool_host/npu_memfabric.py
+++ b/python/sglang/srt/mem_cache/pool_host/npu_memfabric.py
@@ -77,7 +77,7 @@ def ensure_memfabric_capacity(total_bytes: int, device_id: int) -> None:
         config.device_id = device_id
         config.reserve_size = total_bytes
         config.alloc_size = total_bytes
-        config.flags = offload.OFFLOAD_FLAG_URMA_POOL
+        config.flags = offload.OFFLOAD_FLAG_GIANT_PAGE
         config.scene = offload.Scene.LOCAL
         assert offload.initialize(config) == 0, "offload.initialize failed"
         _memfabric_state.update(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -141,7 +141,10 @@ from sglang.srt.model_executor.cuda_graph_config import (
     check_cuda_graph_backend,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
-from sglang.srt.model_executor.forward_context import get_attn_backend
+from sglang.srt.model_executor.forward_context import (
+    get_attn_backend,
+    get_token_to_kv_pool,
+)
 from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.context import (
     is_in_breakable_cuda_graph,
@@ -2462,6 +2465,11 @@ class DeepseekV2DecoderLayer(nn.Module):
         maybe_prefetch_next_full_attention_kv(
             forward_batch, next_full_attention_layer_id
         )
+
+        _kv_pool = get_token_to_kv_pool()
+        _counter = getattr(_kv_pool, "layer_transfer_counter", None)
+        if _counter is not None:
+            _counter.wait_for_prefetch(self.layer_id - _kv_pool.start_layer + 1)
 
         hidden_states, residual = self.layer_communicator.prepare_mlp(
             hidden_states, residual, forward_batch


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
1、Overlap of L2 cache H2D offload operators and computation streams.
2、Rename OFFLOAD_FLAG_URMA_POOL to OFFLOAD_FLAG_GIANT_PAGE

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

export SGLANG_HICACHE_HOST_MEM_BACKEND=memfabric
source /usr/local/memfabric_hybrid/set_env.sh
python3 -m sglang.launch_server --model-path ${MODEL_PATH} \
 --tp 8 \
 --trust-remote-code \
 --attention-backend ascend \
 --device npu \
 --watchdog-timeout 9000 \
 --host 141.61.45.118 --port 6677 \
 --max-running-requests 32 \
 --mem-fraction-static 0.8 \
 --quantization modelslim \
 --chunked-prefill-size 8192 \
 --kv-cache-dtype "fp8_e4m3" \
 --enable-metrics \
 --disable-cuda-graph \
  --moe-a2a-backend deepep \
 --deepep-mode auto \
 --load-balance-method round_robin \
 --enable-hierarchical-cache --hicache-io-backend kernel_ascend --enable-cache-report --hicache-size 100 \

<img width="1514" height="246" alt="image" src="https://github.com/user-attachments/assets/9a6036af-e698-4c32-abba-fcf995a39704" />

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #34733761603](https://github.com/sgl-project/sglang/actions/runs/34733761603)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #34733761524](https://github.com/sgl-project/sglang/actions/runs/34733761524)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #34733761469](https://github.com/sgl-project/sglang/actions/runs/34733761469)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->