### PR TITLE
[Bugfix] Fix non-streaming TTFT and speculative output batching

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -441,9 +441,15 @@ class _GenerationStreamAccumulator:
                     # check_match_stop_str_prefix if  tail_str's suffix match stop_str prefix
                     should_output &= not req.check_match_stop_str_prefix()
             else:
-                should_output = (
+                # Send the first output through detokenization immediately so
+                # non-streaming TTFT includes detok without waiting for a batch.
+                # Speculative decoding may produce several first tokens at once.
+                first_output = req.send_token_offset == 0 and bool(req.output_ids)
+                should_output = first_output or (
                     len(req.output_ids) % self.default_force_stream_interval == 0
                 )
+                if first_output:
+                    should_output &= not req.check_match_stop_str_prefix()
 
         if not should_output:
             return

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -441,12 +441,16 @@ class _GenerationStreamAccumulator:
                     # check_match_stop_str_prefix if  tail_str's suffix match stop_str prefix
                     should_output &= not req.check_match_stop_str_prefix()
             else:
-                # Send the first output through detokenization immediately so
-                # non-streaming TTFT includes detok without waiting for a batch.
-                # Speculative decoding may produce several first tokens at once.
-                first_output = req.send_token_offset == 0 and bool(req.output_ids)
+                # Flush the first token block for arrival-based TTFT, then each
+                # crossed interval. Speculative decoding can skip exact multiples.
+                output_len = len(req.output_ids)
+                first_output = req.send_token_offset == 0 and output_len > 0
                 should_output = first_output or (
-                    len(req.output_ids) % self.default_force_stream_interval == 0
+                    # Preserve exact-boundary sends, including empty metadata
+                    # output for prefill-only/logprob requests.
+                    output_len % self.default_force_stream_interval == 0
+                    or output_len // self.default_force_stream_interval
+                    > req.send_token_offset // self.default_force_stream_interval
                 )
                 if first_output:
                     should_output &= not req.check_match_stop_str_prefix()

--- a/test/registered/unit/managers/test_first_token_timestamp.py
+++ b/test/registered/unit/managers/test_first_token_timestamp.py
@@ -25,7 +25,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
-def accumulator():
+def accumulator(force_interval=50):
     return _GenerationStreamAccumulator(
         return_logprob=False,
         return_hidden_states=False,
@@ -34,15 +34,15 @@ def accumulator():
         spec_algorithm=SimpleNamespace(is_none=lambda: True),
         disaggregation_mode=DisaggregationMode.NULL,
         default_stream_interval=1,
-        default_force_stream_interval=50,
+        default_force_stream_interval=force_interval,
         get_cached_tokens_details=lambda req: None,
         current_weight_version=None,
     )
 
 
 class TestFirstTokenFlush(unittest.TestCase):
-    def emit(self, req):
-        acc = accumulator()
+    def emit(self, req, force_interval=50):
+        acc = accumulator(force_interval)
         acc.accept(req=req)
         return acc.to_payload(dp_rank=0, is_idle_batch=False)
 
@@ -67,6 +67,46 @@ class TestFirstTokenFlush(unittest.TestCase):
         req._finished = True
         req.finished_reason = SimpleNamespace(to_json=lambda: {"type": "length"})
         self.assertEqual(self.emit(req).output_ids, [list(range(50, 53))])
+        self.assertTrue(req.finished_output)
+
+    def test_speculative_steps_flush_when_crossing_force_interval(self):
+        cases = (
+            (50, [1, 8, 49, 53, 99, 106, 128], [1, 53, 106, 128]),
+            (50, [8, 49, 53, 99, 106, 128], [8, 53, 106, 128]),
+            (50, [1, 112, 113, 128], [1, 112, 128]),
+            (3, [1, 2, 4, 5, 8, 10], [1, 4, 8, 10]),
+            (1, [1, 8, 9], [1, 8, 9]),
+        )
+        for interval, counts, expected_flushes in cases:
+            with self.subTest(interval=interval, counts=counts):
+                req = _FakeReq("test", [])
+                flushes, received = [], []
+                for count in counts:
+                    req.output_ids = req.output_ids_through_stop = list(range(count))
+                    if count == counts[-1]:
+                        req._finished = True
+                        req.finished_reason = SimpleNamespace(
+                            to_json=lambda: {"type": "length"}
+                        )
+                    payload = self.emit(req, interval)
+                    if payload is not None:
+                        flushes.append(count)
+                        received.extend(payload.output_ids[0])
+                self.assertEqual(flushes, expected_flushes)
+                self.assertEqual(received, list(range(counts[-1])))
+
+    def test_empty_output_preserves_metadata_flush(self):
+        req = _FakeReq("test", [])
+        payload = self.emit(req)
+        self.assertEqual(payload.output_ids, [[]])
+        self.assertEqual(payload.finished_reasons, [None])
+        self.assertFalse(req.finished_output)
+
+    def test_empty_finished_request_still_flushes(self):
+        req = _FakeReq("test", [], finished=True)
+        payload = self.emit(req)
+        self.assertEqual(payload.output_ids, [[]])
+        self.assertIsNotNone(payload.finished_reasons[0])
         self.assertTrue(req.finished_output)
 
     def test_first_output_waits_for_stop_prefix_to_clear(self):
@@ -175,9 +215,29 @@ class TestNonstreamMetrics(unittest.IsolatedAsyncioTestCase):
                         output_length=output_length,
                         skip_detokenizer=skip_detokenizer,
                     ):
