### PR TITLE
[BugFix][DSA] Respect tensor strides in the decode page-table transform

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/transform_index.py
+++ b/python/sglang/kernels/ops/attention/dsa/transform_index.py
@@ -101,19 +101,26 @@ def transform_index_page_table_decode_kernel(
     result_ptr: torch.Tensor,
     page_size: tl.constexpr,
     page_table_row_stride: tl.constexpr,
+    page_table_col_stride: tl.constexpr,
+    topk_indices_row_stride: tl.constexpr,
+    topk_indices_col_stride: tl.constexpr,
+    result_row_stride: tl.constexpr,
+    result_col_stride: tl.constexpr,
 ):
     TOPK: tl.constexpr = 2048
     req_id = tl.program_id(0)
     page_table_ptr = page_table_ptr + req_id * page_table_row_stride
-    topk_indices_ptr = topk_indices_ptr + req_id * TOPK
-    result_ptr = result_ptr + req_id * TOPK
+    topk_indices_ptr = topk_indices_ptr + req_id * topk_indices_row_stride
+    result_ptr = result_ptr + req_id * result_row_stride
 
     offset = tl.arange(0, TOPK)  # topk should be 2048
-    loaded_topk_indices = tl.load(topk_indices_ptr + offset)
+    loaded_topk_indices = tl.load(topk_indices_ptr + offset * topk_indices_col_stride)
     mask = loaded_topk_indices >= 0
-    loaded_kv_indices = tl.load(page_table_ptr + loaded_topk_indices, mask=mask)
-    tl.store(result_ptr + offset, loaded_kv_indices, mask=mask)
-    tl.store(result_ptr + offset, -1, mask=~mask)
+    loaded_kv_indices = tl.load(
+        page_table_ptr + loaded_topk_indices * page_table_col_stride, mask=mask
+    )
+    tl.store(result_ptr + offset * result_col_stride, loaded_kv_indices, mask=mask)
+    tl.store(result_ptr + offset * result_col_stride, -1, mask=~mask)
 
 
 # Expanded EAGLE page tables are contiguous, so their row stride changes with
@@ -206,6 +213,11 @@ def transform_index_page_table_decode_fast(
         result,
         page_size,
         page_table_row_stride=page_table.stride(0),
+        page_table_col_stride=page_table.stride(1),
+        topk_indices_row_stride=topk_indices.stride(0),
+        topk_indices_col_stride=topk_indices.stride(1),
+        result_row_stride=result.stride(0),
+        result_col_stride=result.stride(1),
     )
     return result
 

--- a/test/registered/kernels/ops/attention/test_dsa_transform_index.py
+++ b/test/registered/kernels/ops/attention/test_dsa_transform_index.py
@@ -1,4 +1,5 @@
 import unittest
+from itertools import product
 from unittest.mock import patch
 
 import torch
@@ -260,6 +261,78 @@ class TestDSATransformIndex(CustomTestCase):
     def test_decode_fast_correctness_and_strides(self):
         self._check_decode_case(17, 8192, provide_result=True)
         self._check_decode_case(17, 8192, zero_row_stride=True)
