### PR TITLE
[MLX] Keep FutureMap relay buffers on CPU under the MLX backend

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1632,7 +1632,8 @@ class Scheduler(
         needs_cpu_seq_lens = decide_needs_cpu_seq_lens(attn_backends)
         needs_confidence_relay = decide_needs_confidence_relay()
         self.future_map = self.spec_algorithm.create_future_map(
-            self.device,
+            # MLX workers return sampled tokens on CPU; relay buffers must match.
+            "cpu" if use_mlx() else self.device,
             self.req_to_token_pool,
             needs_cpu_seq_lens=needs_cpu_seq_lens,
             needs_confidence_relay=needs_confidence_relay,

--- a/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
+++ b/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
@@ -408,14 +408,16 @@ class TestMlxAuxiliaryStateRunnerCache(unittest.TestCase):
         self.assertEqual(pending.lazy_tokens.tolist(), [8])
 
     def test_mlx_scheduler_init_overlap_keeps_future_map_relay(self):
+        """An mps-device MLX scheduler must relay CPU sampled tokens for a multi-request batch."""
         from sglang.srt.managers import scheduler as scheduler_module
         from sglang.srt.managers.overlap_utils import RelayPayload
         from sglang.srt.managers.scheduler import Scheduler
         from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
         from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
+        _set_dummy_server_args_for_auxiliary_state_tests()
         scheduler = object.__new__(Scheduler)
-        scheduler.device = "cpu"
+        scheduler.device = "mps"
         scheduler.draft_worker = None
         scheduler.tp_worker = SimpleNamespace(
             model_runner=SimpleNamespace(attn_backend=None)
@@ -441,12 +443,13 @@ class TestMlxAuxiliaryStateRunnerCache(unittest.TestCase):
         finally:
             scheduler_module.use_mlx = original_use_mlx
 
-        self.assertIsNotNone(scheduler.future_map)
-        indices = torch.tensor([1], dtype=torch.int64)
+        # Two rows: a single-element index_put tolerates a device mismatch.
+        indices = torch.tensor([1, 2], dtype=torch.int64)
         scheduler.future_map.stash(
-            indices, RelayPayload(bonus_tokens=torch.tensor([7], dtype=torch.int64))
+            indices,
+            RelayPayload(bonus_tokens=torch.tensor([7, 8], dtype=torch.int64)),
         )
-        self.assertEqual(int(scheduler.future_map.output_tokens_buf[1].item()), 7)
+        self.assertEqual(scheduler.future_map.output_tokens_buf[1:3].tolist(), [7, 8])
 
     def test_decode_finalize_does_not_snapshot_auxiliary_state(self):
         runner = object.__new__(MlxModelRunner)


### PR DESCRIPTION
## Motivation

On the MLX backend the worker returns sampled tokens as CPU tensors, but `Scheduler.init_overlap` creates `FutureMap` on `self.device`, which is `mps` on Apple Silicon. The first time the normal (non-overlap) loop stashes a batch with two or more requests, `index_put` fails:

```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, mps:0 and cpu!
```

A single-request batch does not trigger it (a one-element `index_put` tolerates the mismatch), which is also why the existing unit test did not catch it.

This path is always taken for hybrid models (e.g. `mlx-community/Qwen3.5-35B-A3B-4bit`) with the radix cache on: the MLX auxiliary-state cache forces `--mamba-radix-cache-strategy no_buffer`, which forces overlap scheduling off.

Related: #35137 also addresses this crash (item 1), by moving indices/values to the buffer device inside `FutureMap.stash()` / `publish()`. This PR is a narrower alternative: the relay buffers are placed on CPU once at construction, so the MLX path does no per-step CPU->mps->CPU round trip of sampled tokens, and `overlap_utils.py` (shared with CUDA) is untouched. Happy to close this if maintainers prefer to land #35137 as a whole. Part of #19137.

## Modifications

- `managers/scheduler.py`: under `use_mlx()`, create `FutureMap` on `"cpu"` instead of `self.device`.
- `test_attention_patching.py`: strengthen `test_mlx_scheduler_init_overlap_keeps_future_map_relay` so it guards this bug:
  - scheduler device `"mps"` instead of `"cpu"` (the old value made the bug unobservable);
  - stash two rows instead of one;
  - publish dummy server args in the test itself, so it also passes when run alone (on current main it fails in isolation with `config namespace 'exec' not published`).

## Accuracy Tests

No change to model outputs: the relay buffers hold the same token ids, only on a different device.

## Speed Tests and Profiling

Not benchmarked. The change removes device transfers rather than adding any; CUDA paths are unaffected (`use_mlx()` is false).

## Test

Apple M4 Max, macOS 26.6.2, Python 3.12, torch 2.13.0, mlx 0.32.2, `SGLANG_USE_MLX=1 HF_HUB_OFFLINE=1`.

- `python test/registered/unit/hardware_backend/mlx/test_attention_patching.py`
  - before the fix: the strengthened test fails with the `mps:0 and cpu` RuntimeError above (both in the full file and alone)
  - after the fix: 38/38 pass; the test also passes alone
- All other files registered in `stage-a-unit-test-mlx` give the same results before and after this change. (Locally, `test_fused_swiglu.py` fails to import without pytest, and two `TestOverlapLoopGracefulExit` cases in `test_scheduler_mixin.py` error on unmodified main too; both are unrelated.)
- End to end, on an earlier main (a63efd9) with this change plus the #32449 fix applied locally: `mlx-community/Qwen3.5-35B-A3B-4bit` with radix cache and `--disable-overlap-schedule`, `bench_serving` generated-shared-prefix, 64 requests at concurrency 16: 64/64 succeed (the server crashed with the error above without it). `mlx-community/Qwen3-30B-A3B-4bit` on the default MLX overlap loop (which only reads `future_map`, never stashes): 64/64 succeed.

## Checklist

- [x] Format code with pre-commit (isort / ruff / ruff-format / codespell at the pinned versions on the changed files)
- [x] Add unit tests
- [ ] Update documentation (not needed)
- [ ] Accuracy and speed benchmark results (not applicable, see above)
- [x] Follow the SGLang code style guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34745061031](https://github.com/sgl-project/sglang/actions/runs/34745061031)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34745060942](https://github.com/sgl-project/sglang/actions/runs/34745060942)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34745061100](https://github.com/sgl-project/sglang/actions/runs/34745061100)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->