### PR TITLE
[Bugfix] Keep per-token top_logprobs in streaming chat logprobs

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -2292,13 +2292,14 @@ class OpenAIServingChat(OpenAIServingBase):
         )
 
     def _process_logprobs_tokens(
-        self, logprobs: LogProbs, use_token_index: bool = False
+        self, logprobs: LogProbs
     ) -> List[ChatCompletionTokenLogprob]:
-        """Common helper to process logprobs tokens for both streaming and non-streaming
+        """Common helper to process logprobs tokens for both streaming and non-streaming.
 
-        Args:
-            logprobs: LogProbs data from model
-            use_token_index: True for non-streaming (use token_idx), False for streaming (use index 0)
+        The caller passes token-aligned lists: non-streaming passes the full
+        sequence, streaming passes this chunk's segment (sliced here, or
+        already sliced by the incremental path). Each token therefore uses its
+        own top_logprobs entry.
         """
         token_logprobs = []
 
@@ -2308,12 +2309,7 @@ class OpenAIServingChat(OpenAIServingBase):
             token_bytes = list(token.encode("utf-8"))
             top_logprobs = []
             if logprobs.top_logprobs:
-                # - Non-streaming (use_token_index=True): uses token_idx for full data
-                # - Streaming (use_token_index=False): uses index 0 for pre-sliced data
-                top_logprobs_idx = token_idx if use_token_index else 0
-                for top_token, top_logprob in logprobs.top_logprobs[
-                    top_logprobs_idx
-                ].items():
+                for top_token, top_logprob in logprobs.top_logprobs[token_idx].items():
                     top_token_bytes = list(top_token.encode("utf-8"))
                     top_logprobs.append(
                         TopLogprob(
@@ -2340,7 +2336,7 @@ class OpenAIServingChat(OpenAIServingBase):
             output_top_logprobs=ret_item["meta_info"].get("output_top_logprobs", None),
         )
 
-        token_logprobs = self._process_logprobs_tokens(logprobs, use_token_index=True)
+        token_logprobs = self._process_logprobs_tokens(logprobs)
         return ChoiceLogprobs(content=token_logprobs)
 
     def _process_tool_call_id(
@@ -2510,7 +2506,7 @@ class OpenAIServingChat(OpenAIServingBase):
             output_top_logprobs=output_top_logprobs,
         )
 
-        token_logprobs = self._process_logprobs_tokens(logprobs, use_token_index=False)
+        token_logprobs = self._process_logprobs_tokens(logprobs)
         return ChoiceLogprobs(content=token_logprobs)
 
     def _process_reasoning_stream(

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -2894,6 +2894,30 @@ class ServingChatTestCase(unittest.TestCase):
             chunks.append(chunk)
         return chunks
 
+    def test_streaming_logprobs_use_per_token_top_logprobs(self):
+        """Each token in a multi-token streaming segment carries its own top_logprobs.
+
+        Streaming can commit more than one token per chunk (speculative decode,
+        stream_interval, coalesced deltas). The segment is token-aligned, so the
+        second token must not report the first token's alternatives.
+        """
+        content = {
+            "meta_info": {
+                "output_token_logprobs": [(-0.1, 1, "a"), (-0.2, 2, "b")],
+                "output_top_logprobs": [
+                    [(-0.1, 1, "a"), (-1.1, 3, "x")],
+                    [(-0.2, 2, "b"), (-2.2, 4, "y")],
+                ],
+            }
+        }
+        choice_logprobs = self.chat._process_streaming_logprobs(content, 0, 2)
+
+        self.assertEqual([t.token for t in choice_logprobs.content], ["a", "b"])
+        first_top = {t.token for t in choice_logprobs.content[0].top_logprobs}
+        second_top = {t.token for t in choice_logprobs.content[1].top_logprobs}
+        self.assertEqual(first_top, {"a", "x"})
+        self.assertEqual(second_top, {"b", "y"})
+
     def test_streaming_logprobs_attached_with_reasoning_parser(self):
         """Logprobs must ride on the reasoning chunk when a reasoning parser is active."""
         self.chat.reasoning_parser = "qwen3"


### PR DESCRIPTION
Fixes #39260

## Motivation

In streaming chat completions, the `top_logprobs` of every token after the first in a chunk is a copy of the first token's `top_logprobs`, while the non-streaming response is correct. This is silent: the token list, the chosen token's logprob, usage, and finish reason stay correct, so only the alternatives are wrong.

Root cause: `_process_logprobs_tokens` indexed `top_logprobs` by token position for non-streaming but always by `0` for streaming (`use_token_index=False`). The streaming caller already passes a token-aligned segment, so index `0` is wrong whenever a chunk contains two or more tokens. A chunk can commit more than one token under speculative decoding, `stream_interval > 1`, or coalesced deltas.

## Modifications

Index `top_logprobs` by token position in both streaming and non-streaming, and remove the now-unused `use_token_index` parameter from `_process_logprobs_tokens`. Add a regression test in `test/registered/unit/entrypoints/openai/test_serving_chat.py`.

## Accuracy Tests

Not applicable: response serialization only, no model forward change.

## Speed Tests and Profiling

Not applicable: the same number of iterations, one index change per token.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35710209237](https://github.com/sgl-project/sglang/actions/runs/35710209237)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35710208962](https://github.com/sgl-project/sglang/actions/runs/35710208962)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35710209281](https://github.com/sgl-project/sglang/actions/runs/35710209281)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->