### PR TITLE
[Fix][Qwen-VL] Normalize <image> sentinel on artifact fast path

### DIFF
--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -393,12 +393,13 @@ class QwenVLImageProcessor(MediaArtifactCacheMixin, SGLangBaseProcessor):
             self.hf_config.vision_config, "tokens_per_second", None
         )
 
+        # Also match the legacy sglang <image> sentinel used by /generate,
+        # so the artifact fast path can normalize it before build_input_ids.
         self.mm_tokens = MultimodalSpecialTokens(
             image_token="<|vision_start|><|image_pad|><|vision_end|>",
             image_token_id=hf_config.image_token_id,
-            # The regex that matches expanded image tokens.
             image_token_regex=re.compile(
-                r"<\|vision_start\|>(?:<\|image_pad\|>)+<\|vision_end\|>"
+                r"<\|vision_start\|>(?:<\|image_pad\|>)+<\|vision_end\|>|<image>"
             ),
             video_token_id=self.VIDEO_TOKEN_ID,
             audio_token_id=self.audio_token_id,
@@ -864,8 +865,12 @@ class QwenVLImageProcessor(MediaArtifactCacheMixin, SGLangBaseProcessor):
         self,
         input_text,
         artifacts: list[QwenVLImagePreprocessArtifact],
-    ) -> MultimodalProcessorOutput:
-        """Compose prompt tokens and request-owned items from cached images."""
+    ) -> Optional[MultimodalProcessorOutput]:
+        """Compose prompt tokens and request-owned items from cached images.
+
+        Returns None when the raw prompt cannot be aligned with the prepared
+        artifacts; the caller falls back to _process_mm_data_uncached.
+        """
         image_grids = []
         for artifact in artifacts:
             grid = self._as_grid_batch(
@@ -879,20 +884,35 @@ class QwenVLImageProcessor(MediaArtifactCacheMixin, SGLangBaseProcessor):
         grid_key = tuple(
             tuple(int(value) for value in row.tolist()) for row in image_grid_thw
         )
-        if isinstance(input_text, str):
-            (
-                input_ids_tuple,
-                offsets,
-                mrope_positions,
-                mrope_position_delta,
-            ) = self._cached_image_prompt_template(input_text, grid_key)
-        else:
-            (
-                input_ids_tuple,
-                offsets,
-                mrope_positions,
-                mrope_position_delta,
-            ) = self._build_image_prompt_template(input_text, grid_key)
+        normalized_text = self._normalize_prompt_for_fast_path(
+            input_text, expected_image_count=len(grid_key)
+        )
+        if normalized_text is None:
+            return None
+        try:
+            if isinstance(normalized_text, str):
+                (
+                    input_ids_tuple,
+                    offsets,
+                    mrope_positions,
+                    mrope_position_delta,
+                ) = self._cached_image_prompt_template(normalized_text, grid_key)
+            else:
+                (
+                    input_ids_tuple,
+                    offsets,
+                    mrope_positions,
+                    mrope_position_delta,
+                ) = self._build_image_prompt_template(normalized_text, grid_key)
+        except ValueError as exc:
+            if "prompt placeholders" not in str(exc):
+                raise
+            logger.debug(
+                "Qwen-VL fast path skipped after normalization (%s); "
+                "falling back to full preprocessing",
+                exc,
+            )
+            return None
         input_ids_list = list(input_ids_tuple)
 
         mm_items = []
@@ -923,6 +943,23 @@ class QwenVLImageProcessor(MediaArtifactCacheMixin, SGLangBaseProcessor):
             mrope_positions=mrope_positions.clone(),
             mrope_position_delta=mrope_position_delta.clone(),
         )
+
+    def _normalize_prompt_for_fast_path(self, input_text, expected_image_count: int):
+        # Non-string input (list of ints) is already in the pre-tokenized shape
+        # build_input_ids expects; only string prompts need placeholder rewriting.
+        if not isinstance(input_text, str):
+            return input_text
+        native = self.mm_tokens.image_token
+        normalized, count = self.mm_tokens.image_token_regex.subn(native, input_text)
+        if count != expected_image_count:
+            logger.debug(
+                "Qwen-VL fast path skipped: %d image placeholder(s) in prompt "
+                "vs %d prepared artifact(s); falling back to full preprocessing",
+                count,
+                expected_image_count,
+            )
+            return None
+        return normalized
 
     @lru_cache(maxsize=256)
     def _cached_image_prompt_template(self, input_text: str, grid_key: tuple):
@@ -1165,7 +1202,12 @@ class QwenVLImageProcessor(MediaArtifactCacheMixin, SGLangBaseProcessor):
         artifacts = await prepare_artifacts(
             image_data, content_hashes=getattr(request_obj, "mm_content_hashes", None)
         )
