### PR TITLE
[Benchmark] Add an opt-out for the token-capacity check

### DIFF
--- a/python/sglang/benchmark/one_batch_server.py
+++ b/python/sglang/benchmark/one_batch_server.py
@@ -124,6 +124,7 @@ class BenchArgs:
     base_url: str = ""
     local_tokenizer_path: str = ""
     skip_warmup: bool = False
+    skip_token_capacity_check: bool = False
     show_report: bool = False
     profile: bool = False
     profile_activities: Tuple[str] = ("CPU", "GPU")
@@ -207,6 +208,11 @@ class BenchArgs:
             ),
         )
         parser.add_argument("--skip-warmup", action="store_true")
+        parser.add_argument(
+            "--skip-token-capacity-check",
+            action="store_true",
+            help="Skip the raw-token capacity check; keep max-running-requests checks.",
+        )
         parser.add_argument("--show-report", action="store_true")
         parser.add_argument("--profile", action="store_true")
         parser.add_argument(
@@ -1229,6 +1235,9 @@ def run_benchmark_internal(
             skip_token_capacity_threshold += state.get("memory_usage", {}).get(
                 "token_capacity", 1000000000
             )
+
+        if bench_args.skip_token_capacity_check:
+            skip_token_capacity_threshold = float("inf")
 
         # Router /get_server_info responses carry "router_manager"; worker
         # responses never do, so its presence confirms a router by design.


### PR DESCRIPTION
## Motivation

The one-batch benchmark estimates KV usage as `batch_size * (input_len + output_len)`. For workloads that have some cache optimizations, this can overestimate physical KV usage and skip valid benchmark cases.

## Modifications

Add the default-off `--skip-token-capacity-check` option to bypass this estimate explicitly. Existing max-running-requests checks and default behavior are preserved.

## Accuracy Tests

- Ten local CPU smoke scenarios passed using the real CLI parser and benchmark control flow with mocked server responses, tokenization, and per-case execution. Checked default rejection, explicit opt-out, max-running rejection, and unchanged warmup, profiling, and returned metrics.
- `pre-commit run --files python/sglang/benchmark/one_batch_server.py` and `git diff --check` passed.
- GPU accuracy tests were not run; model execution is unchanged.

## Speed Tests and Profiling

GPU benchmarks were not run. This changes benchmark case selection only.

## Checklist

- [x] Format code with pre-commit.
- [ ] Add unit tests (local CPU smoke checks performed; no checked-in tests added).
- [x] Document the option in CLI help.
- [ ] Provide GPU accuracy and speed results (not run; no model execution changes).
- [x] Follow SGLang code style.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34746622121](https://github.com/sgl-project/sglang/actions/runs/34746622121)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34799443635](https://github.com/sgl-project/sglang/actions/runs/34799443635)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34746622095](https://github.com/sgl-project/sglang/actions/runs/34746622095)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->