### PR TITLE
[HiCache] Treat file read errors as cache misses

### DIFF
--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -489,10 +489,10 @@ class HiCacheFile(HiCacheStorage):
             if self.metadata_cache is not None:
                 self.metadata_cache.add(suffixed)
             return target_location
-        except FileNotFoundError:
+        except OSError as e:
             if self.metadata_cache is not None:
                 self.metadata_cache.remove(suffixed)
-            logger.warning(f"Failed to fetch {key} from HiCacheFile storage.")
+            logger.warning(f"Failed to fetch {key} from HiCacheFile storage: {e}")
             return None
 
     def batch_get(

--- a/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
+++ b/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
@@ -16,6 +16,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 
+import errno
 import os
 import shutil
 import tempfile
@@ -179,6 +180,59 @@ class TestEvictionDisabledByDefault(HiCacheFileLRUTestBase):
         # No tracking happens.
         self.assertEqual(len(b._evictor._lru), 0)
         self.assertEqual(b._evictor._total_bytes, 0)
+
+
+class TestReadErrors(HiCacheFileLRUTestBase):
+    def test_short_read_returns_miss(self):
+        for enable_metadata_cache in (False, True):
+            for size in (0, 7):
+                with self.subTest(metadata=enable_metadata_cache, size=size):
+                    b = self.make_backend(enable_metadata_cache=enable_metadata_cache)
+                    self.assertTrue(b.set("key", _t(8, fill=1)))
+                    with open(b._get_component_path("key"), "r+b") as f:
+                        f.truncate(size)
+
+                    self.assertIsNone(b.get("key", _t(8)))
+                    if b.metadata_cache is not None:
+                        self.assertFalse(
+                            b.metadata_cache.contains(b._get_suffixed_key("key"))
+                        )
+
+    def test_os_error_returns_miss_and_later_read_succeeds(self):
+        b = self.make_backend(enable_metadata_cache=True)
+        value = _t(8, fill=3)
+        self.assertTrue(b.set("key", value))
+        for error in (errno.EIO, errno.EACCES):
+            with self.subTest(errno=error):
+                self.assertTrue(b.metadata_cache.contains(b._get_suffixed_key("key")))
+                with mock.patch(
+                    "builtins.open", side_effect=OSError(error, "read failed")
+                ):
+                    self.assertIsNone(b.get("key", _t(8)))
+                self.assertFalse(b.metadata_cache.contains(b._get_suffixed_key("key")))
+                # A transient read error must not delete a valid cached page.
+                self.assertTrue(torch.equal(b.get("key", _t(8)), value))
+
+    def test_batch_get_continues_after_short_read(self):
+        b = self.make_backend(enable_metadata_cache=False)
+        keys = ["first", "short", "last"]
+        for key in keys:
+            self.assertTrue(b.set(key, _t(8, fill=5)))
+        with open(b._get_component_path("short"), "r+b") as f:
+            f.truncate(7)
+
+        results = b.batch_get(keys, [_t(8) for _ in keys])
+        self.assertEqual(len(results), 3)
+        self.assertTrue(torch.equal(results[0], _t(8, fill=5)))
+        self.assertIsNone(results[1])
+        self.assertTrue(torch.equal(results[2], _t(8, fill=5)))
+
+    def test_non_io_error_propagates(self):
+        b = self.make_backend(enable_metadata_cache=False)
+        self.assertTrue(b.set("key", _t(8)))
+        with mock.patch("builtins.open", side_effect=ValueError("unexpected error")):
+            with self.assertRaisesRegex(ValueError, "unexpected error"):
+                b.get("key", _t(8))
 
 
 class TestCapBasedEviction(HiCacheFileLRUTestBase):


### PR DESCRIPTION
## Motivation

A truncated HiCache file raises `IOError` (`OSError` in Python 3), but `HiCacheFile.get()` only catches `FileNotFoundError`. The error escapes `batch_get()` and can terminate the storage prefetch I/O worker before it emits its completion acknowledgement. Other file I/O errors, such as EIO, have the same failure path.

## Modifications

- Catch `OSError` in `HiCacheFile.get()`, invalidate the positive metadata entry, log the cause, and return `None`. This lets the existing cache-miss path retain the valid prefix and emit the expected prefetch acknowledgements.
- Add CPU regression coverage for empty/truncated files with metadata caching enabled and disabled, EIO/EACCES followed by a successful read, a failed page inside `batch_get()`, and propagation of non-I/O exceptions.

Corrupt-page repair is outside this fix. A transient read failure does not delete the file.

## Accuracy Tests

- Verified the new short-read and I/O-error cases fail against unpatched main.
- The complete file-backend unit test file passes after the fix: **38 tests and 6 subtests**, using real CPU PyTorch 2.13.0 tensors and real file I/O (EIO/EACCES injected).
- On this macOS host, a local import harness bypassed unrelated GPU/server package initialization. Storage, eviction, environment, and test modules were imported unchanged; required utility definitions were loaded from their original source ASTs. This was local component validation; normal package-level CI is still needed.
- An additional local CPU harness executed the unchanged prefetch controller methods for a 129-page request with a short read, then a healthy request. It verified both batch acknowledgements and completion, installation of only the valid prefix, and continued operation of the same worker. This does not validate distributed collectives or GPU inference.

The registered CPU test entry point is `test/registered/unit/mem_cache/test_hicache_file_lru_unit.py`.

## Speed Tests and Profiling

Not run. This change handles file-read failures; no performance claim is made.

## Checklist

- [x] Format code with the repository's pre-commit hooks.
- [x] Add unit tests to an existing registered CPU test file.
- [ ] Update documentation (not applicable to this error-handling fix).
- [ ] Provide accuracy and speed benchmarks (GPU/model benchmarks not run).
- [x] Follow the existing SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34739155279](https://github.com/sgl-project/sglang/actions/runs/34739155279)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34739155091](https://github.com/sgl-project/sglang/actions/runs/34739155091)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34739155210](https://github.com/sgl-project/sglang/actions/runs/34739155210)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->