### PR TITLE
fix(router): simplify bucket context limit check

### DIFF
--- a/experimental/sgl-router/src/policies/buckets.rs
+++ b/experimental/sgl-router/src/policies/buckets.rs
@@ -164,9 +164,9 @@ impl BucketSelector {
         }) else {
             return Some(candidate);
         };
-        if !spec
+        if spec
             .max_context_tokens
-            .is_none_or(|max_context| request.input_tokens <= max_context)
+            .is_some_and(|max_context| request.input_tokens > max_context)
             || (config.ttft_slo_policy == SloBucketPolicy::SloFirst
                 && !ttft_eligible(spec, request.ttft_slo_ms))
         {


### PR DESCRIPTION
## Summary

- Replace the negated `Option::is_none_or` check with the equivalent `Option::is_some_and` form.
- Fix the `clippy::nonminimal_bool` failure on current `main`.

## Validation

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo test --test component bucket_domains` (9 passed)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34733962338](https://github.com/sgl-project/sglang/actions/runs/34733962338)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34733976864](https://github.com/sgl-project/sglang/actions/runs/34733976864)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->