-                        await self._check_request(mode, output_length, skip_detokenizer)
+                        await self._check_request(
+                            mode,
+                            list(range(1, output_length + 1)),
+                            skip_detokenizer,
+                            [1, 16] if output_length == 16 else [1, 50, 100, 128],
+                        )
 
-    async def _check_request(self, mode, output_length, skip_detokenizer):
+    async def test_speculative_payloads_preserve_ttft_and_final_response(self):
+        for mode in (DisaggregationMode.NULL, DisaggregationMode.DECODE):
+            for skip_detokenizer in (False, True):
+                for counts, expected_flushes in (
+                    ([1, 8, 49, 53, 99, 106, 128], [1, 53, 106, 128]),
+                    ([8, 49, 53, 99, 106, 128], [8, 53, 106, 128]),
+                    ([1, 112, 128], [1, 112, 128]),
+                ):
+                    with self.subTest(
+                        mode=mode, skip_detokenizer=skip_detokenizer, counts=counts
+                    ):
+                        await self._check_request(
+                            mode, counts, skip_detokenizer, expected_flushes
+                        )
+
+    async def _check_request(self, mode, counts, skip_detokenizer, expected_flushes):
         manager = _make_tokenizer_manager(self)
         manager.disaggregation_mode = mode
         manager.enable_metrics = True
@@ -207,8 +267,9 @@ class TestNonstreamMetrics(unittest.IsolatedAsyncioTestCase):
             "sglang.srt.observability.req_time_stats.time",
             SimpleNamespace(perf_counter=lambda: clock.now),
         ):
