### PR TITLE
[Bugfix] Prevent DP scheduler hang near KV capacity

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1171,6 +1171,12 @@ class Scheduler(
             _,
             _,
         ) = self.tp_worker.get_worker_info()
+        self.max_req_input_len = self.get_max_admissible_input_len(
+            self.max_req_input_len,
+            self.max_total_num_tokens,
+            self.page_size,
+            get_parallel().attn_dcp_size,
+        )
         # DFlash auto-enables the legacy formula; other workloads opt in via
         # --min-free-slots-delay. Built independently of the prefill delayer.
         self.min_free_slots_delayer: Optional[MinFreeSlotsDelayer] = None
@@ -2519,11 +2525,11 @@ class Scheduler(
                 )
             max_new_tokens = min(max_new_tokens, self.max_new_tokens_limit)
 
-        # Keep this bound consistent with PrefillAdder's admission budget:
+        # Keep every positive output budget within PrefillAdder's paged budget:
         # ceil_page(input_len) + max_new_tokens + page_size must be strictly
-        # smaller than max_total_num_tokens. Otherwise a request can be accepted
-        # into the waiting queue but can never be scheduled, blocking the queue
-        # and eventually making health checks fail.
+        # smaller than max_total_num_tokens. If no positive budget remains,
+        # request intake separately rejects prompts that cannot pass the raw
+        # input + page_size capacity gate at all.
         paged_input_len = -(-input_len // self.page_size) * self.page_size
         req.sampling_params.max_new_tokens = max(
             0,
@@ -2540,6 +2546,24 @@ class Scheduler(
         # would suppress EOS for the whole generation. Restore the invariant.
         if req.sampling_params.min_new_tokens > req.sampling_params.max_new_tokens:
             req.sampling_params.min_new_tokens = req.sampling_params.max_new_tokens
+
+    @staticmethod
+    def get_max_admissible_input_len(
+        max_req_input_len: int,
+        max_total_num_tokens: int,
+        page_size: int,
+        attn_dcp_size: int,
+    ) -> int:
+        """Return the threshold for the base PrefillAdder capacity gate.
+
+        ``validate_input_length`` rejects inputs with ``len >= threshold``.
+        Keep one allocator page beyond the raw input, matching the first
+        ``PrefillAdder.add_one_req`` total-token gate after output clipping.
+        This prevents a request that passes the public input-length check but
+        can never pass scheduler admission.
+        """
+        total_capacity = max_total_num_tokens * attn_dcp_size
+        return min(max_req_input_len, total_capacity - page_size)
 
     def _process_and_broadcast_mm_inputs(
         self,
@@ -2980,9 +3004,6 @@ class Scheduler(
                 self._add_request_to_queue(req)
                 return
 
-        # initialize before returning
-        self.init_req_max_new_tokens(req)
-
         # Validate prompt length
         error_msg = validate_input_length(
             req,
@@ -2991,8 +3012,14 @@ class Scheduler(
         )
         if error_msg:
             req.set_finish_with_abort(error_msg)
+            self.init_req_max_new_tokens(req)
             self._add_request_to_queue(req)
             return
+
+        # Initialize after validation so auto-truncation is reflected in the
+        # output budget rather than leaving a formerly too-long prompt with a
+        # clipped zero-token generation budget.
+        self.init_req_max_new_tokens(req)
 
         if not recv_req.return_logprob and recv_req.logprob_start_len != -1:
             # When return_logprob is False, logprob_start_len should be ignored
@@ -3396,6 +3423,7 @@ class Scheduler(
             get_serving().allow_auto_truncate,
         )
         if error_msg:
+            req.set_finish_with_abort(error_msg)
             self._add_request_to_queue(req)
             return
 
@@ -3726,6 +3754,13 @@ class Scheduler(
 
         if self.enable_priority_preemption or self.is_hybrid_swa:
             # Reset batch_is_full to try preemption with a prefill adder.
+            running_batch.batch_is_full = False
+
+        if running_batch.is_empty():
+            # `batch_is_full` is an admission hint for the current running
+            # batch. It must not survive after that batch drains (for example,
+            # when a queued request that returned NO_TOKEN is cancelled), or
+            # the fast path below skips the waiting queue indefinitely.
             running_batch.batch_is_full = False
 
         if (

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -236,12 +236,39 @@ def validate_input_length(
     """
     if len(req.origin_input_ids) >= max_req_input_len:
         if allow_auto_truncate:
+            truncate_len = max_req_input_len - 1
+            if truncate_len <= 0:
+                return (
+                    f"Input length ({len(req.origin_input_ids)} tokens) cannot fit "
+                    "in the available KV cache because there is no room for a "
+                    "non-empty prompt. Increase the KV cache capacity."
+                )
+
             logger.warning(
                 "Request length is longer than the KV cache pool size or "
                 "the max context length. Truncated. "
                 f"{len(req.origin_input_ids)=}, {max_req_input_len=}."
             )
-            req.origin_input_ids = req.origin_input_ids[:max_req_input_len]
+            # The validation condition is ``len >= max_req_input_len``, so
+            # truncating to the threshold would still leave an inadmissible
+            # request. Keep one token below it.
+            req.origin_input_ids = req.origin_input_ids[:truncate_len]
+            # Keep token-aligned request fields consistent with the effective
+            # prompt. In particular, stale token_type_ids would otherwise have
+            # a different length from the flattened embedding input.
+            for attr in (
+                "origin_input_ids_unpadded",
+                "input_embeds",
+                "token_type_ids",
+            ):
+                value = getattr(req, attr, None)
+                if value is not None:
+                    setattr(req, attr, value[:truncate_len])
+            delimiter_indices = getattr(req, "multi_item_delimiter_indices", None)
+            if delimiter_indices is not None:
+                req.multi_item_delimiter_indices = [
+                    index for index in delimiter_indices if 0 <= index < truncate_len
+                ]
             return None
         else:
             error_msg = (

--- a/test/registered/e2e/scheduler/test_near_kv_admission.py
+++ b/test/registered/e2e/scheduler/test_near_kv_admission.py
@@ -1,6 +1,7 @@
 import unittest
 
 import requests
+
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import (

--- a/test/registered/scheduler/test_near_kv_admission.py
+++ b/test/registered/scheduler/test_near_kv_admission.py
@@ -1,0 +1,104 @@
+import unittest
+
+import requests
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=90, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestNearKVAdmission(CustomTestCase):
+    """Exercise both sides of the near-capacity admission boundary."""
+
+    max_total_tokens = 512
+    page_size = 64
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--max-total-tokens",
+                str(cls.max_total_tokens),
+                "--page-size",
+                str(cls.page_size),
+                "--disable-cuda-graph",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_near_kv_boundary_does_not_block_followup(self):
+        # 447 + one allocator page is still below capacity. Its generation
+        # budget is clipped to zero, but it must enter a runnable batch and
+        # finish rather than poisoning the next scheduler iteration.
+        admitted = requests.post(
+            self.base_url + "/generate",
+            json={
+                "rid": "near-kv-admitted",
+                "input_ids": [1] * (self.max_total_tokens - self.page_size - 1),
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": self.page_size,
+                    "ignore_eos": True,
+                },
+            },
+            timeout=30,
+        )
+        self.assertEqual(admitted.status_code, 200, admitted.text)
+        self.assertEqual(
+            admitted.json()["meta_info"]["prompt_tokens"],
+            self.max_total_tokens - self.page_size - 1,
+        )
+        self.assertEqual(admitted.json()["meta_info"]["completion_tokens"], 0)
+
+        # 448 + one allocator page is exactly capacity. PrefillAdder cannot
+        # admit this request, so the public length check must reject it before
+        # it can enter the waiting queue with max_new_tokens clipped to zero.
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "rid": "near-kv-rejected",
+                "input_ids": [1] * (self.max_total_tokens - self.page_size),
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": self.page_size,
+                    "ignore_eos": True,
+                },
+            },
+            timeout=30,
+        )
+        self.assertEqual(response.status_code, 400, response.text)
+        self.assertIn("Input length", response.json()["error"]["message"])
+
+        follow_up = requests.post(
+            self.base_url + "/generate",
+            json={
+                "rid": "near-kv-admission-followup",
+                "input_ids": [1] * 8,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 4,
+                    "ignore_eos": True,
+                },
+            },
+            timeout=30,
+        )
+        self.assertEqual(follow_up.status_code, 200, follow_up.text)
+        self.assertEqual(follow_up.json()["meta_info"]["completion_tokens"], 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -125,6 +125,36 @@ class TestPrefillAdder(CustomTestCase):
         defaults.update(kwargs)
         return PrefillAdder(**defaults)
 
+    def test_near_capacity_raw_input_boundary(self):
+        capacity, page_size = 512, 64
+
+        for input_len, admitted in ((447, True), (448, False)):
+            with self.subTest(input_len=input_len):
+                self.mock_token_allocator.available_size.return_value = capacity
+                adder = self.create_adder(
+                    self.create_running_batch(), page_size=page_size
+                )
+                req = self.create_mock_req(
+                    f"near-capacity-{input_len}",
+                    priority=0,
+                    max_new_tokens=0,
+                )
+                req.full_untruncated_fill_ids = list(range(input_len))
+                req.last_node = MagicMock()
+                req.sampling_params.ignore_eos = False
+                req.set_extend_range = MagicMock(
+                    side_effect=lambda start, end, req=req: setattr(
+                        req, "extend_range", Range(start, end)
+                    )
+                )
+
+                result = adder.add_one_req(
+                    req, has_chunked_req=False, truncation_align_size=None
+                )
+
+                self.assertEqual(result, AddReqResult.NO_TOKEN)
+                self.assertEqual(req in adder.can_run_list, admitted)
+
     def test_storage_prefetch_fulfillment_resolves_at_admission(self):
         adder = self.create_adder(self.create_running_batch())
         req = self.create_mock_req("storage-hit", priority=0, max_new_tokens=1)

--- a/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
+++ b/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
@@ -1,9 +1,11 @@
 import logging
 import unittest
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from sglang.srt.environ import envs
 from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.utils import validate_input_length
 from sglang.srt.runtime_context import get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -22,8 +24,8 @@ class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):
       5. min_new_tokens <= max_new_tokens afterwards
 
     Each case asserts all rules hold and the result is tight: one more token
-    would violate a rule or exceed the request. Over-long inputs degenerate to
-    max_new_tokens = 0 and are rejected by later admission checks.
+    would violate a rule or exceed the request. Request intake rejects raw
+    inputs that can never pass PrefillAdder's total-token gate.
     """
 
     @classmethod
@@ -144,6 +146,79 @@ class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):
                 max_total_num_tokens - paged_input_len - page_size - 1,
             )
 
+    def test_max_req_input_len_matches_prefill_admission_boundary(self):
+        # With a 190,784-token pool and 64-token pages, the old advertised
+        # input limit was 190,778. Inputs in [190,720, 190,777] pass that
+        # check but can never pass PrefillAdder's first total-token gate. The
+        # threshold itself is rejected by validate_input_length, so 190,719 is
+        # the largest admitted input.
+        capacity, page_size = 190_784, 64
+        threshold = Scheduler.get_max_admissible_input_len(
+            capacity - 6, capacity, page_size, attn_dcp_size=1
+        )
+        self.assertEqual(threshold, 190_720)
+
+        scheduler = self._new_scheduler(
+            max_req_len=capacity - 1,
+            max_total_num_tokens=capacity,
+            page_size=page_size,
+        )
+        req = self._new_req(max_new_tokens=1 << 20, input_len=threshold - 1)
+        self.assertEqual(self._init_and_check(scheduler, req), 0)
+
+        oversized_req = self._new_req(max_new_tokens=1 << 20, input_len=190_720)
+        self.assertIsNotNone(
+            validate_input_length(oversized_req, threshold, allow_auto_truncate=False)
+        )
+
+        # Auto truncation must produce an admissible input and must run before
+        # init_req_max_new_tokens, so both use the same final prompt length.
+        self.assertIsNone(
+            validate_input_length(oversized_req, threshold, allow_auto_truncate=True)
+        )
+        self.assertEqual(len(oversized_req.origin_input_ids), threshold - 1)
+        self.assertEqual(self._init_and_check(scheduler, oversized_req), 0)
+
+    def test_max_req_input_len_accounts_for_dcp_capacity(self):
+        self.assertEqual(
+            Scheduler.get_max_admissible_input_len(
+                max_req_input_len=2_000,
+                max_total_num_tokens=512,
+                page_size=64,
+                attn_dcp_size=2,
+            ),
+            960,
+        )
+
+    def test_auto_truncate_rejects_when_no_nonempty_prompt_can_fit(self):
+        for threshold in (0, 1):
+            with self.subTest(threshold=threshold):
+                req = self._new_req(max_new_tokens=1, input_len=8)
+
+                error_msg = validate_input_length(
+                    req, threshold, allow_auto_truncate=True
+                )
+
+                self.assertIsNotNone(error_msg)
+                self.assertIn("no room for a non-empty prompt", error_msg)
+                self.assertEqual(len(req.origin_input_ids), 8)
+
+    def test_auto_truncate_keeps_token_aligned_fields_consistent(self):
+        req = self._new_req(max_new_tokens=1, input_len=10)
+        req.origin_input_ids = list(range(10))
+        req.origin_input_ids_unpadded = list(range(10))
+        req.input_embeds = [[value] for value in range(10)]
+        req.token_type_ids = [value % 2 for value in range(10)]
+        req.multi_item_delimiter_indices = [0, 3, 7, 9]
+
+        self.assertIsNone(validate_input_length(req, 8, allow_auto_truncate=True))
+
+        self.assertEqual(req.origin_input_ids, list(range(7)))
+        self.assertEqual(req.origin_input_ids_unpadded, list(range(7)))
+        self.assertEqual(req.input_embeds, [[value] for value in range(7)])
+        self.assertEqual(req.token_type_ids, [value % 2 for value in range(7)])
+        self.assertEqual(req.multi_item_delimiter_indices, [0, 3])
+
     def test_min_new_tokens_clamped_to_limit(self):
         with envs.SGLANG_MAX_NEW_TOKENS_LIMIT.override(16):
             scheduler = self._new_scheduler()
@@ -179,6 +254,72 @@ class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):
                                         max_new_tokens=requested, input_len=input_len
                                     )
                                     self._init_and_check(scheduler, req)
+
+    @patch(
+        "sglang.srt.managers.scheduler.get_memory",
+        return_value=SimpleNamespace(enable_flexkv=False),
+    )
+    def test_empty_running_batch_clears_stale_batch_is_full(self, _get_memory):
+        scheduler = object.__new__(Scheduler)
+        scheduler.grammar_manager = SimpleNamespace(has_waiting_grammars=lambda: False)
+        scheduler.enable_hierarchical_cache = False
+        scheduler.enable_unified_cache_external_linker = False
+        scheduler.enable_priority_preemption = False
+        scheduler.is_hybrid_swa = False
+        scheduler.waiting_queue = []
+        scheduler.chunked_req = None
+
+        running_batch = SimpleNamespace(
+            batch_is_full=True,
+            is_empty=lambda: True,
+        )
+        batch_to_run, returned_batch = Scheduler._get_new_batch_prefill_raw(
+            scheduler, None, running_batch
+        )
+
+        self.assertIsNone(batch_to_run)
+        self.assertIs(returned_batch, running_batch)
+        self.assertFalse(running_batch.batch_is_full)
+
+    @patch(
+        "sglang.srt.managers.scheduler.get_serving",
+        return_value=SimpleNamespace(allow_auto_truncate=False),
+    )
+    @patch("sglang.srt.managers.scheduler.Req")
+    def test_oversized_embedding_request_is_finished_before_queueing(
+        self, req_cls, _get_serving
+    ):
+        scheduler = object.__new__(Scheduler)
+        scheduler.tokenizer = object()
+        scheduler.max_req_input_len = 448
+        scheduler._maybe_namespace_elastic_radix_cache = MagicMock()
+        scheduler._add_request_to_queue = MagicMock()
+
+        req = req_cls.return_value
+        req.origin_input_ids = [1] * 448
+        recv_req = SimpleNamespace(
+            rid="oversized-embedding",
+            input_text=None,
+            input_ids=req.origin_input_ids,
+            sampling_params=SimpleNamespace(max_new_tokens=0),
+            positional_embed_overrides=None,
+            token_type_ids=None,
+            routed_dp_rank=None,
+            priority=None,
+            dimensions=None,
+            lora_id=None,
+            http_worker_ipc=None,
+            time_stats=None,
+            return_pooled_hidden_states=False,
+            multi_item_delimiter_indices=None,
+            mm_inputs=None,
+        )
+
+        scheduler.handle_embedding_request(recv_req)
+
+        error_msg = req.set_finish_with_abort.call_args.args[0]
+        self.assertIn("Input length (448 tokens)", error_msg)
+        scheduler._add_request_to_queue.assert_called_once_with(req)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #39271 

A near-KV-capacity request can pass the request-entry length validation but still be rejected permanently by `PrefillAdder`.

For example, with 190,784 tokens of KV capacity per DP rank and `page_size=64`, requests containing 190,720–190,777 input tokens pass the previous public length check. However, `PrefillAdder` reserves an additional KV page and returns `NO_TOKEN`, because these requests can never fit.

This sets the persistent `running_batch.batch_is_full` flag. Subsequent scheduling iterations check that stale flag before processing the waiting queue. Even after the original request is cancelled and the running batch and KV usage become empty, the DP rank can continue returning early indefinitely. All later requests remain queued until the server is restarted.

The issue can be reproduced entirely on CPU. No model is loaded or executed; the reproduction directly exercises the scheduler admission and stale-state logic with mocked KV allocator and cache objects.

## Modifications

- Align the public maximum input length with the effective KV admission limit used by `PrefillAdder`, including its one-page KV reservation.
- Account for `attn_dcp_size` when calculating the effective input-length limit.
- Validate and truncate inputs before initializing `max_new_tokens`, ensuring token budgets are calculated from the final input.
- Keep `origin_input_ids_unpadded`, input embeddings, token type IDs, and delimiter indices consistent after automatic truncation.
- Clear the stale `running_batch.batch_is_full` flag when the running batch is empty, allowing the scheduler to reconsider waiting requests.
- Mark invalid embedding requests as aborted consistently with generation requests.
- Add unit tests covering:
  - The KV admission boundary.
  - The 190K-token regression case.
  - DCP-adjusted capacity.
  - Automatic truncation.
  - Recovery from stale `batch_is_full`.
  - Embedding-request validation.
- Add a registered scheduler regression test verifying that a rejected near-capacity request does not block a subsequent short request.

## Accuracy Tests

Not applicable. This change only affects scheduler admission and state handling; it does not modify model execution, kernels, or generated outputs.

CPU-only tests in a `uv` virtual environment:

    43 passed, 17 warnings, 558 subtests passed

The same state-level reproduction produces the following result on `main`:

    public_threshold=190778
    input_validation=accepted
    prefill_result=NO_TOKEN
    request_admitted=False
    batch_is_full_after_empty_iteration=True
    BUG_REPRODUCED

With this fix:

    public_threshold=190720
    input_validation=rejected
    prefill_result=NO_TOKEN
    request_admitted=False
    batch_is_full_after_empty_iteration=False
    FIX_CONFIRMED

## Speed Tests and Profiling

Not applicable. The change does not affect model forward execution or performance-critical kernels. It adds only constant-time admission checks and resets scheduler state when the running batch is empty.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable: no user-facing API or configuration changes.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable to scheduler-only correctness changes.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34740216736](https://github.com/sgl-project/sglang/actions/runs/34740216736)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34740216596](https://github.com/sgl-project/sglang/actions/runs/34740216596)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34740216702](https://github.com/sgl-project/sglang/actions/runs/34740216702)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->