### PR TITLE
Fix hybrid session references after an empty terminal cache insert

### DIFF
--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1055,7 +1055,12 @@ class UnifiedRadixCache(BasePrefixCache):
         if req.last_node is not None:
             self._dec_req_lock(req, skip_swa=req.swa_prefix_lock_released)
 
-        if is_insert and result is not None and result.last_device_node is not None:
+        if (
+            is_insert
+            and result is not None
+            and result.last_device_node is not None
+            and result.last_device_node != self.root_node.id
+        ):
             req.last_node = result.last_device_node
 
         # cleanup

--- a/test/registered/unit/mem_cache/test_session_unified_radix_cache.py
+++ b/test/registered/unit/mem_cache/test_session_unified_radix_cache.py
@@ -7,6 +7,7 @@ register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 import unittest
 from array import array
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 
@@ -142,6 +143,82 @@ class TestSessionUnifiedRadixCache(CustomTestCase):
         self.assertEqual(match_len(self.cache, [7, 8, 9]), 0)
         self.assertEqual(match_len(self.cache, [1, 2, 3, 4]), 4)
         self.assertEqual(self.full.session_ref(referenced), 1)
+
+
+class TestSessionTerminalLeaf(CustomTestCase):
+    def test_empty_terminal_insert_preserves_prior_hybrid_session_leaf(self):
+        import test_unified_radix_cache_unittest as native
+
+        from sglang.srt.managers.schedule_batch import FINISH_ABORT, FINISH_LENGTH
+
+        cases = (
+            ("missing_checkpoint", True, None, True, False, False),
+            ("zero_checkpoint", True, 0, True, False, False),
+            ("new_checkpoint", True, 256, True, False, False),
+            ("no_prefix", False, None, True, False, False),
+            ("aborted", True, None, True, True, False),
+            ("no_insert", True, None, False, False, False),
+            ("stale_generation", True, None, True, False, True),
+        )
+        for name, prior, checkpoint, insert_tail, aborted, stale in cases:
+            with (
+                self.subTest(case=name),
+                patch.object(native, "_TREE_CORE_TEST_BACKEND", "python"),
+            ):
+                cfg = native.CacheConfig(
+                    components=(ComponentType.FULL, ComponentType.MAMBA),
+                    page_size=64,
+                    kv_size=2048,
+                    max_context_len=1024,
+                    enable_mamba_extra_buffer=True,
+                    mamba_cache_size=60,
+                )
+                cache, allocator, pool = native.build_fixture(
+                    cfg, enable_session_radix_cache=True
+                )
+                helper = native.UnifiedRadixCacheSuite()
+                helper.cfg = cfg
+                tokens = array("q", range(256))
+                if prior:
+                    helper._insert(cache, allocator, pool, tokens)
+                req = helper._make_req(pool)
+                match = cache.match_prefix(MatchPrefixParams(key=RadixKey(tokens)))
+                helper._apply_match_to_req(req, match)
+                cache.inc_lock_ref(req.last_node)
+                req.kv.cache_protected_len = len(match.device_indices)
+                req.origin_input_ids = tokens
+                req.output_ids = array("q", range(2000, 2008))
+                length = len(tokens) + len(req.output_ids)
+                suffix = helper._alloc(allocator, length - len(match.device_indices))
+                indices = torch.cat([match.device_indices, suffix])
+                pool.write((req.kv.req_pool_idx, slice(0, length)), indices)
+                req.kv.kv_committed_len = req.kv.kv_allocated_len = length
+                req.full_untruncated_fill_ids = tokens + req.output_ids
+                req.set_extend_range(len(match.device_indices), length)
+                req.kv.mamba_last_track_seqlen = checkpoint
+                req.session_id = "terminal-leaf"
+                req.session_generation = cache.open_radix_session(req.session_id)
+                if stale:
+                    cache.release_radix_session(req.session_id)
+                    cache.open_radix_session(req.session_id)
+                req.finished_reason = (
+                    FINISH_ABORT() if aborted else FINISH_LENGTH(length=8)
+                )
+                cache.cache_finished_req(
+                    req, is_insert=insert_tail, kv_len_to_handle=length
+                )
+                expected = int(prior and insert_tail and not aborted and not stale)
+                for component in cache.components.values():
+                    refs = component._session_leaves.get(req.session_id, ())
+                    self.assertEqual(
+                        sum(component.session_ref(node) > 0 for node in refs), expected
+                    )
+                self.assertEqual(match_len(cache, tokens), 256 if prior else 0)
+                cache.sanity_check()
+                cache.release_radix_session(req.session_id)
+                cache.evict(EvictParams(num_tokens=2048, mamba_num=60))
+                self.assertEqual(match_len(cache, tokens), 0)
+                self.assertEqual(allocator.available_size(), 2048)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This is a narrow correctness fix for the session-reference behavior added in #29173.

For a hybrid FULL+MAMBA request, a valid reusable prefix may already be stored in `req.last_node`. If the request finishes without a new usable Mamba checkpoint, the terminal cache insert can return the root. The current code then replaces the valid prior leaf with that root before session registration. Because the root is not registered as a session reference, the earlier reusable prefix loses its session-aware eviction protection.

This PR keeps the previous leaf when terminal insertion returns the root.

## What changes

`req.last_node` is replaced only when terminal insertion returns a non-root device leaf.

Request locks, stale-generation handling, abort behavior, session close and normal eviction are unchanged. This does not pin KV or introduce a new retention policy.

## Validation

The registered Python FULL+MAMBA session-cache tests cover:

- missing and zero Mamba checkpoints
- a new checkpoint
- no prior prefix
- abort and no-insert paths
- stale session generations

The native module passes all 5 tests, and removing only this guard fails exactly the missing/zero-checkpoint cases. All 2,048 allocated KV slots are recovered after session close/eviction.

Rust session-reference coverage is not claimed because the existing upstream session test helper still disables the #29173 session path for the Rust tree.

No model arithmetic or serving-performance claim is attached to this PR.

## Review question

Could a cache owner confirm that preserving the previous non-root leaf is the intended session-reference contract when terminal insertion produces no reusable leaf?