### PR TITLE
[Bugfix] Fix Gemma auxiliary hidden-state captures

### DIFF
--- a/python/sglang/srt/models/gemma3_causal.py
+++ b/python/sglang/srt/models/gemma3_causal.py
@@ -640,7 +640,11 @@ class Gemma3TextModel(PreTrainedModel):
         if _is_cpu and _is_cpu_amx_available:
             for i, layer in enumerate(self.layers):
                 if i in self.layers_to_capture:
-                    aux_hidden_states.append(hidden_states)
+                    aux_hidden_states.append(
+                        hidden_states.clone()
+                        if residual is None
+                        else hidden_states + residual
+                    )
                 hidden_states, residual = layer(
                     positions=positions,
                     position_embeddings_global=None,
@@ -658,7 +662,11 @@ class Gemma3TextModel(PreTrainedModel):
             position_embeddings_local = self.rotary_emb_local(hidden_states, positions)
             for i, layer in enumerate(self.layers):
                 if i in self.layers_to_capture:
-                    aux_hidden_states.append(hidden_states)
+                    aux_hidden_states.append(
+                        hidden_states.clone()
+                        if residual is None
+                        else hidden_states + residual
+                    )
                 hidden_states, residual = layer(
                     positions=positions,
                     position_embeddings_global=position_embeddings_global,
@@ -673,7 +681,9 @@ class Gemma3TextModel(PreTrainedModel):
         # layers_to_capture uses +1 offset (captures input of layer i = output of i-1),
         # so index num_layers means the output of the final layer.
         if num_layers in self.layers_to_capture:
-            aux_hidden_states.append(hidden_states)
+            aux_hidden_states.append(
+                hidden_states.clone() if residual is None else hidden_states + residual
+            )
 
         hidden_states, _ = self.norm(hidden_states, residual)
 

--- a/python/sglang/srt/models/gemma4_causal.py
+++ b/python/sglang/srt/models/gemma4_causal.py
@@ -994,7 +994,8 @@ class Gemma4TextModel(PreTrainedModel):
 
         for layer_idx in range(self.start_layer, self.end_layer):
             if layer_idx in self.layers_to_capture:
-                aux_hidden_states.append(hidden_states)
+                # The next layer's fused norm updates its input residual in place.
+                aux_hidden_states.append(hidden_states.clone())
 
             if per_layer_inputs is not None:
                 per_layer_input = per_layer_inputs[:, layer_idx, :]

--- a/test/registered/kernel/speculative/test_gemma_aux_hidden_states.py
+++ b/test/registered/kernel/speculative/test_gemma_aux_hidden_states.py
@@ -1,0 +1,153 @@
+"""Speculative captures must retain the eager decoder's complete layer outputs."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+from sglang.srt.layers.layernorm import Gemma3RMSNorm, RMSNorm
+from sglang.srt.models.gemma3_causal import Gemma3DecoderLayer, Gemma3TextModel
+from sglang.srt.models.gemma4_causal import Gemma4DecoderLayer, Gemma4TextModel
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=15, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+class ToyAttention(nn.Module):
+    is_sliding = False
+
+    def forward(self, hidden_states, **kwargs):
+        return hidden_states.roll(1, dims=-1) * 0.25
+
+
+def make_model(version, device, dtype):
+    """Use the real decoder and norm paths, with small deterministic sublayers."""
+    model_cls, layer_cls, norm_cls = (
+        (Gemma3TextModel, Gemma3DecoderLayer, Gemma3RMSNorm)
+        if version == 3
+        else (Gemma4TextModel, Gemma4DecoderLayer, RMSNorm)
+    )
+
+    def norm():
+        module = norm_cls(128, eps=1e-6).to(device=device, dtype=dtype)
+        offset = 0.0 if version == 3 else 1.0
+        module.weight.data.copy_(
+            torch.linspace(-0.2, 0.2, 128, device=device, dtype=dtype) + offset
+        )
+        if device == "cpu":
+            module._forward_method = module.forward_native
+        return module
+
+    model = model_cls.__new__(model_cls)
+    nn.Module.__init__(model)
+    layers = []
+    for _ in range(3):
+        layer = layer_cls.__new__(layer_cls)
+        nn.Module.__init__(layer)
+        layer.self_attn = ToyAttention()
+        layer.mlp = nn.Tanh()
+        layer.input_layernorm = norm()
+        layer.post_attention_layernorm = norm()
+        layer.pre_feedforward_layernorm = norm()
+        layer.post_feedforward_layernorm = norm()
+        if version == 4:
+            layer.enable_moe_block = False
+            layer.has_ple = False
+            layer.moe = None
+            layer.layer_scalar = torch.tensor([0.75], device=device, dtype=dtype)
+        layers.append(layer)
+    model.layers = nn.ModuleList(layers)
+    model.norm = norm()
+    model.layers_to_capture = [0, 1, 3]
+    if version == 3:
+        model.rotary_emb = lambda *args: None
+        model.rotary_emb_local = lambda *args: None
+    else:
+        model.config = SimpleNamespace(num_hidden_layers=3)
+        model.pp_group = SimpleNamespace(is_first_rank=True, is_last_rank=True)
+        model.start_layer, model.end_layer = 0, 3
+        model.per_layer_model_projection = None
+    return model
+
+
+def eager_reference(model, inputs, version):
+    """Unfused residual additions, without a separately carried residual stream."""
+
+    def norm(x, module):
+        value = x.float()
+        value = value * torch.rsqrt(value.square().mean(-1, keepdim=True) + 1e-6)
+        weight = module.weight.float() + (1.0 if version == 3 else 0.0)
+        return (value * weight).to(x.dtype)
+
+    hidden = inputs.clone()
+    outputs = [hidden]
+    for layer in model.layers:
+        attn = layer.self_attn(hidden_states=norm(hidden, layer.input_layernorm))
+        hidden = hidden + norm(attn, layer.post_attention_layernorm)
+        mlp = layer.mlp(norm(hidden, layer.pre_feedforward_layernorm))
+        hidden = hidden + norm(mlp, layer.post_feedforward_layernorm)
+        if version == 4:
+            hidden = hidden * layer.layer_scalar
+        outputs.append(hidden)
+    return norm(hidden, model.norm), [outputs[i] for i in model.layers_to_capture]
+
+
+class TestGemmaAuxHiddenStates(CustomTestCase):
+    def check_captures(self, version, device, dtype, tokens, graph=False):
+        model = make_model(version, device, dtype)
+        generator = torch.Generator(device=device).manual_seed(42)
+        inputs = torch.randn(tokens, 128, generator=generator, device=device).to(dtype)
+        positions = torch.arange(tokens, device=device)
+
+        def forward():
+            return model(None, positions, None, input_embeds=inputs.clone())
+
+        expected_final, expected_captures = eager_reference(model, inputs, version)
+        final, captured = forward()
+        if graph:
+            for _ in range(3):
+                forward()
+            cuda_graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(cuda_graph):
+                final, captured = forward()
+            cuda_graph.replay()
+            cuda_graph.replay()
+            torch.cuda.synchronize()
+        atol, rtol = (0.08, 0.02) if dtype == torch.bfloat16 else (0.005, 0.005)
+        self.assertEqual(len(captured), len(expected_captures))
+        for actual, expected in zip(captured, expected_captures):
+            torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+        torch.testing.assert_close(final, expected_final, atol=atol, rtol=rtol)
+        model.layers_to_capture = []
+        torch.testing.assert_close(final, forward(), atol=0, rtol=0)
+
+    @torch.no_grad()
+    def test_native_captures_match_eager_residual_additions(self):
+        for version in (3, 4):
+            for cpu_amx in (False, True):
+                with (
+                    self.subTest(version=version, cpu_amx=cpu_amx),
+                    patch("sglang.srt.models.gemma3_causal._is_cpu", cpu_amx),
+                    patch(
+                        "sglang.srt.models.gemma3_causal._is_cpu_amx_available",
+                        cpu_amx,
+                        create=True,
+                    ),
+                ):
+                    self.check_captures(version, "cpu", torch.float32, 3)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    @torch.no_grad()
+    def test_fused_captures_survive_inplace_norms_and_graph_replay(self):
+        for version in (3, 4):
+            for dtype in (torch.float16, torch.bfloat16):
+                for tokens in (1, 8):
+                    with self.subTest(version=version, dtype=dtype, tokens=tokens):
+                        self.check_captures(version, "cuda", dtype, tokens, graph=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Gemma3's auxiliary captures still store `hidden_states` alone after #32383 separated the residual stream across decoder layers. The captures omit the residual and can be overwritten by subsequent fused normalization, reducing EAGLE3 acceptance.

Gemma4 returns complete layer outputs, but its captures share storage with the next layer's in-place residual update. The aliasing mechanism was discussed in #27540; this change preserves the actual auxiliary captures passed to the draft.

## Modifications

- Include Gemma3's residual at each requested capture boundary and snapshot Gemma4's intermediate captures.
- Add a regression test for complete capture values, snapshot preservation, unchanged target outputs, and CUDA graph replay.

## Accuracy Tests

Evaluated on one RTX PRO 6000 Blackwell 96GB with TP=1, temperature=0, max_new_tokens=8192 and concurrency=16, using native chat templates. Acceptance length includes target bonus tokens.

| Model | Backend | Task | N | Score | Acc. Length |
| --- | --- | --- | ---: | ---: | ---: |
| Gemma3-27B AWQ (EAGLE3) | FlashInfer | GSM8K | 500 | 92.00% → 94.00% | 1.058 → 1.891 |
| Gemma3-27B AWQ (EAGLE3) | FlashInfer | MT-Bench | 80 | 6.6125 → 5.2875 | 1.030 → 1.195 |
| Gemma3-27B AWQ (EAGLE3) | FlashInfer | HumanEval | 164 | 81.10% → 79.88% | 1.098 → 1.602 |
| Gemma3-27B AWQ (EAGLE3) | FlashInfer | LiveCodeBench v6 increment | 175 | 20.57% → 2.29% | 1.174 → 1.241 |
| Gemma4-31B-it (DFlash) | Triton | GSM8K | 500 | 97.20% → 97.40% | 6.646 → 6.425 |
| Gemma4-31B-it (DFlash) | Triton | MT-Bench | 80 | 9.5625 → 9.5312 | 3.563 → 3.449 |
| Gemma4-31B-it (DFlash) | Triton | HumanEval | 164 | 94.51% → 95.73% | 10.527 → 9.336 |
| Gemma4-31B-it (DFlash) | Triton | LiveCodeBench v6 increment | 175 | 70.29% → 72.00% | 5.409 → 5.119 |

We observed degradation on Gemma3 MT-Bench and LiveCodeBench, which is due to a FlashInfer EAGLE/SWA verification issue. A separate PR (#39287) will address this issue.

## Speed Tests and Profiling

End-to-end throughput on the same GPU, with fixed prompts, 256 output tokens per request (`ignore_eos=True`) and concurrency 1/16. Results use median elapsed time over 16 measurements after warmup. Gemma4 EAGLE3 uses the base checkpoint and raw completion prompts.

| Model | Backend | Concurrency | tok/s |
| --- | --- | ---: | ---: |
| Gemma3-27B AWQ (EAGLE3) | FlashInfer | 1 | 47.0 → 62.8 |
| Gemma3-27B AWQ (EAGLE3) | FlashInfer | 16 | 277.0 → 392.4 |
| Gemma4-31B-it (DFlash) | Triton | 1 | 85.9 → 83.0 |
| Gemma4-31B-it (DFlash) | Triton | 16 | 490.7 → 462.4 |
| Gemma4-31B (EAGLE3) | Triton | 1 | 50.2 → 51.5 |
| Gemma4-31B (EAGLE3) | Triton | 16 | 390.9 → 392.4 |

## Checklist

- [x] Code formatted.
- [x] Unit tests added.
- [x] No documentation update is needed.
- [x] Accuracy and speed benchmark results provided.
- [x] Follow the SGLang code style.

Assisted-by: OpenAI Codex

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34747308725](https://github.com/sgl-project/sglang/actions/runs/34747308725)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34747308531](https://github.com/sgl-project/sglang/actions/runs/34747308531)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34747308648](https://github.com/sgl-project/sglang/actions/runs/34747308648)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->