-            for count in range(1, output_length + 1):
-                req.output_ids.append(10)
+            output_length = counts[-1]
+            for count in counts:
+                req.output_ids.extend([10] * (count - len(req.output_ids)))
                 if count == output_length:
                     req._finished = True
                     req.finished_reason = SimpleNamespace(
@@ -223,15 +284,15 @@ class TestNonstreamMetrics(unittest.IsolatedAsyncioTestCase):
                 flushes.append(count)
                 if not skip_detokenizer:
                     payload = detokenizer.handle_batch_token_id_out(payload)
-                # The first token is ready at 101; include 200 ms for delivery
+                # The first block is ready at 101; include 200 ms for delivery
                 # and detokenization, then 10 ms per additional generated token.
-                clock.now = 101.2 + (count - 1) * 0.01
+                clock.now = 101.2 + (count - counts[0]) * 0.01
                 await manager._handle_batch_output(payload)
                 self.assertAlmostEqual(state.time_stats.first_token_time, 101.2)
                 self.assertEqual(state.event.is_set(), count == output_length)
                 self.assertEqual(len(state.out_list), int(count == output_length))
 
-        self.assertEqual(flushes, [1, 16] if output_length == 16 else [1, 50, 100, 128])
+        self.assertEqual(flushes, expected_flushes)
         self.assertEqual(state.out_list[0]["output_ids"], [10] * output_length)
         if not skip_detokenizer:
             self.assertEqual(state.out_list[0]["text"], "x" * output_length)
@@ -241,7 +302,7 @@ class TestNonstreamMetrics(unittest.IsolatedAsyncioTestCase):
         self.assertAlmostEqual(observe.call_args.args[1], 1.2)
         self.assertEqual(observe.call_args.kwargs, {"stream": False})
         self.assertAlmostEqual(
-            state.time_stats.get_e2e_latency(), 1.2 + (output_length - 1) * 0.01
+            state.time_stats.get_e2e_latency(), 1.2 + (output_length - counts[0]) * 0.01
         )
 
 

--- a/test/registered/unit/managers/test_first_token_timestamp.py
+++ b/test/registered/unit/managers/test_first_token_timestamp.py
@@ -1,0 +1,249 @@
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from test_output_streamer_customized_info import _FakeReq
+from test_tokenizer_manager_rid_cleanup import (
+    _make_req_state,
+    _make_tokenizer_manager,
+)
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.detokenizer_manager import DetokenizerManager
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.managers.scheduler_components.output_streamer import (
+    _GenerationStreamAccumulator,
+)
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.observability.req_time_stats import (
+    APIServerReqTimeStats,
+    SchedulerReqTimeStats,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def accumulator():
+    return _GenerationStreamAccumulator(
+        return_logprob=False,
+        return_hidden_states=False,
+        return_routed_experts=False,
+        return_indexer_topk=False,
+        spec_algorithm=SimpleNamespace(is_none=lambda: True),
+        disaggregation_mode=DisaggregationMode.NULL,
+        default_stream_interval=1,
+        default_force_stream_interval=50,
+        get_cached_tokens_details=lambda req: None,
+        current_weight_version=None,
+    )
+
+
+class TestFirstTokenFlush(unittest.TestCase):
+    def emit(self, req):
+        acc = accumulator()
+        acc.accept(req=req)
+        return acc.to_payload(dp_rank=0, is_idle_batch=False)
+
+    def test_nonstream_first_token_and_speculative_block_flush_immediately(self):
+        for count in (1, 8, 50):
+            with self.subTest(count=count):
+                req = _FakeReq("test", list(range(count)))
+                payload = self.emit(req)
+                self.assertEqual(payload.output_ids, [list(range(count))])
+                self.assertEqual(req.send_token_offset, count)
+                self.assertEqual(payload.finished_reasons, [None])
+                self.assertFalse(req.stream)
+
+    def test_subsequent_outputs_keep_batching_without_duplicate_tokens(self):
+        req = _FakeReq("test", list(range(8)))
+        self.assertEqual(self.emit(req).output_ids, [list(range(8))])
+        req.output_ids = req.output_ids_through_stop = list(range(9))
+        self.assertIsNone(self.emit(req))
+        req.output_ids = req.output_ids_through_stop = list(range(50))
+        self.assertEqual(self.emit(req).output_ids, [list(range(8, 50))])
+        req.output_ids = req.output_ids_through_stop = list(range(53))
+        req._finished = True
+        req.finished_reason = SimpleNamespace(to_json=lambda: {"type": "length"})
+        self.assertEqual(self.emit(req).output_ids, [list(range(50, 53))])
+        self.assertTrue(req.finished_output)
+
+    def test_first_output_waits_for_stop_prefix_to_clear(self):
+        req = _FakeReq("test", [10])
+        req.check_match_stop_str_prefix = Mock(return_value=True)
+        self.assertIsNone(self.emit(req))
+        self.assertEqual(req.send_token_offset, 0)
+        req.output_ids = req.output_ids_through_stop = [10, 11]
+        req.check_match_stop_str_prefix.return_value = False
+        self.assertEqual(self.emit(req).output_ids, [[10, 11]])
+
+    def test_stop_prefix_blocks_first_output_even_at_batch_boundary(self):
+        req = _FakeReq("test", list(range(50)))
+        req.check_match_stop_str_prefix = Mock(return_value=True)
+        self.assertIsNone(self.emit(req))
+
+    def test_finished_request_flushes_even_with_stop_prefix(self):
+        req = _FakeReq("test", [10], finished=True)
+        req.check_match_stop_str_prefix = Mock(return_value=True)
+        self.assertEqual(self.emit(req).output_ids, [[10]])
+        req.check_match_stop_str_prefix.assert_not_called()
+
+    def test_streaming_interval_and_stop_prefix_are_preserved(self):
+        req = _FakeReq("test", [10])
+        req.stream = True
+        req.sampling_params.stream_interval = 3
+        req.check_match_stop_str_prefix = Mock(return_value=True)
+        self.assertIsNone(self.emit(req))
+        req.check_match_stop_str_prefix.return_value = False
+        self.assertEqual(self.emit(req).output_ids, [[10]])
+        req.output_ids = req.output_ids_through_stop = [10, 11]
+        self.assertIsNone(self.emit(req))
+        req.output_ids = req.output_ids_through_stop = [10, 11, 12, 13]
+        self.assertEqual(self.emit(req).output_ids, [[11, 12, 13]])
+
+    def test_beam_candidates_remain_buffered(self):
+        req = _FakeReq("test", [10])
+        req.beam_group = object()
+        for is_leader in (False, True):
+            req.is_beam_leader = is_leader
+            self.assertIsNone(self.emit(req))
+            self.assertEqual(req.send_token_offset, 0)
+
+    def test_ttft_includes_post_generation_delivery_time(self):
+        # Generation at 12, followed by IPC and detok until arrival at 15.
+        api = APIServerReqTimeStats(
+            created_time=10, first_token_time=15, last_time=15, finished_time=30
+        )
+        self.assertEqual(api.get_first_token_latency(), 5)
+        self.assertEqual(api.get_decode_latency(), 15)
+        self.assertEqual(api.get_e2e_latency(), 20)
+        self.assertEqual(
+            api.get_first_token_latency() + api.get_decode_latency(),
+            api.get_e2e_latency(),
+        )
+
+
+class TestNonstreamResponse(unittest.IsolatedAsyncioTestCase):
+    async def test_first_internal_output_does_not_yield_to_client(self):
+        manager = SimpleNamespace(
+            incremental_streaming_output=False,
+            request_logger=Mock(),
+            request_metrics_exporter_manager=SimpleNamespace(
+                exporter_enabled=lambda: False
+            ),
+        )
+        obj = SimpleNamespace(rid="test", stream=False)
+        state = SimpleNamespace(
+            event=asyncio.Event(),
+            out_list=[{"text": None, "meta_info": {}}],
+            finished=False,
+            time_stats=SimpleNamespace(response_sent_to_client_time=1),
+        )
+        state.event.set()
+        response = TokenizerManager._stream_one_response(manager, obj, state)
+        pending = asyncio.create_task(response.__anext__())
+        try:
+
+            async def wait_until_consumed():
+                while state.event.is_set():
+                    await asyncio.sleep(0)
+
+            await asyncio.wait_for(wait_until_consumed(), timeout=1)
+            self.assertFalse(pending.done())
+            final = {"text": "complete output", "meta_info": {}}
+            state.out_list.append(final)
+            state.finished = True
+            state.event.set()
+            self.assertEqual(await asyncio.wait_for(pending, timeout=1), final)
+            with self.assertRaises(StopAsyncIteration):
+                await response.__anext__()
+        finally:
+            if not pending.done():
+                pending.cancel()
+                await asyncio.gather(pending, return_exceptions=True)
+            await response.aclose()
+
+
+class TestNonstreamMetrics(unittest.IsolatedAsyncioTestCase):
+    async def test_first_payload_records_ttft_without_notifying_client(self):
+        for mode in (DisaggregationMode.NULL, DisaggregationMode.DECODE):
+            for output_length in (16, 128):
+                for skip_detokenizer in (False, True):
+                    with self.subTest(
+                        mode=mode,
+                        output_length=output_length,
+                        skip_detokenizer=skip_detokenizer,
+                    ):
+                        await self._check_request(mode, output_length, skip_detokenizer)
+
+    async def _check_request(self, mode, output_length, skip_detokenizer):
+        manager = _make_tokenizer_manager(self)
+        manager.disaggregation_mode = mode
+        manager.enable_metrics = True
+        manager.enable_priority_scheduling = False
+        manager.metrics_collector = Mock(labels={})
+        state = _make_req_state("test")
+        state.obj = GenerateReqInput(
+            rid="test", text="test", stream=False, sampling_params={}, log_metrics=True
+        )
+        state.time_stats.created_time = 100.0
+        manager.rid_to_state["test"] = state
+        req = _FakeReq("test", [])
+        req.time_stats = SchedulerReqTimeStats()
+
+        detokenizer = DetokenizerManager.__new__(DetokenizerManager)
+        detokenizer.decode_status = {}
+        detokenizer.disable_tokenizer_batch_decode = True
+        detokenizer.is_tool_call_parser_gpt_oss = False
+        detokenizer.vocab_size = 100
+        detokenizer.tokenizer = SimpleNamespace(
+            decode=lambda ids, **kwargs: "x" * len(ids)
+        )
+
+        flushes = []
+        clock = SimpleNamespace(now=100.0)
+        with patch(
+            "sglang.srt.observability.req_time_stats.time",
+            SimpleNamespace(perf_counter=lambda: clock.now),
+        ):
+            for count in range(1, output_length + 1):
+                req.output_ids.append(10)
+                if count == output_length:
+                    req._finished = True
+                    req.finished_reason = SimpleNamespace(
+                        to_json=lambda: {"type": "length"}
+                    )
+                acc = accumulator()
+                acc.disaggregation_mode = mode
+                acc.accept(req=req)
+                payload = acc.to_payload(dp_rank=0, is_idle_batch=False)
+                if payload is None:
+                    continue
+                flushes.append(count)
+                if not skip_detokenizer:
+                    payload = detokenizer.handle_batch_token_id_out(payload)
+                # The first token is ready at 101; include 200 ms for delivery
+                # and detokenization, then 10 ms per additional generated token.
+                clock.now = 101.2 + (count - 1) * 0.01
+                await manager._handle_batch_output(payload)
+                self.assertAlmostEqual(state.time_stats.first_token_time, 101.2)
+                self.assertEqual(state.event.is_set(), count == output_length)
+                self.assertEqual(len(state.out_list), int(count == output_length))
+
+        self.assertEqual(flushes, [1, 16] if output_length == 16 else [1, 50, 100, 128])
+        self.assertEqual(state.out_list[0]["output_ids"], [10] * output_length)
+        if not skip_detokenizer:
+            self.assertEqual(state.out_list[0]["text"], "x" * output_length)
+        observe = manager.metrics_collector.observe_time_to_first_token
+        observe.assert_called_once()
+        self.assertEqual(observe.call_args.args[0], {})
+        self.assertAlmostEqual(observe.call_args.args[1], 1.2)
+        self.assertEqual(observe.call_args.kwargs, {"stream": False})
+        self.assertAlmostEqual(
+            state.time_stats.get_e2e_latency(), 1.2 + (output_length - 1) * 0.01
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Non-streaming generation currently delays its first internal output until the force-stream interval is reached (50 tokens by default), or until the request finishes. `TokenizerManager` records `first_token_time` when it receives the first output batch, so `sglang:time_to_first_token_seconds{is_streaming="false"}` includes time spent generating additional tokens. A short non-streaming request can consequently report nearly its entire request latency as TTFT.

The same output gate also misses periodic flushes during speculative decoding: accepted token blocks can jump across a multiple of the force-stream interval without landing on it. For example, a step from 49 to 53 accumulated tokens does not satisfy `% 50 == 0`. Repeated jumps can postpone detokenization and API-side progress accounting until the final output.

This change fixes both the initial output delay and skipped periodic flushes, and protects later non-streaming flushes against partial stop-string leakage. It applies to the unified Python serving path and the PD decode output path, which share the accumulator. Non-streaming clients still receive a single complete final response.

### Root cause

The current non-streaming condition is:

```python
len(req.output_ids) % self.default_force_stream_interval == 0
```

It has two consequences:

1. The first ordinary prefill output has one token and fails the gate. The API-side first-token timestamp is not recorded until a later emitted payload arrives.
2. The gate requires an exact token-count multiple. A speculative block that crosses a boundary without hitting it produces no periodic payload.

Suppressing intermediate client responses happens later in `TokenizerManager` and does not correct either internal-output delay.

## Modifications

The non-streaming gate now sends the first nonempty token block immediately, unless its tail matches a stop-string prefix. It uses `send_token_offset` to identify whether any output tokens have already been sent, so an initial speculative block is handled just like an initial single token.

Subsequent output preserves the existing exact-boundary condition and also flushes when the accumulated token count crosses an interval boundary since the previous send:

```python
output_len // force_interval > send_token_offset // force_interval
```

The check uses the existing token offset; it does not add another per-request counter. Crossing several intervals in one speculative step produces one payload containing the unsent token delta. Ordinary one-token decoding retains the same 50/100/... periodic boundaries, subject to stop-prefix deferral, rather than shifting them to 51/101/... after the new initial flush.

With no pending stop-string prefix, for a final length of 128 and an interval of 50:

| Accumulated tokens after each step | Internal payload boundaries before | Internal payload boundaries after |
|---|---|---|
| Every token from 1 through 128 | `[50, 100, 128]` | `[1, 50, 100, 128]` |
| `[1, 8, 49, 53, 99, 106, 128]` | `[128]` | `[1, 53, 106, 128]` |
| `[8, 49, 53, 99, 106, 128]` | `[128]` | `[8, 53, 106, 128]` |
| `[1, 112, 113, 128]` | `[128]` | `[1, 112, 128]` |

### Stop-prefix safety (review follow-up)

As pointed out in [review](https://github.com/sgl-project/sglang/pull/39270#issuecomment-5651357605), the stop-prefix guard must apply to **every eligible unfinished non-streaming flush**, not just the first output:

```python
if should_output:
    should_output &= not req.check_match_stop_str_prefix()
```

Non-streaming delivery is final-only at the client boundary, but intermediate text already accumulates downstream. `DetokenizerManager` tracks its sent text offset and `TokenizerManager` appends each delta. Trimming a completed stop string later cannot retract a prefix already appended to the API-side buffer. The ordinary exact-boundary gap predates this PR; speculative boundary-crossing flushes need the same protection. This is the non-streaming counterpart of the issue discussed in #11462.

For stop string `STOP`, the regression reproduces a trailing `S` with 49 ordinary characters before the stop, and a trailing `ST` with 51 characters and speculative counts `[1, 49, 53, 55]`. Both are absent with the extended guard.

Deferral leaves token/decode send offsets unchanged. If the suffix ceases to match, the crossed-boundary condition releases the entire buffered delta without waiting for the next exact multiple. The finished-output path still bypasses deferral; stop trimming, `no_stop_trim`, and an unmatched prefix at length termination retain their existing semantics.

### Compatibility and response behavior

- The finished-output path still takes precedence, including zero-token completion notifications.
- Existing exact-boundary sends remain permitted. In particular, empty token payloads can carry prefill-only logprobs or other metadata; they must not be dropped by treating every empty output as redundant.
- Streaming requests retain their existing interval and stop-prefix logic. Beam admission is still evaluated before the non-streaming gate.
- `send_token_offset` continues to delimit each token delta, preventing duplicated tokens in the assembled final response.
- Intermediate non-streaming payloads accumulate in `TokenizerManager` with `out_dict=None`; they do not append a client response or set the response event.
- The PD prebuilt result handler sends the handoff token through the same accumulator. The prefill role's existing TTFT histogram exclusion remains in effect.

### Metric semantics

TTFT still measures request creation to the first processed internal output at the API server. Internal transport and detokenization remain included; the change does not replace the arrival timestamp with a scheduler-ready timestamp.

Stop-prefix protection and beam admission can still delay output. An output may contain no printable text, and existing metadata-only output paths remain supported. The metric is not a measurement of the first visible character or of client receipt.

The earlier first output also restores the API-side decode latency interval and accounts for decode intervals previously swallowed by the initial batch. Later non-streaming ITL observations remain averages between emitted batches; the change does not provide a per-step latency distribution.

## Accuracy Tests

Validation used CPU component tests with synthetic token production, a deterministic tokenizer double, and controlled timestamps. The production accumulator, detokenizer, TokenizerManager output handler, and metric collection path are exercised. No live model, model-quality evaluation, or cross-machine PD transfer benchmark was run.

### Regression coverage

The committed tests cover:

- The first single token and an initial speculative block.
- Ordinary periodic batching and complete, nonduplicated token deltas.
- Speculative steps crossing one or several interval boundaries.
- Configurable force intervals of 1, 3, and 50.
- Stop-prefix deferral at initial, exact-boundary, speculative-crossing, and multi-interval flushes, including unchanged offsets while deferred and immediate release after the prefix clears.
- Full-stop trimming, `no_stop_trim`, overlapping stop strings, and length termination with an unmatched stop prefix through real `Req`, detokenizer, and tokenizer-manager paths.
- Finished-output precedence, empty metadata output, and empty final output.
- Existing streaming interval behavior and beam admission.

The component regression additionally covers unified and PD decode modes, text through the real DetokenizerManager and direct token-ID payloads, short/long ordinary output, and three speculative token-count sequences. It verifies:

1. The first non-streaming token block records TTFT without waiting for the force interval.
2. A simulated 200 ms transport/detokenization delay remains included.
3. Subsequent flushes do not overwrite the first-token timestamp.
4. TTFT is observed exactly once with `stream=False`.
5. Intermediate output neither populates the response list nor sets the response event.
6. The final text/token sequence is complete and contains no duplicated tokens.
7. E2E remains the elapsed time to the final output.

### Red/green validation

The selected TTFT and speculative-boundary regressions were run against the unmodified upstream main Python package at `7763f666f348d99e28a3dc839e99adf5cd7e1861`: **24 regression subcases failed as expected**. These include eight ordinary-output metric cases, twelve speculative-output metric cases, and four accumulator boundary cases.

The new stop-prefix regressions were also run against the previous PR head, `922091cd6982bd63a865de64a09e1d11c492f515`: **19 expected assertion failures**, including the leaked `S`/`ST` final-response cases. They pass with the extended guard.

On this branch, the five-file test set below passed: **64 tests and 49 subtests**. Existing metadata, logprob, request-cleanup, and timing tests are included. The logprob test double was updated to implement the existing `Req.check_match_stop_str_prefix()` interface; its assertions are unchanged.

```bash
PYTHONPATH=python python -m pytest -q \
  test/registered/unit/managers/test_first_token_timestamp.py \
  test/registered/unit/managers/test_output_streamer_customized_info.py \
  test/registered/unit/managers/test_output_streamer_logprobs.py \
  test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py \
  test/registered/unit/observability/test_req_time_stats.py

pre-commit run --files \
  python/sglang/srt/managers/scheduler_components/output_streamer.py \
  test/registered/unit/managers/test_first_token_timestamp.py \
  test/registered/unit/managers/test_output_streamer_logprobs.py
```

The commands were run with a Python 3.12.3 uv environment. Relevant repository pre-commit hooks passed, including formatting, import/lint checks, and registered-test validation.

An additional local component harness passed **64 scenarios**, including output lengths 1/16/49/50/51/100/128, both output modes, configurable force intervals, speculative token-count jumps, real isolated Prometheus histograms, and the prefill-role metric guard. The committed regression does not require that external harness.

## Speed Tests and Profiling

These are controlled-clock correctness results, not inference benchmarks. The first generated token is ready after 1 second and each additional token adds 10 ms; the cases below omit additional IPC/detokenization delay.

| Request | TTFT before | TTFT after | E2E before / after |
|---|---:|---:|---:|
| Streaming, 128 tokens | 1.00 s | 1.00 s | 2.27 s / 2.27 s |
| Non-streaming, 16 tokens | 1.15 s | 1.00 s | 1.15 s / 1.15 s |
| Non-streaming, 128 tokens | 1.49 s | 1.00 s | 2.27 s / 2.27 s |

An ordinary request adds at most one internal output payload and an earlier detokenization pass. Speculative requests can additionally emit periodic payloads that the exact-modulo gate previously skipped. These are internal payloads; final-only client delivery is preserved.

Serving-load overhead was not benchmarked. An initial payload can carry prompt logprobs or other requested metadata, so its cost should not be assumed negligible for every configuration. No throughput or E2E speedup is claimed.

## Checklist

- [x] Relevant repository pre-commit hooks pass.
- [x] CPU regression tests are registered with the existing test suite.
- [x] TTFT and speculative-boundary regressions fail on upstream main and pass with the fix.
- [x] Later-flush stop-prefix regressions fail on the previous PR head and pass with the extended guard.
- [x] Existing output metadata, logprob, request-cleanup, and timing tests pass.
- [x] Metric semantics, performance costs, and validation limits are documented above.
- [ ] Live model accuracy/speed and cross-machine PD validation: not performed.

AI assistance was used for source analysis, implementation, test development, and local validation. James Liu is credited as a co-author for the initial first-output change and its original regression tests.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34773531078](https://github.com/sgl-project/sglang/actions/runs/34773531078)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34773530890](https://github.com/sgl-project/sglang/actions/runs/34773530890)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34773531043](https://github.com/sgl-project/sglang/actions/runs/34773531043)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
