### PR TITLE
Allocate packed weight receive buffers directly from metadata

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
+++ b/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
@@ -287,18 +287,7 @@ class WeightUpdater:
         self: WeightUpdater, names, dtypes, shapes, group_name
     ):
         try:
-            named_tensors = []
-            for name, dtype, shape in zip(names, dtypes, shapes):
-                target_dtype = (
-                    dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
-                )
-                named_tensors.append(
-                    (
-                        name,
-                        torch.empty(shape, dtype=target_dtype, device=self.device),
-                    )
-                )
-            bucket = FlattenedTensorBucket(named_tensors=named_tensors)
+            bucket = FlattenedTensorBucket.empty(names, dtypes, shapes, self.device)
             flattened_tensor = bucket.get_flattened_tensor()
             torch.distributed.broadcast(
                 flattened_tensor,

--- a/python/sglang/srt/weight_sync/tensor_bucket.py
+++ b/python/sglang/srt/weight_sync/tensor_bucket.py
@@ -83,6 +83,34 @@ class FlattenedTensorBucket:
         """Get the flattened tensor containing all bucket tensors"""
         return self.flattened_tensor
 
+    @classmethod
+    def empty(cls, names, dtypes, shapes, device):
+        """Allocate a receive bucket without constructing or copying its tensors."""
+        metadata = []
+        offset = 0
+        for name, dtype, shape in zip(names, dtypes, shapes, strict=True):
+            dtype = dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
+            shape = torch.Size(shape)
+            if any(dim < 0 for dim in shape):
+                raise ValueError(
+                    f"Negative dimension in received tensor {name}: {shape}"
+                )
+            if offset % dtype.itemsize:
+                raise ValueError(
+                    f"Unaligned received tensor {name}: byte offset {offset}, dtype {dtype}"
+                )
+            size = shape.numel() * dtype.itemsize
+            metadata.append(
+                FlattenedTensorMetadata(name, shape, dtype, offset, offset + size, size)
+            )
+            offset += size
+        if not metadata:
+            raise ValueError("Cannot create empty tensor bucket")
+        return cls(
+            flattened_tensor=torch.empty(offset, dtype=torch.uint8, device=device),
+            metadata=metadata,
+        )
+
     def get_metadata(self) -> List[FlattenedTensorMetadata]:
         """Get metadata for all tensors in the bucket"""
         return self.metadata

--- a/test/registered/rl/test_tensor_bucket.py
+++ b/test/registered/rl/test_tensor_bucket.py
@@ -1,0 +1,61 @@
+import pytest
+import torch
+
+from sglang.srt.weight_sync.tensor_bucket import FlattenedTensorBucket
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+@pytest.mark.parametrize("dtype_strings", [False, True])
+def test_receive_bucket_preserves_mixed_dtype_wire_bytes(dtype_strings):
+    scale_bits = torch.tensor(
+        [0, -2147483648, 2143289345, 2139095040], dtype=torch.int32
+    )
+    values = [
+        ("packed_weight", torch.arange(16, dtype=torch.uint8).reshape(2, 8)),
+        ("block_scales", torch.arange(8, dtype=torch.uint8).view(torch.float8_e4m3fn)),
+        ("global_scale", scale_bits.view(torch.float32)[2].reshape(())),
+        ("other_scales", scale_bits.view(torch.float32)),
+        ("bf16", torch.tensor([1.5, -2.0], dtype=torch.bfloat16)),
+        ("empty", torch.empty((0, 4), dtype=torch.float32)),
+    ]
+    sent = FlattenedTensorBucket(named_tensors=values)
+    dtypes = [value.dtype for _, value in values]
+    if dtype_strings:
+        dtypes = [str(dtype).removeprefix("torch.") for dtype in dtypes]
+    received = FlattenedTensorBucket.empty(
+        [name for name, _ in values],
+        dtypes,
+        [value.shape for _, value in values],
+        "cpu",
+    )
+    assert received.metadata == sent.metadata
+    received.flattened_tensor.copy_(sent.flattened_tensor)
+    for (name, original), (received_name, actual), meta in zip(
+        values, received.reconstruct_tensors(), sent.metadata, strict=True
+    ):
+        assert name == received_name
+        assert original.shape == actual.shape and original.dtype == actual.dtype
+        assert torch.equal(
+            original.reshape(-1).view(torch.uint8), actual.reshape(-1).view(torch.uint8)
+        )
+        if actual.numel():
+            assert (
+                actual.data_ptr()
+                == received.flattened_tensor.data_ptr() + meta.start_idx
+            )
+
+
+@pytest.mark.parametrize(
+    "names,dtypes,shapes",
+    [
+        ([], [], []),
+        (["a"], [], [[4]]),
+        (["a"], [torch.float32], [[-1, -1]]),
+        (["a", "b"], [torch.uint8, torch.float32], [[3], []]),
+    ],
+)
+def test_receive_bucket_rejects_invalid_metadata(names, dtypes, shapes):
+    with pytest.raises(ValueError):
+        FlattenedTensorBucket.empty(names, dtypes, shapes, "cpu")


### PR DESCRIPTION
## Motivation

@humansand

Packed weight updates allocate every destination tensor and concatenate their uninitialized bytes immediately before overwriting that buffer with a broadcast. Allocate the receive buffer directly from tensor metadata to remove the discarded concatenation and temporary allocations.

This draft targets `main` at `7763f666f348d99e28a3dc839e99adf5cd7e1861`. Full-model weight-sync benefit is unmeasured.

## Modifications

- Add `FlattenedTensorBucket.empty(names, dtypes, shapes, device)`: retain byte offsets and allocate one contiguous uint8 buffer. Reconstruction returns the original typed shared-storage views.
- Use the factory in the update-and-load receiver. Preserve the existing single broadcast, model-loading call where applicable, and error handling. Sender packing, mixed-dtype wire format, quantization, collective group and finalization are unchanged.
- Fail on inconsistent metadata lengths, negative shapes, empty metadata or offsets incompatible with dtype alignment. No padding or dtype promotion.
- Production methods match private NCCL-tested candidate `e81dd43b02ce2661a797b5bdd28be45463323694` literally. The bucket module AST is identical; its only difference is formatter line wrapping. No private API compatibility layer is added.

## Accuracy Tests

- Six registered CPU tests cover mixed uint8/FP8/FP32/BF16 bytes, dtype objects/strings, scalar and empty shapes, signed zero/infinity/NaN payloads, exact reconstruction aliases and invalid metadata. Local Python3.12.12/PyTorch2.14.0 CPU runs passed.
- Additional project-local checks AST-compile the complete changed receiver methods, compare their ASTs against private candidate `e81dd43b02ce2661a797b5bdd28be45463323694`, intercept only the collective, and check all typed bytes/addresses plus actual model-delivery calls over four different payload versions. Main:4 actual-call cases; sglang-miles:8.
- Initial ordinary pytest package import failed before test execution because the Mac environment lacks `pybase64`. The successful local run bypassed only package `__init__` bootstrap with namespace modules; production bucket, CI registration and tests remained unchanged. This is not a complete serving-runtime import.

```text
# main
......                                                                   [100%]
6 passed in 0.01s
CPU_REAL_MODULE_TESTS_AND_ACTUAL_RECEIVER_METHODS_PASS (4 actual-method cases)
# sglang-miles
......                                                                   [100%]
6 passed in 0.01s
CPU_REAL_MODULE_TESTS_AND_ACTUAL_RECEIVER_METHODS_PASS (8 actual-method cases)
```

Registered regression command in an installed SGLang development environment:

```bash
CUDA_VISIBLE_DEVICES= PYTHONPATH=python python -m pytest -q \
  --confcutdir=test/registered/rl -p no:cacheprovider \
  test/registered/rl/test_tensor_bucket.py
```

**Previously executed real NCCL protocol test:** two B300 GPUs, Python3.12.3, PyTorch2.13.0+cu130, CUDA13.0, NCCL2.29.7. Exact image:
`us-docker.pkg.dev/hai-infra/hai/hai-miles@sha256:202dbc57befbd2d8abd626f480dae284fc1989f3826070071eb1298050f8a9ee`.

The actual private candidate factory and receive-only method passed four distinct versions each of a100-byte toy and339,751,136-byte GLM16-expert fixture. Both ranks checked every byte, name, dtype, shape and shared-storage address. Dtype objects/strings alternate. The branch adaptations retain production AST equivalence; this does not claim a new upstream GPU execution or full-model loader qualification.

```bash
# Standalone harness with its frozen source and manifest files present.
CUDA_VISIBLE_DEVICES=0,1 timeout --signal=TERM --kill-after=10s 240s \
  python test_receiver_nccl.py --output receiver-nccl-cuda-001
```

```text
TWO_GPU_NCCL_PROTOCOL_PASS
```

Both workers and parent exited0. Exact owned-process identities were absent and all eight GPUs were idle afterward; no models or serving endpoints were created. Source manifest SHA256 `46b5a99af146ad0e6113638f5feeed569fe8fefa85484c3c94d4a181443cbc60`; helper `0890d9e9b2a2ca8ba31f415895551a788f30b00a311cd6b11f35e3e33909b80e`; full protocol/cleanup receipt `a1cea72082c20756c6a8d50efa0123a3c14d83e23f071e1120fc23f647ce8b11`.

## Speed Tests and Profiling

Previously measured on one B300 in the same image:2 warmups and10 alternating trials per variant. Both variants include an identical local device overwrite and typed-view reconstruction. Completed wall time includes device synchronization. Peak allocation is live PyTorch tensor allocation above the preallocated payload, not RSS or reserved memory.

| Tensors | Payload bytes | Original median wall ms | Metadata-only median wall ms | Original peak allocation bytes | Metadata-only peak allocation bytes |
|---:|---:|---:|---:|---:|---:|
| 10 | 21245964 | 0.144953 | 0.095179 | 42493952 | 21246464 |
| 37 | 84946992 | 0.408382 | 0.221236 | 170936320 | 85983232 |
| 145 | 339751104 | 1.403790 | 0.634502 | 679526912 | 339751424 |

Original construction has one `aten::cat`; the metadata-only path has none. Local completed-wall reduction is0.050–0.769ms per bucket and temporary allocation is approximately halved. This earlier construction benchmark used an equivalent metadata-only function; the subsequent real NCCL test used the actual production factory. Neither measures full-model loading/finalization or end-to-end synchronization benefit. Unflatten host work and per-name model loading remain unchanged. The larger NVFP4-vs-MXFP8 sync gap is not attributed to this small result.

```bash
CUDA_VISIBLE_DEVICES=0 python receiver_construction_bench.py \
  --tensor-bucket receiver-source-001/tensor_bucket.py \
  --weight-updater receiver-source-001/weight_updater.py \
  --output receiver-cuda-001 --device cuda:0 \
  --expert-counts 1 4 16 --warmup 2 --repeats 10 --profile --timeout-seconds 300
```

Construction helper `d6c92e241a30f16563a7955777f8a59f7bf805c5b716a03f263423eeaa6d8561`; raw result `1bdac967966b958f80fd760732b769b2ba1b5aa4e71afec4fa8a2c70e5265cb4`; analysis `c8e229ef147056ca490101f1d6c5b1c0cd03d7755fde360349e420011dfd6260`. Complete raw timings, six traces, source/AST and cleanup evidence are preserved in project-local validation artifacts.

Ruff F401/F821/UP037, formatting of changed code, compile and diff checks passed. Full repository pre-commit was not run. Local Ruff0.16.7 flags an unrelated preexisting sglang-miles assert format; that baseline line remains unchanged.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34737161366](https://github.com/sgl-project/sglang/actions/runs/34737161366)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34737161281](https://github.com/sgl-project/sglang/actions/runs/34737161281)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34737161348](https://github.com/sgl-project/sglang/actions/runs/34737161348)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->