+
+    def test_decode_fast_noncontiguous_tensors(self):
+        batch_size, context_length = 3, 4096
+
+        def make_view(tensor, layout):
+            if layout == "transpose":
+                return tensor.T.contiguous().T
+            if layout == "slice":
+                storage = torch.zeros(
+                    (tensor.shape[0] * 2, tensor.shape[1] * 2 + 1),
+                    dtype=tensor.dtype,
+                    device=self.device,
+                )
+                view = storage[::2, 1::2]
+                view.copy_(tensor)
+                return view
+            if layout == "expand":
+                return tensor[:1].expand_as(tensor)
+            if layout == "expand_columns":
+                return tensor[:, :1].expand_as(tensor)
+            return tensor
+
+        for operand in ("page_table", "topk_indices", "result"):
+            layouts = ("transpose", "slice", "expand", "expand_columns")
+            if operand == "result":
+                layouts = ("transpose", "slice")
+            for layout, index_dtype in product(layouts, (torch.int32, torch.int64)):
+                with self.subTest(operand=operand, layout=layout, dtype=index_dtype):
+                    page_table = self._make_page_table(batch_size, context_length)
+                    topk_indices = self._make_topk(batch_size, context_length).to(
+                        index_dtype
+                    )
+                    if operand == "page_table":
+                        page_table = make_view(page_table, layout)
+                    elif operand == "topk_indices":
+                        topk_indices = make_view(topk_indices, layout)
+
+                    expected = torch.gather(
+                        page_table, 1, topk_indices.long().clamp(min=0)
+                    )
+                    expected[topk_indices < 0] = -1
+                    result = None
+                    if operand == "result":
+                        result = make_view(torch.zeros_like(expected), layout)
+
+                    actual = transform_index_page_table_decode_fast(
+                        page_table, topk_indices, result=result
+                    )
+                    torch.cuda.synchronize()
+                    if result is not None:
+                        self.assertIs(actual, result)
+                    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_decode_fast_preserves_output_padding(self):
+        page_table = self._make_page_table(3, 4096)
+        topk_indices = self._make_topk(3, 4096)
+        sentinel = -123
+        storage = torch.full(
+            (6, TOPK * 2 + 1), sentinel, dtype=torch.int32, device=self.device
+        )
+        result = storage[::2, 1::2]
+        expected = torch.full_like(storage, sentinel)
+        values = torch.gather(page_table, 1, topk_indices.clamp(min=0))
+        values[topk_indices < 0] = -1
+        expected[::2, 1::2] = values
+
+        actual = transform_index_page_table_decode_fast(
+            page_table, topk_indices, result=result
+        )
+        torch.cuda.synchronize()
+        self.assertIs(actual, result)
+        torch.testing.assert_close(storage, expected, rtol=0, atol=0)
 
     def test_decode_fast_extreme_shapes(self):
         self._check_decode_case(8192, 4096)


### PR DESCRIPTION
## Motivation

The 2048-wide DSA decode transform assumes contiguous top-k indices and output tensors, and a unit column stride for the page table. For transposed or sliced tensors accepted by the wrapper, this produces incorrect token locations. A caller-provided output view can also overwrite storage outside that view. The existing torch reference handles these layouts correctly.

## Modifications

Pass the actual column and row strides into the decode kernel and use them in pointer arithmetic. The new stride arguments remain constexpr, so contiguous layouts retain the same address calculations. Add regression coverage for 20 layout/index-dtype combinations (int32/int64, transpose, slice and broadcast), including a separate check that output-view padding remains untouched.

## Accuracy Tests

Configured a WSL Ubuntu 24.04 environment with Python 3.11.16, PyTorch 2.13.0+cu130, CUDA 13.0, Triton 3.7.1, FlashInfer 0.6.18 and sglang-kernel 0.4.6.post1. Tests run on an NVIDIA RTX 5060 8GB.

On upstream `23bc4c6ed9d143c6cabdd243913af304bb658d4f` with the patch:

```bash
PYTHONPATH=python python test/registered/kernels/ops/attention/test_dsa_transform_index.py
```

All 11 tests pass through the standard repository entry point and `CustomTestCase`. With the unmodified upstream kernel, the new output-padding regression fails: 10,235 of 24,582 storage elements differ. The patched kernel passes the same regression. All applicable pre-commit hooks pass for both changed files.

This establishes operator-level correctness. Full-model accuracy, other GPU architectures and upstream CI were not run locally.

## Speed Tests and Profiling

Earlier contiguous-layout checks on PyTorch 2.9.1+cu128 / Triton 3.5.1 found identical PTX after removing source-location directives and comments. Five alternating CUDA-graph timing samples per shape showed overlapping ranges; for the largest measured case, the patched median was approximately 1.5% higher. No speedup is claimed. Those measurements were not repeated under the newer validation environment and are not end-to-end serving benchmarks.

## Related Work

#36888 changes stride specialization policy; #38543 adds non-2048 top-k widths. Neither inspected diff fixes the existing 2048 decode path's input/output stride handling. This patch does not change specialization policy or top-k width support.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35685955523](https://github.com/sgl-project/sglang/actions/runs/35685955523)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35685955253](https://github.com/sgl-project/sglang/actions/runs/35685955253)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35685955289](https://github.com/sgl-project/sglang/actions/runs/35685955289)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->