### PR TITLE
[Bugfix] Accept empty PP input in DSpark non-overlap dispatch

### DIFF
--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -512,7 +512,11 @@ class DSparkWorkerV2(BaseSpecWorker):
         batch: ScheduleBatch,
         on_publish=None,
         grammar_barrier=None,
+        pp_proxy_tensors=None,
     ) -> GenerationBatchResult:
+        # The non-overlap scheduler passes this keyword even when PP is disabled.
+        if pp_proxy_tensors is not None:
+            raise NotImplementedError("DSpark does not support pipeline parallelism")
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             self._verify_planner.note_non_decode_step()
             self._observers.note_prefill_step()

--- a/test/registered/unit/spec/test_dspark_worker_dispatch.py
+++ b/test/registered/unit/spec/test_dspark_worker_dispatch.py
@@ -1,0 +1,65 @@
+"""DSpark accepts the non-overlap scheduler's PP=None call (#39262)."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from sglang.srt.speculative.dspark_components.dspark_worker_v2 import DSparkWorkerV2
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDSparkWorkerDispatch(CustomTestCase):
+    def setUp(self):
+        self.worker = object.__new__(DSparkWorkerV2)
+        self.prefill_result = object()
+        self.decode_result = object()
+        self.worker._verify_planner = SimpleNamespace(note_non_decode_step=Mock())
+        self.worker._observers = SimpleNamespace(note_prefill_step=Mock())
+        self.worker._forward_prefill = Mock(return_value=self.prefill_result)
+        self.worker._forward_decode = Mock(return_value=self.decode_result)
+
+    def make_batch(self, *, extend=False, mixed=False):
+        return SimpleNamespace(
+            forward_mode=SimpleNamespace(is_extend=lambda: extend),
+            is_extend_in_batch=mixed,
+        )
+
+    def test_non_overlap_accepts_empty_pp_input(self):
+        for extend, mixed in ((True, False), (False, True), (False, False)):
+            with self.subTest(extend=extend, mixed=mixed):
+                batch = self.make_batch(extend=extend, mixed=mixed)
+                result = self.worker.forward_batch_generation(
+                    batch, pp_proxy_tensors=None
+                )
+                self.assertIs(
+                    result,
+                    self.prefill_result if extend or mixed else self.decode_result,
+                )
+
+    def test_existing_callbacks_are_preserved(self):
+        batch = self.make_batch()
+        publish, barrier = Mock(), Mock()
+        result = self.worker.forward_batch_generation(
+            batch, on_publish=publish, grammar_barrier=barrier
+        )
+        self.assertIs(result, self.decode_result)
+        self.worker._forward_decode.assert_called_once_with(batch, publish, barrier)
+
+    def test_nonempty_pp_input_is_rejected_before_forward(self):
+        for extend in (False, True):
+            with self.subTest(extend=extend):
+                with self.assertRaisesRegex(
+                    NotImplementedError, "pipeline parallelism"
+                ):
+                    self.worker.forward_batch_generation(
+                        self.make_batch(extend=extend), pp_proxy_tensors=object()
+                    )
+        self.worker._forward_prefill.assert_not_called()
+        self.worker._forward_decode.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #39262. The non-overlap scheduler calls speculative workers with
`pp_proxy_tensors=None`, including when `pp_size=1`. DSpark's entry point does not
accept that keyword, so Python raises `TypeError` before prefill or decode begins.
The issue reporter identified the missing parameter and verified a runtime patch
on LFM2.5-2.6B with its DSpark draft.

## Modifications

- Accept the optional `pp_proxy_tensors` keyword after the existing callback
  arguments, preserving positional-call compatibility.
- Reject non-None PP payloads explicitly. DSpark's configuration handler already
  requires `pp_size == 1`; this change does not implement PP support or silently
  discard intermediate tensors.
- Register CPU component tests for non-overlap prefill/decode/mixed dispatch,
  existing callback forwarding, and rejection before computation of unsupported
  PP input. Model computation is mocked at the dispatch boundary.

## Validation / draft status

- All applicable pre-commit hooks passed for the two changed files, including CI
  registration checks; `git diff --check` passed.
- An isolated source-level reproducer compiles the unchanged worker dispatch
  method body and the actual scheduler call expression from the checkout. On
  macOS/Python 3.12 and Linux/Python 3.11, the same eight checks produced two passes
  and six errors before the fix, and eight passes after it. The reproducer is not
  included in this PR.
- The three registered test bodies also passed an isolated check with the worker
  dispatch extracted from source and CI/import boundaries substituted. This is
  **not** a successful run of the registered test in a full SGLang environment.
- Normal execution of the registered test is still pending: the local tool-only
  environment fails during SGLang imports due to missing dependencies. This PR
  remains a draft pending normal component-test execution/CI.

## Accuracy Tests

No kernel, logits, sampling, or downstream model-forward implementation changes.
Real LFM2 + DSpark generation has not been tested by this PR author; available
server GPUs were occupied. No model-accuracy claim is made.

## Speed Tests and Profiling

Not run. This fixes a Python call-contract failure; no throughput claim is made.

## Checklist

- [x] Format code with the repository's pre-commit hooks.
- [x] Add focused CPU regression tests and register them for CI.
- [x] Review code style and keep the change scoped to #39262.
- [ ] Run the registered test with normal SGLang imports in a supported environment.
- [ ] Complete upstream CI and an LFM2 + DSpark non-overlap serving smoke test.

No user-facing configuration or API option is added; documentation changes are
not required for this internal interface fix. Full DSpark PP support is separate
work, such as #32281.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34746670156](https://github.com/sgl-project/sglang/actions/runs/34746670156)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34746670010](https://github.com/sgl-project/sglang/actions/runs/34746670010)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34746670131](https://github.com/sgl-project/sglang/actions/runs/34746670131)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->