### PR TITLE
[HiCache] Intersect restorable prefixes across pools and ranks

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -234,6 +234,10 @@ class StorageOperation:
         # hash_value is truncated to the hit boundary; the tail is the
         # absence signal that invalidates buffer-mode existence beliefs.
         self.all_hash_values: Optional[List[str]] = None
+        # Legal storage-prefix endpoints, in pages, before cross-rank sync.
+        # None preserves legacy hit-length behavior for backends that do not
+        # report candidates; an empty list means no endpoint is restorable.
+        self.restorable_prefix_pages: Optional[List[int]] = None
         # Prefetch-outcome accounting, set at enqueue by the tree cache.
         self.stats_requested_tokens = 0
         # Absolute token offset at which this storage-prefetched span starts.
@@ -1216,6 +1220,41 @@ class HiCacheController:
 
         return hash_value, storage_query_count
 
+    def _sync_storage_hit_count(self, operation, storage_hit_count: int) -> int:
+        restorable = operation.restorable_prefix_pages
+        # Keep the collective identical for plain KV and hybrid controllers:
+        # different pipeline stages may have different auxiliary pools. A
+        # terminated operation still participates with a zero hit count.
+        hit_info = torch.tensor(
+            [storage_hit_count, int(restorable is None)], dtype=torch.int
+        )
+        self._all_reduce(
+            hit_info, torch.distributed.ReduceOp.MIN, self.prefetch_hits_sync_groups
+        )
+        common_hit_count, all_legacy = hit_info.tolist()
+        if common_hit_count == 0 or all_legacy:
+            return common_hit_count
+
+        # A per-rank maximum is not sufficient for sparse trailing pools:
+        # min(max({1, 3}), max({1, 2})) == 2 is illegal on the first rank.
+        # Size every rank's mask from the synchronized upper bound, then
+        # intersect legal endpoints across the same TP/CP/PP groups.
+        max_pages = common_hit_count // self.page_size
+        if restorable is None:
+            # Preserve the previous contiguous-prefix assumption where the
+            # backend does not provide the optional endpoint metadata.
+            mask = torch.ones(max_pages + 1, dtype=torch.int)
+        else:
+            mask = torch.zeros(max_pages + 1, dtype=torch.int)
+            mask[0] = 1
+            candidates = [page for page in restorable if 0 < page <= max_pages]
+            if candidates:
+                mask[candidates] = 1
+        self._all_reduce(
+            mask, torch.distributed.ReduceOp.MIN, self.prefetch_hits_sync_groups
+        )
+        return int(torch.nonzero(mask, as_tuple=True)[0][-1]) * self.page_size
+
     def prefetch_thread_func(self):
         """
         Manage prefetching operations from storage backend to host memory.
@@ -1229,15 +1268,9 @@ class HiCacheController:
                     hash_value, storage_hit_count = [], 0
                 else:
                     hash_value, storage_hit_count = self._storage_hit_query(operation)
-                storage_hit_count_tensor = torch.tensor(
-                    storage_hit_count, dtype=torch.int
+                storage_hit_count = self._sync_storage_hit_count(
+                    operation, storage_hit_count
                 )
-                self._all_reduce(
-                    storage_hit_count_tensor,
-                    torch.distributed.ReduceOp.MIN,
-                    self.prefetch_hits_sync_groups,
-                )
-                storage_hit_count = storage_hit_count_tensor.item()
 
                 # Record the TP-synced hit count; the scheduler thread decides
                 # at drain time whether to revoke (below threshold) or allocate.

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -187,8 +187,9 @@ class HiCacheStorage(ABC):
         ------------------------------------------------------
         Each ``PoolTransfer`` in ``pool_transfers`` describes a secondary
         cache pool (e.g. Mamba SSM states) that must be co-present with the
-        KV pages.  The final ``final_pages`` is the minimum across all pools,
-        so a missing auxiliary page shrinks the usable prefix.
+        KV pages. The usable prefix ends at the greatest stop point that all
+        pools can restore. Trailing-page pools may have gaps in their valid
+        stop points, so taking the minimum of their maxima is not sufficient.
 
         - ``"all_pages"`` (default):  every page in [0, kv_hit) must exist
           for this pool.  Used for pools that are required for every token
@@ -634,31 +635,39 @@ class HiCacheFile(HiCacheStorage):
         )
 
         hit_count: dict[str, int] = {PoolName.KV: kv_pages} if kv_pages else {}
-        final_pages = kv_pages
+        # Trailing pools can have holes in their valid stop points: a longer
+        # prefix being restorable does not imply that a shorter one is. Keep
+        # the common stop points instead of taking the minimum of maxima.
+        restorable = list(range(1, kv_pages + 1))
 
         for transfer in pool_transfers or []:
-            if final_pages == 0:
+            if not restorable:
                 break
             name = transfer.name
             if transfer.hit_policy == PoolHitPolicy.ALL_PAGES:
                 boundary = next(
                     (i for i in range(kv_pages) if not has_component(i, name)), kv_pages
                 )
+                pool_restorable = list(range(1, boundary + 1))
             else:  # trailing_pages
                 trailing = max(1, len(transfer.keys) if transfer.keys else 1)
-                boundary = 0
-                for prefix_len in range(kv_pages, 0, -1):
-                    if all(
-                        has_component(i, name)
-                        for i in range(max(0, prefix_len - trailing), prefix_len)
-                    ):
-                        boundary = prefix_len
-                        break
+                pool_restorable = []
+                consecutive = 0
+                for prefix_len in range(1, kv_pages + 1):
+                    if has_component(prefix_len - 1, name):
+                        consecutive += 1
+                    else:
+                        consecutive = 0
+                    if consecutive >= min(trailing, prefix_len):
+                        pool_restorable.append(prefix_len)
+                boundary = pool_restorable[-1] if pool_restorable else 0
             if boundary:
                 hit_count[name] = boundary
-            final_pages = min(final_pages, boundary)
+            pool_restorable_set = set(pool_restorable)
+            restorable = [p for p in restorable if p in pool_restorable_set]
 
-        return PoolTransferResult(final_pages, hit_count)
+        final_pages = restorable[-1] if restorable else 0
+        return PoolTransferResult(final_pages, hit_count, restorable)
 
     def _log_key(self, pool_name: str, key: str) -> str:
         return key if pool_name == PoolName.KV else f"{key}.{pool_name}"

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -597,6 +597,7 @@ class HybridCacheController(BaseHiCacheController):
             )
 
         kv_hit_pages = hit_result.kv_hit_pages
+        operation.restorable_prefix_pages = hit_result.restorable_prefix_pages
         operation.pool_storage_result.update_kv_hit_pages(kv_hit_pages)
 
         return (

--- a/test/registered/unit/mem_cache/test_hicache_file_prefix.py
+++ b/test/registered/unit/mem_cache/test_hicache_file_prefix.py
@@ -1,0 +1,137 @@
+"""CPU coverage for file-backend hybrid prefix intersection."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from sglang.srt.mem_cache.hicache_storage import (
+    HiCacheFile,
+    MetadataCache,
+    PoolHitPolicy,
+    PoolName,
+    PoolTransfer,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestHiCacheFilePrefix(CustomTestCase):
+    def check_prefix(self, kv_pages, pools, expected, num_pages=3):
+        # Exercise real file scans and metadata lookups without constructing
+        # the unrelated eviction/controller machinery.
+        for metadata_enabled in (False, True):
+            for reverse in (False, True):
+                with self.subTest(metadata=metadata_enabled, reverse=reverse):
+                    with tempfile.TemporaryDirectory() as directory:
+                        backend = HiCacheFile.__new__(HiCacheFile)
+                        backend.file_path = directory
+                        backend.config_suffix = "_prefix_test"
+                        backend.metadata_cache = (
+                            MetadataCache(-1.0) if metadata_enabled else None
+                        )
+                        keys = [f"page{i}" for i in range(1, num_pages + 1)]
+                        for name, pages in [(PoolName.KV, kv_pages)] + [
+                            (name, pages) for name, pages, _, _ in pools
+                        ]:
+                            for page in pages:
+                                Path(
+                                    backend._get_component_path(keys[page - 1], name)
+                                ).touch()
+                        transfers = [
+                            PoolTransfer(
+                                name=name, keys=keys[-window:], hit_policy=policy
+                            )
+                            for name, _, policy, window in pools
+                        ]
+                        if reverse:
+                            transfers.reverse()
+                        # Second query also exercises warm metadata-cache hits.
+                        for _ in range(2):
+                            result = backend.batch_exists_v2(keys, transfers)
+                            self.assertEqual(
+                                result.kv_hit_pages, max(expected, default=0)
+                            )
+                            self.assertEqual(result.restorable_prefix_pages, expected)
+
+    def test_aligned_checkpoints(self):
+        self.check_prefix(
+            {1, 2, 3},
+            [
+                (PoolName.SWA, {3}, PoolHitPolicy.TRAILING_PAGES, 1),
+                (PoolName.MAMBA, {3}, PoolHitPolicy.TRAILING_PAGES, 1),
+            ],
+            [3],
+        )
+
+    def test_disjoint_checkpoints(self):
+        self.check_prefix(
+            {1, 2, 3},
+            [
+                (PoolName.SWA, {3}, PoolHitPolicy.TRAILING_PAGES, 1),
+                (PoolName.MAMBA, {2}, PoolHitPolicy.TRAILING_PAGES, 1),
+            ],
+            [],
+        )
+
+    def test_preserves_non_contiguous_stop_points(self):
+        self.check_prefix(
+            {1, 2, 3},
+            [(PoolName.MAMBA, {1, 3}, PoolHitPolicy.TRAILING_PAGES, 1)],
+            [1, 3],
+        )
+
+    def test_earlier_common_checkpoint(self):
+        self.check_prefix(
+            {1, 2, 3},
+            [
+                (PoolName.SWA, {1, 3}, PoolHitPolicy.TRAILING_PAGES, 1),
+                (PoolName.MAMBA, {1, 2}, PoolHitPolicy.TRAILING_PAGES, 1),
+            ],
+            [1],
+        )
+
+    def test_all_pages_truncates_trailing_pool(self):
+        self.check_prefix(
+            {1, 2, 3},
+            [
+                (PoolName.INDEXER, {1, 2}, PoolHitPolicy.ALL_PAGES, 3),
+                (PoolName.MAMBA, {1, 3}, PoolHitPolicy.TRAILING_PAGES, 1),
+            ],
+            [1],
+        )
+
+    def test_multi_page_window_with_holes(self):
+        self.check_prefix(
+            {1, 2, 3, 4, 5},
+            [
+                (PoolName.SWA, {1, 2, 4, 5}, PoolHitPolicy.TRAILING_PAGES, 2),
+                (PoolName.MAMBA, {2, 4}, PoolHitPolicy.TRAILING_PAGES, 1),
+            ],
+            [2],
+            num_pages=5,
+        )
+
+    def test_prefix_shorter_than_window(self):
+        self.check_prefix(
+            {1, 2},
+            [(PoolName.SWA, {1, 2}, PoolHitPolicy.TRAILING_PAGES, 3)],
+            [1, 2],
+        )
+
+    def test_kv_hole_limits_auxiliary_hits(self):
+        self.check_prefix(
+            {1, 3},
+            [(PoolName.MAMBA, {3}, PoolHitPolicy.TRAILING_PAGES, 1)],
+            [],
+        )
+
+    def test_kv_only_and_empty(self):
+        self.check_prefix({1, 3}, [], [1])
+        self.check_prefix(set(), [], [])
+        self.check_prefix(set(), [], [], num_pages=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_hicache_prefix_sync.py
+++ b/test/registered/unit/mem_cache/test_hicache_prefix_sync.py
@@ -1,0 +1,301 @@
+"""CPU/Gloo coverage for hybrid storage prefix agreement across ranks."""
+
+import multiprocessing
+import tempfile
+import threading
+import time
+import unittest
+from datetime import timedelta
+from pathlib import Path
+from queue import Queue
+from unittest.mock import patch
+
+import torch.distributed as dist
+
+from sglang.srt.managers.cache_controller import (
+    HiCacheController,
+    PrefetchOperation,
+    StorageOperation,
+)
+from sglang.srt.mem_cache.hicache_storage import (
+    HiCacheFile,
+    PoolHitPolicy,
+    PoolName,
+    PoolTransfer,
+)
+from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
+    HybridCacheController,
+)
+from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
+    PrefetchOperation as HybridPrefetchOperation,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+_PAGE_SIZE = 4
+_TOKENS = list(range(4 * _PAGE_SIZE))
+_HASHES = [f"{page:064x}" for page in range(1, 5)]
+_COLLECTIVE_TIMEOUT = timedelta(seconds=30)
+_WORKER_TIMEOUT = 90
+
+
+def _controller(controller_cls, groups):
+    controller = controller_cls.__new__(controller_cls)
+    controller.page_size = _PAGE_SIZE
+    controller.prefetch_hits_sync_groups = groups
+    return controller
+
+
+def _check_file_prefetch(rank, groups, scenario):
+    """Exercise real file queries and the full hit-queue handoff, without GPUs."""
+    kv_pages = 4
+    checkpoints = (4,)
+    controller_cls = HybridCacheController
+    terminated = False
+    if scenario == "aligned":
+        expected = 4
+    elif scenario == "disjoint":
+        checkpoints = (4,) if rank % 2 == 0 else (3,)
+        expected = 0
+    elif scenario == "earlier_common":
+        checkpoints = (1, 4) if rank % 2 == 0 else (1, 3)
+        expected = 1
+    elif scenario == "kv_bound":
+        kv_pages = 4 if rank % 2 == 0 else 3
+        checkpoints = (1, 3, 4) if rank % 2 == 0 else (1, 2, 4)
+        expected = 1
+    elif scenario == "zero_hit":
+        kv_pages = 0 if rank == 0 else 4
+        expected = 0
+    elif scenario == "terminated":
+        terminated = rank == 0
+        expected = 0
+    elif scenario in ("mixed_controllers", "hybrid_kv_only"):
+        if rank % 2 == 0:
+            if scenario == "mixed_controllers":
+                controller_cls = HiCacheController
+            kv_pages = 3
+        checkpoints = (1, 4)
+        expected = 1
+    else:
+        raise AssertionError(f"Unknown scenario: {scenario}")
+
+    hashes = _HASHES
+    # Native hashing is Linux-only and independent of prefix agreement. Use
+    # fixed page keys; file lookup, controller logic and collectives stay real.
+    with (
+        tempfile.TemporaryDirectory() as directory,
+        patch("sglang.srt.mem_cache.utils.get_native_hash", return_value=hashes),
+    ):
+        backend = HiCacheFile.__new__(HiCacheFile)
+        backend.file_path = directory
+        backend.config_suffix = f"_rank{rank}"
+        backend.metadata_cache = None
+        for name, pages in (
+            (PoolName.KV, range(1, kv_pages + 1)),
+            (PoolName.MAMBA, checkpoints),
+        ):
+            for page in pages:
+                Path(backend._get_component_path(hashes[page - 1], name)).touch()
+
+        controller = _controller(controller_cls, groups)
+        controller.storage_backend = backend
+        if controller_cls is HybridCacheController:
+            operation = HybridPrefetchOperation(
+                "request",
+                _TOKENS,
+                pool_transfers=[
+                    PoolTransfer(
+                        name=PoolName.MAMBA,
+                        keys=hashes[-1:],
+                        hit_policy=PoolHitPolicy.TRAILING_PAGES,
+                    )
+                ],
+            )
+            if scenario == "hybrid_kv_only" and rank % 2 == 0:
+                operation.pool_transfers = None
+        else:
+            operation = PrefetchOperation("request", _TOKENS)
+        if terminated:
+            operation.mark_terminate()
+
+        controller.prefetch_queue = Queue()
+        controller.prefetch_hit_queue = Queue()
+        controller.prefetch_queue.put(operation)
+        # The production loop drains pending work after stop is requested.
+        controller.storage_stop_event = threading.Event()
+        controller.storage_stop_event.set()
+        controller.prefetch_thread_func()
+
+        result = controller.prefetch_hit_queue.get_nowait()
+        assert result is operation
+        assert result.storage_hit_count == expected * _PAGE_SIZE, (
+            rank,
+            scenario,
+            result.storage_hit_count,
+        )
+        assert result.hash_value == hashes[:expected], (rank, scenario)
+        assert controller.prefetch_hit_queue.empty()
+        if (
+            isinstance(operation, HybridPrefetchOperation)
+            and operation.pool_transfers
+            and expected
+        ):
+            assert expected in operation.restorable_prefix_pages
+            controller._sync_trailing_keys(
+                operation.pool_transfers, operation.all_hash_values, expected
+            )
+            assert operation.pool_transfers[0].keys == hashes[expected - 1 : expected]
+            assert Path(
+                backend._get_component_path(hashes[expected - 1], PoolName.MAMBA)
+            ).is_file()
+
+
+def _prefix_sync_worker(rank, world_size, rendezvous):
+    dist.init_process_group(
+        backend="gloo",
+        init_method=rendezvous,
+        rank=rank,
+        world_size=world_size,
+        timeout=_COLLECTIVE_TIMEOUT,
+    )
+    try:
+        groups = [dist.group.WORLD]
+        for scenario in (
+            "aligned",
+            "disjoint",
+            "earlier_common",
+            "kv_bound",
+            "zero_hit",
+            "terminated",
+            "mixed_controllers",
+            "hybrid_kv_only",
+        ):
+            _check_file_prefetch(rank, groups, scenario)
+
+        # Backends without metadata retain the legacy dense-prefix assumption.
+        # Explicit [] is different: it declares no restorable positive prefix.
+        for candidates, hit_pages, expected in (
+            (None, 3 if rank == 0 else 4, 3),
+            (None if rank == 0 else [1, 4], 3 if rank == 0 else 4, 1),
+            ([] if rank == 0 else None, 4, 0),
+        ):
+            operation = StorageOperation(None, _TOKENS)
+            operation.restorable_prefix_pages = candidates
+            controller = _controller(HiCacheController, groups)
+            actual = controller._sync_storage_hit_count(
+                operation, hit_pages * _PAGE_SIZE
+            )
+            assert actual == expected * _PAGE_SIZE, (rank, candidates, actual)
+
+        if world_size == 4:
+            # Orthogonal groups model the sequential CP/TP (or TP/PP) sync.
+            # Each row has an earlier endpoint absent from the other row.
+            groups = []
+            created_groups = []
+            for ranks in ([0, 1], [2, 3], [0, 2], [1, 3]):
+                group = dist.new_group(ranks, timeout=_COLLECTIVE_TIMEOUT)
+                if rank in ranks:
+                    groups.append(group)
+                    created_groups.append(group)
+            try:
+                operation = StorageOperation(None, _TOKENS)
+                operation.restorable_prefix_pages = (
+                    [1, 2, 4],
+                    [1, 2, 3],
+                    [1, 3, 4],
+                    [1, 3],
+                )[rank]
+                controller = _controller(HiCacheController, groups)
+                actual = controller._sync_storage_hit_count(
+                    operation, max(operation.restorable_prefix_pages) * _PAGE_SIZE
+                )
+                assert actual == _PAGE_SIZE, (rank, actual)
+            finally:
+                for group in created_groups:
+                    dist.destroy_process_group(group)
+    finally:
+        dist.destroy_process_group()
+
+
+class TestHiCachePrefixSync(CustomTestCase):
+    def test_single_rank_metadata_contract(self):
+        controller = _controller(HiCacheController, [])
+        for candidates, hit_pages, expected in (
+            (None, 3, 3),
+            ([], 3, 0),
+            ([1, 3], 3, 3),
+            ([1, 4], 3, 1),
+            ([4], 3, 0),
+            ([1, 4], 0, 0),
+        ):
+            with self.subTest(candidates=candidates, hit_pages=hit_pages):
+                operation = StorageOperation(None, _TOKENS)
+                operation.restorable_prefix_pages = candidates
+                self.assertEqual(
+                    controller._sync_storage_hit_count(
+                        operation, hit_pages * _PAGE_SIZE
+                    ),
+                    expected * _PAGE_SIZE,
+                )
+
+    def test_trailing_windows_follow_selected_endpoint(self):
+        controller = _controller(HybridCacheController, [])
+        hashes = _HASHES
+        for endpoint in (0, 1, 3):
+            with self.subTest(endpoint=endpoint):
+                transfers = [
+                    PoolTransfer(
+                        name=pool,
+                        keys=hashes[-window:],
+                        hit_policy=PoolHitPolicy.TRAILING_PAGES,
+                    )
+                    for pool, window in ((PoolName.MAMBA, 1), (PoolName.SWA, 2))
+                ]
+                controller._sync_trailing_keys(transfers, hashes, endpoint)
+                self.assertEqual(
+                    transfers[0].keys, hashes[max(0, endpoint - 1) : endpoint]
+                )
+                self.assertEqual(
+                    transfers[1].keys, hashes[max(0, endpoint - 2) : endpoint]
+                )
+
+    def _run_distributed(self, world_size):
+        if not dist.is_available() or not dist.is_gloo_available():
+            self.skipTest("Gloo is required for CPU prefix synchronization")
+        context = multiprocessing.get_context("spawn")
+        with tempfile.TemporaryDirectory() as directory:
+            rendezvous = Path(directory, "rendezvous").as_uri()
+            workers = [
+                context.Process(
+                    target=_prefix_sync_worker,
+                    args=(rank, world_size, rendezvous),
+                )
+                for rank in range(world_size)
+            ]
+            try:
+                for worker in workers:
+                    worker.start()
+                deadline = time.monotonic() + _WORKER_TIMEOUT
+                for rank, worker in enumerate(workers):
+                    worker.join(max(0, deadline - time.monotonic()))
+                    self.assertFalse(worker.is_alive(), f"Rank {rank} timed out")
+                    self.assertEqual(worker.exitcode, 0, f"Rank {rank} failed")
+            finally:
+                for worker in workers:
+                    if worker.is_alive():
+                        worker.terminate()
+                    if worker.pid is not None:
+                        worker.join(timeout=5)
+
+    def test_two_ranks(self):
+        self._run_distributed(2)
+
+    def test_four_ranks(self):
+        self._run_distributed(4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #39147.

Supersedes #39149, which remains closed after GitHub rejected reopening it. This revision was locally validated before resubmission.

Sparse trailing pools have non-contiguous legal restore endpoints. Taking the minimum of per-pool or per-rank maxima can select an endpoint that a required pool cannot restore. For example, `{1, 3}` and `{1, 2}` share endpoint 1, not 2.

This revision covers both the file backend's local pool intersection and the controller's cross-rank agreement. The original version only covered the first step.

## Modifications

- Intersect legal endpoints in `HiCacheFile.batch_exists_v2()`, retaining a linear scan for trailing windows and returning the complete `restorable_prefix_pages` list.
- Preserve backend candidate endpoints on the storage operation instead of dropping them after the hybrid query.
- Use a fixed-size first reduction to agree on the hit upper bound and whether endpoint metadata is present. If needed, intersect equally sized endpoint masks over the existing TP/CP/PP synchronization groups.
- Keep the same collective protocol for plain KV and hybrid controllers, including when one rank terminates its request before querying. Distinguish an empty candidate list from unavailable metadata.
- Preserve legacy behavior for backends without endpoint metadata; this does not extend the guarantee to sparse trailing backends that still return `None`.
- Add nine file-query regression tests and four synchronization test methods, including real 2/4-process Gloo communication, orthogonal groups, mixed controllers, early termination and trailing-key realignment.

## Accuracy Tests

Standard pytest execution on macOS / Apple Silicon with Python 3.12.14 and Torch 2.13.0:

```bash
python -m pytest -q -rs \
  test/registered/unit/mem_cache/test_hicache_file_prefix.py \
  test/registered/unit/mem_cache/test_hicache_prefix_sync.py \
  test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py \
  test/registered/unit/mem_cache/test_hicache_file_lru_unit.py \
  test/registered/unit/mem_cache/test_mooncake_group_semantics.py
```

Result: **73 passed, 1 skipped**, plus 53 subtests. The skip is the existing, unmodified Mamba write-back staging test marked disabled upstream.

- The tests import the actual controllers normally through the repository's existing Apple Silicon compatibility layer. The earlier isolated-import limitation came from the local sandbox not exposing MPS; this revision was tested outside that sandbox.
- Distributed tests use real Gloo process groups, actual file existence queries, the production prefetch loop and its hit-queue handoff. Only the unrelated Linux-only native page hashing is replaced with fixed fixture keys; controller/query logic and collectives are not mocked.
- A local negative control using the old scalar MIN with the same two-rank file fixture incorrectly selects 12 tokens; the new synchronization selects the expected 4 tokens on both ranks.
- Multiprocessing-aware coverage reports **100% of 36 changed executable production lines** against the rebased `origin/main`. This is line coverage, not proof of complete behavioral coverage.
- All applicable pre-commit hooks pass for all five changed files.

## Scope and Remaining Validation

No model weights or GPU E2E run were used. This fixes the demonstrated endpoint-selection mechanisms, but does not establish that it resolves every cause of the zero-L3-hit report in the issue comment. The scheduler/stub path described in [#38452](https://github.com/sgl-project/sglang/issues/38452), missing backup data, and backends without legal endpoint candidates are outside this PR's scope.

The former CI failures were `run-ci` label gates and their dependent summary jobs; lint was canceled when the PR was closed. No CI gate or test was disabled by this revision. An authorized maintainer still needs to enable CI for the current commit.

## Speed Tests and Profiling

Local endpoint scanning remains linear in the number of candidate pages. Cross-rank synchronization adds one mask reduction only when endpoint metadata is available and the common upper bound is positive. Mask size is bounded by that synchronized upper bound. No model-serving throughput benchmark was run.

## Checklist

- [x] Focused regression tests and real CPU/Gloo multi-process tests pass locally.
- [x] Related component regressions and changed-file pre-commit checks pass.
- [x] Incremental production line coverage meets the repository threshold.
- [x] Local limitations and legacy-backend behavior are documented above.
- [ ] Upstream CI and GPU E2E validation.

## Review and Merge Process

Please review the collective protocol and file-backend restore semantics. Could an authorized maintainer enable and rerun CI for this revision with `/tag-and-rerun-ci`? AI assistance was used for investigation, implementation and testing.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34738161869](https://github.com/sgl-project/sglang/actions/runs/34738161869)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34738161749](https://github.com/sgl-project/sglang/actions/runs/34738161749)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34738161837](https://github.com/sgl-project/sglang/actions/runs/34738161837)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->