-        return self.compose_image_artifacts(input_text, artifacts)
+        composed = self.compose_image_artifacts(input_text, artifacts)
+        if composed is not None:
+            return composed
+        return await self._process_mm_data_uncached(
+            image_data, input_text, request_obj, *args, **kwargs
+        )
 
     def _mark_cuda_ipc_features_for_deferred_reconstruction(self, mm_items):
         supports_deferred_reconstruction = get_mm().mm_enable_dp_encoder or (


### PR DESCRIPTION
## Summary

- Root cause: PR #36411 routes every Qwen3-VL image request through the new artifact fast path (`compose_image_artifacts` → `_build_image_prompt_template` → `build_input_ids`). The scan only counts image slots when the prompt contains `<|vision_start|><|image_pad|><|vision_end|>` triples, so `/generate` requests using sglang's `<image>` sentinel raise `ValueError: Qwen-VL image artifacts do not match prompt placeholders` and the client sees `KeyError: 'meta_info'` (HTTP 400 body served as if it were a normal response).
- This regresses XPU CI (`test/registered/xpu/test_encoder_attention_backend.py`, which POSTs `"<image>\n Tell me..."` to `/generate`) and would fail identically on any CUDA caller that uses `<image>` against Qwen3-VL, since `uses_media_artifacts_without_cache` is unconditional on `qwen3_vl` / `qwen3_vl_moe`.
- Fix normalizes the raw prompt in the fast path and defensively falls back to `_process_mm_data_uncached` when the invariant cannot be recovered.

## What changed

`python/sglang/srt/multimodal/processors/qwen_vl.py`:

1. **`mm_tokens.image_token_regex`** now also matches sglang's `<image>` sentinel:
   ```
   r\"<\\|vision_start\\|>(?:<\\|image_pad\\|>)+<\\|vision_end\\|>|<image>\"
   ```
2. **`_normalize_prompt_for_fast_path(input_text, expected_image_count)`** — new protected helper. For string prompts, `regex.subn` replaces each recognized placeholder with the model's wrapped `<|vision_start|><|image_pad|><|vision_end|>` and checks the count against `len(artifacts)`. Chat-template inputs (already wrapped) substitute to themselves, so the hot path is a no-op with a single `subn` call. Returns `None` on mismatch.
3. **`compose_image_artifacts`** now returns `Optional[MultimodalProcessorOutput]`: normalizes first, and catches a residual `ValueError('...prompt placeholders...')` from `_build_image_prompt_template` to signal a fallback rather than propagating a 500.
4. **`process_mm_data_async`** falls through to `_process_mm_data_uncached` (the pre-#36411 authoritative path) when `compose_image_artifacts` returns `None`. The user never sees a 400; only a debug log records the miss.

## Why this is the right layer

- Uses the existing `MultimodalSpecialTokens` machinery — teaching the processor which prompt shapes represent an image slot is exactly what `image_token_regex` is for. Extending it once also fixes `load_mm_data`'s `<image>` handling on the uncached path (previously it fell through to `legacy_load_mm_data` which never actually substitutes `<image>`).
- Preserves the H100 win: chat-template inputs match the wrapped triple, `subn` is a self-replacement, `_cached_image_prompt_template`'s LRU cache still hits, and `_build_image_prompt_template` still avoids the HF processor. No new tensor allocations on the hot path.
- Small, contained: one file, ~60 net-added lines, no API surface changes outside a return-type widening (`MultimodalProcessorOutput` → `Optional[MultimodalProcessorOutput]`) on a Qwen-VL-only method that has a single caller inside the same class.

## Repro (before this PR, on `main` at `0a57403468` or later)

```bash
python3 -m sglang.launch_server \\
  --model-path Qwen/Qwen3-VL-2B-Thinking \\
  --device xpu --mm-attention-backend xpu_attn --port 21000

curl -s http://127.0.0.1:21000/generate -H content-type:application/json -d \\
  '{\"text\":\"<image>\\n Tell me what you can see from the image.\",
    \"image_data\":\"examples/assets/example_image.png\",
    \"sampling_params\":{\"temperature\":0,\"max_new_tokens\":32}}'
# -> {\"error\":{\"message\":\"Qwen-VL image artifacts do not match prompt placeholders\"}}
```

Same repro on CUDA hits the same error (has to; `uses_media_artifacts_without_cache = True`).

## Failing CI runs

- https://github.com/sgl-project/sglang/actions/runs/34740216597
- https://github.com/sgl-project/sglang/actions/runs/34739837263
- https://github.com/sgl-project/sglang/actions/runs/34738318077 (push on `main`, not a PR — so this landed as a `main` regression, not just a PR failure)

## Test plan

- [ ] `test/registered/xpu/test_encoder_attention_backend.py` (XPU) — expected PASS
- [ ] Existing Qwen3-VL CUDA benchmarks / accuracy tests exercising `/v1/chat/completions` — expected UNCHANGED (fast path still taken; substitution is a no-op)
- [ ] Manual `/generate` with raw `<image>` — returns a normal `meta_info["finish_reason"]`
- [ ] Manual `/generate` with mismatched placeholder count (e.g. two `<image>` markers, one image) — falls back to uncached path; error, if any, surfaces from the HF processor rather than an internal 500

## Follow-ups (not in this PR)

- Add a regression test that POSTs `<image>` to `/generate` on CUDA — the XPU test is the only current guard and it lives under `test/registered/xpu/`.
- Consider a similar audit for other processors that inherit `MediaArtifactCacheMixin` and set `generates_input_ids_from_raw_prompt = True`.

cc @BBuf / @xzhang711 (author of #36411), @jianan-gu (original author of the failing XPU test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #34743586770](https://github.com/sgl-project/sglang/actions/runs/34743586770)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34743586620](https://github.com/sgl-project/sglang/actions/runs/34743586620)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34743586729](https://github.com/sgl-project/sglang/actions/runs/34743586729)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->