### PR TITLE
[Bugfix] Fix EAGLE sliding-window verification in FlashInfer and Triton

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -284,6 +284,14 @@ def split_spec_info(
         seq_lens_cpu=seq_lens_cpu,
         seq_lens_sum=seq_lens_sum,
     )
+    if getattr(spec_info, "swa_custom_mask", None) is not None:
+        mask_lens = (
+            spec_info.seq_lens_cpu.clamp(max=spec_info.swa_mask_window)
+            + spec_info.draft_token_num
+        ) * spec_info.draft_token_num
+        start = int(mask_lens[:start_seq_index].sum())
+        end = int(mask_lens[:end_seq_index].sum())
+        output_spec_info.swa_custom_mask = spec_info.swa_custom_mask[start:end]
     return output_spec_info
 
 

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1069,6 +1069,7 @@ class FlashInferAttnBackend(AttentionBackend):
                 dtype=torch.uint8,
                 device="cuda",
             )
+            self.cuda_graph_swa_custom_mask = None
             self.cuda_graph_qk_indptr = [x.clone() for x in self.kv_indptr]
             self.cuda_graph_qo_indptr = [x.clone() for x in self.kv_indptr]
 
@@ -1104,17 +1105,33 @@ class FlashInferAttnBackend(AttentionBackend):
             wrappers = self.decode_cuda_graph_metadata[bs]
         return wrappers
 
-    def _create_prefill_wrappers(self, bs: int, use_custom_mask: bool = False) -> list:
+    def _create_prefill_wrappers(
+        self,
+        bs: int,
+        use_custom_mask: bool = False,
+        use_eagle_swa_mask: bool = False,
+    ) -> list:
         # FlashInfer's prefill wrapper decides mask mode based on whether
         # `custom_mask_buf` is initialized (not whether a custom mask is provided).
         # For cases like DFLASH draft (ENCODER_ONLY / non-causal) we do NOT use a
         # custom mask, so we must avoid initializing `custom_mask_buf`, otherwise
         # FlashInfer will treat the (zero) buffer as a real mask and block attention.
+        separate_swa_mask = use_custom_mask and use_eagle_swa_mask
+        if separate_swa_mask and self.cuda_graph_swa_custom_mask is None:
+            # Allocate only when a SWA custom-mask wrapper is actually captured.
+            # Its packed mask must survive planning the full-attention wrapper.
+            self.cuda_graph_swa_custom_mask = torch.empty_like(
+                self.cuda_graph_custom_mask
+            )
         wrappers = []
         for i in range(self.num_wrappers):
             extra = (
                 {
-                    "custom_mask_buf": self.cuda_graph_custom_mask,
+                    "custom_mask_buf": (
+                        self.cuda_graph_swa_custom_mask
+                        if separate_swa_mask and i == 0
+                        else self.cuda_graph_custom_mask
+                    ),
                     "mask_indptr_buf": self.cuda_graph_qk_indptr[i][: bs + 1],
                 }
                 if use_custom_mask
@@ -1262,7 +1279,15 @@ class FlashInferAttnBackend(AttentionBackend):
                 and spec_info is not None
                 and getattr(spec_info, "custom_mask", None) is not None
             )
-            prefill_wrappers = self._create_prefill_wrappers(bs, use_custom_mask)
+            prefill_wrappers = self._create_prefill_wrappers(
+                bs,
+                use_custom_mask,
+                use_eagle_swa_mask=(
+                    self.dispatch_reason == WrapperDispatch.SLIDING_WINDOW
+                    and spec_info is not None
+                    and spec_info.spec_input_type == SpecInputType.EAGLE_VERIFY
+                ),
+            )
             self.prefill_cuda_graph_metadata[bs] = prefill_wrappers
             self.forward_metadata = PrefillMetadata(
                 prefill_wrappers, forward_mode.is_dllm_extend(), False
@@ -2172,7 +2197,14 @@ class FlashInferIndicesUpdaterPrefill:
             custom_mask = cross_attention_custom_mask
         else:
             assert isinstance(spec_info, SpecInput)
-            if spec_info.spec_input_type == SpecInputType.DFLASH_VERIFY:
+            # The SWA updater binds wrapper 0 to this indptr buffer; offsets
+            # alone cannot identify it (cross-attention also has offsets).
+            eagle_swa = (
+                self.attn_backend.dispatch_reason == WrapperDispatch.SLIDING_WINDOW
+                and kv_indptr is self.kv_indptr[0]
+                and spec_info.spec_input_type == SpecInputType.EAGLE_VERIFY
+            )
+            if spec_info.spec_input_type == SpecInputType.DFLASH_VERIFY or eagle_swa:
                 kv_indices, kv_indptr, qo_indptr, custom_mask = (
                     spec_info.generate_attn_arg_prefill(
                         req_pool_indices,

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -40,6 +40,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import get_exec, get_parallel, get_schedule, get_spec
+from sglang.srt.speculative.spec_info import SpecInputType
 from sglang.srt.speculative.spec_utils import (
     draft_kv_indices_buffer_width,
     draft_kv_indices_used_len,
@@ -137,6 +138,8 @@ class ForwardMetadata:
     lean_Lp: Optional[torch.Tensor] = None
     lean_Op: Optional[torch.Tensor] = None
     lean_locks: Optional[torch.Tensor] = None
+    swa_custom_mask: Optional[torch.Tensor] = None
+    swa_mask_indptr: Optional[torch.Tensor] = None
 
 
 class TritonAttnBackend(AttentionBackend):
@@ -387,6 +390,8 @@ class TritonAttnBackend(AttentionBackend):
 
         self.forward_metadata: ForwardMetadata = None
         self._verify_mask = None
+        self.cuda_graph_swa_custom_mask = None
+        self.swa_mask_indptr = None
         # Tree-mask scratch is fetched from the target backend only.
         self.is_draft_runner = model_runner.is_draft_worker
 
@@ -611,6 +616,34 @@ class TritonAttnBackend(AttentionBackend):
         seq_mask_len = num_draft_tokens * (seq_lens + num_draft_tokens)
         mask_indptr = self.mask_indptr[: bs + 1]
         mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
+        swa_mask = getattr(spec_info, "swa_custom_mask", None)
+        if (
+            self._verify_mask is not None
+            and self.sliding_window_size is not None
+            and self.sliding_window_size > 0
+            and spec_info is not None
+            and spec_info.spec_input_type == SpecInputType.EAGLE_VERIFY
+        ):
+            if self.cuda_graph_swa_custom_mask is None:
+                # Allocate at EAGLE/SWA warmup, before capture; retain stable
+                # addresses as request lengths change across graph replays.
+                self.cuda_graph_swa_custom_mask = torch.ones(
+                    self._verify_mask.max_bs
+                    * self.num_draft_tokens
+                    * (self.sliding_window_size + self.num_draft_tokens),
+                    dtype=torch.bool,
+                    device=self.device,
+                )
+                self.swa_mask_indptr = torch.zeros_like(self.mask_indptr)
+            if swa_mask is None:
+                # Capture/idle stubs carry a fully visible placeholder mask.
+                self.cuda_graph_swa_custom_mask.fill_(True)
+            else:
+                self.cuda_graph_swa_custom_mask[: swa_mask.numel()].copy_(swa_mask)
+                self.cuda_graph_swa_custom_mask[swa_mask.numel() :].fill_(True)
+            self.swa_mask_indptr[: bs + 1] = (
+                window_kv_indptr[: bs + 1] + qo_indptr
+            ) * num_draft_tokens
         return (
             qo_indptr,
             kv_indptr,
@@ -1036,6 +1069,19 @@ class TritonAttnBackend(AttentionBackend):
             lean_Op=lean_Op,
             lean_locks=lean_locks,
         )
+        if (
+            forward_batch.forward_mode.is_target_verify()
+            and spec_info is not None
+            and spec_info.spec_input_type == SpecInputType.EAGLE_VERIFY
+            and window_kv_indptr is not None
+        ):
+            self.forward_metadata.swa_custom_mask = getattr(
+                spec_info, "swa_custom_mask", None
+            )
+            if self.forward_metadata.swa_custom_mask is not None:
+                self.forward_metadata.swa_mask_indptr = (
+                    window_kv_indptr + qo_indptr
+                ) * max_extend_len
 
     def init_cuda_graph_state(
         self,
@@ -1204,6 +1250,11 @@ class TritonAttnBackend(AttentionBackend):
                 lean_locks=self.cuda_graph_lean_locks,
             )
         elif forward_mode.is_target_verify():
+            use_swa_mask = (
+                swa
+                and spec_info is not None
+                and spec_info.spec_input_type == SpecInputType.EAGLE_VERIFY
+            )
             custom_mask = (
                 self._verify_mask.buffer
                 if self._verify_mask is not None
@@ -1233,6 +1284,12 @@ class TritonAttnBackend(AttentionBackend):
                     self.cuda_graph_window_num_kv_splits if swa else None
                 ),
                 window_kv_offsets=self.cuda_graph_window_kv_offsets if swa else None,
+                swa_custom_mask=self.cuda_graph_swa_custom_mask
+                if use_swa_mask
+                else None,
+                swa_mask_indptr=self.swa_mask_indptr[: bs + 1]
+                if use_swa_mask
+                else None,
                 swa_out_cache_loc=swa_out_cache_loc,
                 out_cache_loc_full_physical=out_cache_loc_full_physical,
             )
@@ -1681,6 +1738,19 @@ class TritonAttnBackend(AttentionBackend):
             kv_indices = self.forward_metadata.kv_indices
             window_kv_offsets = None
 
+        custom_mask = self.forward_metadata.custom_mask
+        mask_indptr = self.forward_metadata.mask_indptr
+        use_swa_mask = (
+            sliding_window_size >= 0
+            and self.forward_metadata.swa_custom_mask is not None
+        )
+        if use_swa_mask:
+            custom_mask = self.forward_metadata.swa_custom_mask
+            mask_indptr = self.forward_metadata.swa_mask_indptr
+            # The compact mask already uses tree depths for the window bound.
+            sliding_window_size = -1
+            window_kv_offsets = None
+
         if layer.k_scale is not None and layer.v_scale is not None:
             k_descale = layer.k_scale_float
             v_descale = layer.v_scale_float
@@ -1705,6 +1775,7 @@ class TritonAttnBackend(AttentionBackend):
             verify_fwd = None
         if (
             verify_fwd is not None
+            and not use_swa_mask
             and score_mod is None
             and forward_batch.forward_mode.is_target_verify()
             and verify_fwd(
@@ -1744,9 +1815,9 @@ class TritonAttnBackend(AttentionBackend):
             self.forward_metadata.qo_indptr,
             kv_indptr,
             kv_indices,
-            self.forward_metadata.custom_mask,
+            custom_mask,
             causal,
-            self.forward_metadata.mask_indptr,
+            mask_indptr,
             self.forward_metadata.max_extend_len,
             k_descale,
             v_descale,
@@ -1760,6 +1831,7 @@ class TritonAttnBackend(AttentionBackend):
             score_mod=score_mod,
             aux_tensors=aux_tensors,
             extend_seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+            skip_prefix_custom_mask=not use_swa_mask,
         )
         return o
 
@@ -2100,6 +2172,16 @@ class TritonAttnBackend(AttentionBackend):
             k_descale = 1.0
             v_descale = 1.0
 
+        custom_mask = self.forward_metadata.custom_mask
+        mask_indptr = self.forward_metadata.mask_indptr
+        if (
+            sliding_window_size >= 0
+            and self.forward_metadata.swa_custom_mask is not None
+        ):
+            custom_mask = self.forward_metadata.swa_custom_mask
+            mask_indptr = self.forward_metadata.swa_mask_indptr
+            sliding_window_size = -1
+
         # Call unified kernel
         self.extend_attention_fwd_unified(
             q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
@@ -2113,8 +2195,8 @@ class TritonAttnBackend(AttentionBackend):
             unified_kv_indices,
             prefix_lens,
             self.forward_metadata.max_extend_len,
-            custom_mask=self.forward_metadata.custom_mask,
-            mask_indptr=self.forward_metadata.mask_indptr,
+            custom_mask=custom_mask,
+            mask_indptr=mask_indptr,
             sm_scale=layer.scaling,
             logit_cap=logits_soft_cap,
             is_causal=causal,

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -12,6 +12,44 @@ from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
 logger = logging.getLogger(__name__)
 
 
+@torch.compile(dynamic=True)
+def apply_eagle_swa_mask(
+    mask: torch.Tensor,
+    prefix_lens: torch.Tensor,
+    positions: torch.Tensor,
+    window: int,
+):
+    """Apply tree-position window bounds to an already compact tree mask.
+
+    Only the first draft-token-count prefix columns can leave the window.
+    A window smaller than the tree also needs the draft columns checked.
+    This touches O(batch * draft_tokens**2) cells, independent of context length.
+    """
+    _, draft_tokens = positions.shape
+    prefix = prefix_lens.clamp(max=window)
+    width = prefix + draft_tokens
+    starts = (width.cumsum(0) - width) * draft_tokens
+    q = torch.arange(draft_tokens, device=mask.device)
+    span = draft_tokens if window >= draft_tokens else window + draft_tokens
+    columns = torch.minimum(
+        torch.arange(span, device=mask.device)[None, :], width[:, None] - 1
+    )
+    tree_columns = (columns - prefix[:, None]).clamp(0, draft_tokens - 1)
+    key_positions = torch.where(
+        columns < prefix[:, None],
+        prefix_lens[:, None] - prefix[:, None] + columns,
+        positions.gather(1, tree_columns.long()),
+    )
+    indices = (
+        starts[:, None, None]
+        + q[None, :, None] * width[:, None, None]
+        + columns[:, None, :]
+    )
+    mask[indices] = mask[indices] & (
+        key_positions[:, None, :] >= positions[:, :, None] - window
+    )
+
+
 @dataclass
 class EagleVerifyInput(SpecInput):
     draft_token: torch.Tensor
@@ -33,6 +71,10 @@ class EagleVerifyInput(SpecInput):
 
     # Shape info for padding
     num_tokens_per_req: int = -1  # -1 auto-fills from draft_token_num.
+
+    # Compact tree mask with logical-position bounds for SWA verify layers.
+    swa_custom_mask: Optional[torch.Tensor] = None
+    swa_mask_window: Optional[int] = None
 
     def __post_init__(self):
         super().__init__(SpecInputType.EAGLE_VERIFY)
@@ -85,6 +127,7 @@ class EagleVerifyInput(SpecInput):
         paged_kernel_lens: torch.Tensor,
         paged_kernel_lens_sum: int,
         req_to_token: torch.Tensor,
+        kv_start_idx: Optional[torch.Tensor] = None,
     ):
         device = req_pool_indices.device
         batch_size = len(req_pool_indices)
@@ -112,7 +155,7 @@ class EagleVerifyInput(SpecInput):
             req_pool_indices,
             paged_kernel_lens,
             cum_kv_seq_len,
-            None,
+            kv_start_idx,
             kv_indices,
             req_to_token.size(1),
         )
@@ -120,13 +163,15 @@ class EagleVerifyInput(SpecInput):
             paged_kernel_lens_sum * self.draft_token_num
             + (self.draft_token_num**2) * batch_size
         )
-        if self.custom_mask.numel() < mask_numel:
+        use_swa_mask = kv_start_idx is not None and self.swa_custom_mask is not None
+        custom_mask = self.swa_custom_mask if use_swa_mask else self.custom_mask
+        if custom_mask.numel() < mask_numel:
             # FIXME(attn): temporary fix for custom mask padding with cuda graph
-            self.custom_mask = torch.cat(
+            custom_mask = torch.cat(
                 [
-                    self.custom_mask,
+                    custom_mask,
                     torch.full(
-                        (mask_numel - self.custom_mask.numel(),),
+                        (mask_numel - custom_mask.numel(),),
                         True,
                         dtype=torch.bool,
                         device=device,
@@ -135,6 +180,10 @@ class EagleVerifyInput(SpecInput):
                 dim=0,
             )
 
+        if use_swa_mask:
+            return kv_indices, cum_kv_seq_len, qo_indptr, custom_mask[:mask_numel]
+        # Preserve the original full-mask padding and return contract.
+        self.custom_mask = custom_mask
         return kv_indices, cum_kv_seq_len, qo_indptr, self.custom_mask
 
 

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -15,7 +15,12 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
 )
-from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
+from sglang.srt.runtime_context import get_spec
+from sglang.srt.speculative.eagle_info import (
+    EagleDraftInput,
+    EagleVerifyInput,
+    apply_eagle_swa_mask,
+)
 from sglang.srt.speculative.eagle_utils import (
     TreeMaskMode,
     build_tree_kernel_efficient,
@@ -345,7 +350,8 @@ def build_eagle_verify_input(
     # Write straight into the backend's buffer when it owns one and this batch
     # fits; an eager batch past the captured max_bs falls back to allocating.
     bs = batch.seq_lens.shape[0]
-    target_attn_backend = target_worker.model_runner.attn_backend
+    model_runner = target_worker.model_runner
+    target_attn_backend = model_runner.attn_backend
     verify_mask = target_attn_backend.verify_mask
     if verify_mask is None:
         tree_mask_buf, mask_mode, fill_mask = None, tree_mask_mode, True
@@ -369,7 +375,7 @@ def build_eagle_verify_input(
         retrieve_index,
         retrieve_next_token,
         retrieve_next_sibling,
-        draft_tokens,
+        verify_tokens,
     ) = build_tree_kernel_efficient(
         draft_input.bonus_tokens,
         parent_list,
@@ -385,9 +391,64 @@ def build_eagle_verify_input(
         fill_prefix_mask=fill_mask,
     )
 
+    swa_custom_mask = None
+    verify_backend = (
+        model_runner.decode_attention_backend_str
+        if get_spec().speculative_attention_mode == "decode"
+        else model_runner.prefill_attention_backend_str
+    )
+    window = model_runner.sliding_window_size
+    if (
+        verify_backend in ("flashinfer", "triton")
+        and window is not None
+        and window >= 0
+    ):
+        # Rebuild only the mask in the SWA wrapper's compact KV coordinates.
+        # Positions and retrieval indices must retain the original prefix lengths.
+        if batch.seq_lens_cpu is not None:
+            swa_seq_lens_sum = int(torch.clamp(batch.seq_lens_cpu, max=window).sum())
+        else:
+            # Allocation upper bound, as above; avoid a device-to-host sync.
+            swa_seq_lens_sum = bs * window
+        window_covers_tree = (
+            batch.seq_lens_cpu is not None
+            and int(batch.seq_lens_cpu.max()) + min(num_steps, num_draft_tokens - 1)
+            <= window
+        )
+        if window_covers_tree:
+            swa_custom_mask = tree_mask[
+                : (swa_seq_lens_sum + bs * num_draft_tokens) * num_draft_tokens
+            ]
+        elif batch.seq_lens_cpu is not None and swa_seq_lens_sum == seq_lens_sum:
+            swa_custom_mask = tree_mask[
+                : (swa_seq_lens_sum + bs * num_draft_tokens) * num_draft_tokens
+            ].clone()
+        else:
+            swa_custom_mask = build_tree_kernel_efficient(
+                draft_input.bonus_tokens,
+                parent_list,
+                top_scores_index,
+                draft_tokens,
+                torch.clamp(batch.seq_lens, max=window),
+                swa_seq_lens_sum,
+                topk,
+                num_steps,
+                num_draft_tokens,
+                TreeMaskMode.FULL_MASK,
+            )[0]
+        if not window_covers_tree:
+            apply_eagle_swa_mask(
+                swa_custom_mask,
+                batch.seq_lens,
+                position.view(bs, num_draft_tokens),
+                window,
+            )
+
     return EagleVerifyInput(
-        draft_token=draft_tokens,
+        draft_token=verify_tokens,
         custom_mask=tree_mask,
+        swa_custom_mask=swa_custom_mask,
+        swa_mask_window=window if swa_custom_mask is not None else None,
         positions=position,
         retrieve_index=retrieve_index,
         retrieve_next_token=retrieve_next_token,

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -250,6 +250,7 @@ def record_stream_for_v2_verify(batch, verify_input, fwd_stream):
                 for attr in (
                     "draft_token",
                     "custom_mask",
+                    "swa_custom_mask",
                     "positions",
                     "retrieve_index",
                     "retrieve_next_token",

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
@@ -1231,13 +1231,28 @@ def prepare_dense_runner_inputs(
     *,
     max_context_len: int,
 ) -> None:
-    del batch
+    # Verify capture/replay rebuilds the mapping; fill its current locations.
+    # Other runner modes retain their original fixture layout.
+    req_to_token = (
+        (
+            fixture.runner.req_to_token_pool.req_to_token[batch.req_pool_indices]
+            .cpu()
+            .tolist()
+        )
+        if batch.forward_mode.is_target_verify()
+        else None
+    )
     _populate_prefix_kv(
         fixture.actual_module,
         case,
         fixture.runner,
         inputs["prefix_hidden"],
         max_context_len=max_context_len,
+        loc_fn=(
+            (lambda req_idx, pos: req_to_token[req_idx][pos])
+            if req_to_token is not None
+            else None
+        ),
     )
 
 

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_target_verify_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_target_verify_runner.py
@@ -301,7 +301,30 @@ def _expected_case_and_masks_for_spec_verify(
         )
 
     masks_by_req, _ = _make_custom_masks(case, topk=topk, device=device)
+    if _is_eagle_swa(case, spec_kind):
+        # A sibling's flattened index is not its logical token position.
+        # Define visibility from the tree and token positions, independently
+        # of the backend's windowed KV layout.
+        depth = (
+            _draft_tree_mask(
+                draft_token_num=_check_target_verify_case(case),
+                topk=topk,
+                device=device,
+            ).sum(dim=1)
+            - 1
+        )
+        for prefix_len, mask in zip(case.prefix_lens, masks_by_req):
+            query_pos = prefix_len + depth
+            key_pos = torch.cat((torch.arange(prefix_len, device=device), query_pos))
+            mask &= key_pos[None, :] >= query_pos[:, None] - case.sliding_window_size
+        return replace(case, sliding_window_size=None), masks_by_req
     return case, masks_by_req
+
+
+def _is_eagle_swa(case, spec_kind: SpecVerifyKind) -> bool:
+    return (
+        spec_kind == "eagle" and getattr(case, "sliding_window_size", None) is not None
+    )
 
 
 def _make_retrieve_tensors(
@@ -376,10 +399,19 @@ def _make_spec_verify_input(
         "eagle": EagleVerifyInput,
         "frozen_kv_mtp": FrozenKVMTPVerifyInput,
     }[spec_kind]
-    return verify_cls(
+    positions = batch.positions
+    if _is_eagle_swa(case, spec_kind):
+        depth = (
+            _draft_tree_mask(
+                draft_token_num=draft_token_num, topk=topk, device=device
+            ).sum(dim=1)
+            - 1
+        )
+        positions = torch.cat([prefix_len + depth for prefix_len in case.prefix_lens])
+    verify_input = verify_cls(
         draft_token=batch.input_ids,
         custom_mask=custom_mask,
-        positions=batch.positions,
+        positions=positions,
         retrieve_index=retrieve_index,
         retrieve_next_token=retrieve_next_token,
         retrieve_next_sibling=retrieve_next_sibling,
@@ -396,6 +428,29 @@ def _make_spec_verify_input(
         seq_lens_sum=batch.seq_lens_sum,
         seq_lens_cpu=batch.seq_lens_cpu,
     )
+    if _is_eagle_swa(case, spec_kind) and case.backend in (
+        "flashinfer",
+        "triton",
+    ):
+        from sglang.srt.speculative.eagle_info import apply_eagle_swa_mask
+
+        compact_case = replace(
+            case,
+            prefix_lens=tuple(
+                min(n, case.sliding_window_size) for n in case.prefix_lens
+            ),
+        )
+        _, verify_input.swa_custom_mask = _make_custom_masks(
+            compact_case, topk=topk, device=device
+        )
+        apply_eagle_swa_mask(
+            verify_input.swa_custom_mask,
+            batch.seq_lens,
+            positions.view(case.batch_size, draft_token_num),
+            case.sliding_window_size,
+        )
+        verify_input.swa_mask_window = case.sliding_window_size
+    return verify_input
 
 
 def _make_eagle_verify_input(

--- a/test/registered/attention/unittests/swa/test_flashinfer.py
+++ b/test/registered/attention/unittests/swa/test_flashinfer.py
@@ -1,21 +1,35 @@
 import unittest
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 
 from sglang.srt.environ import envs
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.utils import is_flashinfer_available
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.attention_unittest.attention_methods.dense_attention import (
+    DENSE_ATOL,
+    DENSE_RTOL,
     DenseAttentionCase,
+    _make_forward_batch,
+    build_dense_attention_fixture,
+    dense_attention_reference_with_custom_mask,
+    dense_fixture_inputs,
+    make_dense_random_inputs,
     make_swa_no_prefix_input_config_cases,
     make_swa_prefix_input_config_cases,
+    prepare_dense_runner_inputs,
     run_dense_attention_case,
+    run_dense_forward,
 )
 from sglang.test.kits.attention_unittest.runner_modes.cuda_graph_decode_runner import (
     run_dense_cuda_graph_decode_case,
 )
 from sglang.test.kits.attention_unittest.runner_modes.speculative_target_verify_runner import (
+    _prepare_spec_verify_batch,
     run_dense_spec_verify_case,
     run_dense_spec_verify_cuda_graph_case,
 )
@@ -154,6 +168,394 @@ class TestFlashInferSWAAttentionBackendCorrectness(CustomTestCase):
             "dflash",
         ),
     )
+
+    EAGLE_VERIFY_CASES = tuple(
+        DenseAttentionCase(
+            name=f"eagle_swa_{prefix_lens}_{draft_tokens}_{window}",
+            backend="flashinfer",
+            forward_mode=ForwardMode.TARGET_VERIFY,
+            num_heads=4,
+            num_kv_heads=2,
+            page_size=16,
+            prefix_lens=prefix_lens,
+            extend_lens=(draft_tokens,) * len(prefix_lens),
+            sliding_window_size=window,
+        )
+        for prefix_lens, draft_tokens, window in (
+            ((2,), 3, 4),
+            ((3, 4, 5), 3, 4),
+            ((9, 2), 3, 4),
+            ((2, 9), 3, 4),
+            ((12, 7), 3, 4),
+            ((0, 9), 3, 4),
+            ((9, 2), 7, 2),
+            ((1220, 325), 8, 1023),
+            ((325, 1220), 8, 1023),
+        )
+    )
+
+    def test_eagle_swa_tree_generation(self):
+        from sglang.srt.batch_overlap.two_batch_overlap import split_spec_info
+        from sglang.srt.layers.attention.verify_mask import VerifyMask
+        from sglang.srt.runtime_context import get_context
+        from sglang.srt.speculative.eagle_utils import (
+            TreeMaskMode,
+            build_tree_kernel_efficient,
+        )
+        from sglang.srt.speculative.eagle_worker_common import build_eagle_verify_input
+
+        runner = SimpleNamespace(
+            attn_backend=SimpleNamespace(verify_mask=None, max_context_len=2048),
+            sliding_window_size=4,
+            prefill_attention_backend_str="flashinfer",
+            decode_attention_backend_str="triton",
+        )
+        for lengths, host_lens, mode in (
+            ((12, 7), True, "prefill"),
+            ((2, 9), True, "prefill"),
+            ((1, 4), True, "prefill"),
+            ((1, 1), True, "prefill"),
+            ((12, 7), False, "prefill"),
+            ((12, 7), True, "decode"),
+            ((1, 1), True, "decode"),
+            ((1, 4), True, "decode"),
+        ):
+            with self.subTest(lengths=lengths, host_lens=host_lens, mode=mode):
+                override = get_context().override_server_args(
+                    speculative_attention_mode=mode
+                )
+                override.install()
+                self.addCleanup(override.restore)
+                bs, draft = len(lengths), 8
+                runner.attn_backend.verify_mask = (
+                    VerifyMask(
+                        buffer=torch.zeros(
+                            bs * draft * (2048 + draft),
+                            dtype=torch.uint8,
+                            device="cuda",
+                        ),
+                        mode=TreeMaskMode.FULL_MASK,
+                        max_bs=bs,
+                    )
+                    if mode == "decode"
+                    else None
+                )
+                cpu = torch.tensor(lengths)
+                batch = SimpleNamespace(
+                    forward_mode=ForwardMode.DECODE,
+                    seq_lens=cpu.cuda(),
+                    seq_lens_cpu=cpu if host_lens else None,
+                    seq_lens_sum=sum(lengths) if host_lens else None,
+                )
+                bonus = torch.arange(bs, device="cuda")
+                parents = torch.tensor(
+                    [[0, 0, 1, 4, 0, 5, 0, 0, 0]] * bs, device="cuda"
+                )
+                indices = torch.tensor([[0, 1, 4, 8, 5, 20, 12]] * bs, device="cuda")
+                tokens = torch.arange(bs * (draft - 1), device="cuda").view(bs, -1)
+                expected = build_tree_kernel_efficient(
+                    bonus,
+                    parents,
+                    indices,
+                    tokens,
+                    batch.seq_lens,
+                    sum(lengths),
+                    4,
+                    3,
+                    draft,
+                )
+                with patch(
+                    "sglang.srt.speculative.eagle_worker_common.build_tree_kernel_efficient",
+                    wraps=build_tree_kernel_efficient,
+                ) as build:
+                    actual = build_eagle_verify_input(
+                        batch,
+                        SimpleNamespace(bonus_tokens=bonus),
+                        parents,
+                        indices,
+                        tokens,
+                        None,
+                        target_worker=SimpleNamespace(model_runner=runner),
+                        topk=4,
+                        num_steps=3,
+                        num_draft_tokens=draft,
+                        tree_mask_mode=TreeMaskMode.FULL_MASK,
+                        device="cuda",
+                    )
+                torch.testing.assert_close(
+                    actual.custom_mask[: expected[0].numel()],
+                    expected[0],
+                    check_dtype=False,
+                )
+                for attr, value in zip(
+                    (
+                        "positions",
+                        "retrieve_index",
+                        "retrieve_next_token",
+                        "retrieve_next_sibling",
+                        "draft_token",
+                    ),
+                    expected[1:],
+                ):
+                    torch.testing.assert_close(getattr(actual, attr), value)
+                full_masks, offset = [], 0
+                for request, prefix in enumerate(lengths):
+                    size = draft * (prefix + draft)
+                    full = expected[0][offset : offset + size].view(draft, -1)
+                    pos = expected[1].view(bs, draft)[request]
+                    key_pos = torch.cat((torch.arange(prefix, device="cuda"), pos))
+                    bounded = full & (key_pos[None, :] >= pos[:, None] - 4)
+                    full_masks.append(bounded[:, max(0, prefix - 4) :].flatten())
+                    offset += size
+                compact = torch.cat(full_masks)
+                if host_lens:
+                    self.assertEqual(actual.swa_custom_mask.numel(), compact.numel())
+                torch.testing.assert_close(
+                    actual.swa_custom_mask[: compact.numel()],
+                    compact,
+                    check_dtype=False,
+                )
+                self.assertEqual(build.call_count, 1 if max(lengths) <= 4 else 2)
+                if max(lengths) + 3 <= 4:
+                    self.assertEqual(
+                        actual.swa_custom_mask.data_ptr(), actual.custom_mask.data_ptr()
+                    )
+                else:
+                    self.assertIsNot(actual.swa_custom_mask, actual.custom_mask)
+                actual.seq_lens_cpu = cpu
+                for i, expected_mask in enumerate(full_masks):
+                    child = split_spec_info(
+                        actual, i, i + 1, i * draft, (i + 1) * draft
+                    )
+                    torch.testing.assert_close(
+                        child.swa_custom_mask, expected_mask, check_dtype=False
+                    )
+
+    def test_full_verify_mask_padding_contract(self):
+        from sglang.srt.speculative.eagle_info import EagleVerifyInput
+        from sglang.srt.speculative.frozen_kv_mtp_info import FrozenKVMTPVerifyInput
+
+        for verify_cls in (EagleVerifyInput, FrozenKVMTPVerifyInput):
+            for size in (5, 29):
+                with self.subTest(verify_cls=verify_cls.__name__, size=size):
+                    info = verify_cls.create_idle_input(1, 2, 3, "cuda")
+                    original = torch.arange(size, device="cuda") % 2 == 0
+                    info.custom_mask = original
+                    info.swa_custom_mask = torch.zeros(
+                        21, device="cuda", dtype=torch.bool
+                    )
+                    indices, _, _, mask = info.generate_attn_arg_prefill(
+                        torch.tensor([0], device="cuda"),
+                        torch.tensor([4], device="cuda"),
+                        4,
+                        torch.arange(32, device="cuda").view(1, -1),
+                    )
+                    torch.testing.assert_close(
+                        indices, torch.arange(7, device="cuda", dtype=torch.int32)
+                    )
+                    expected = torch.cat(
+                        (
+                            original,
+                            torch.ones(
+                                max(0, 21 - size), device="cuda", dtype=torch.bool
+                            ),
+                        )
+                    )
+                    torch.testing.assert_close(mask, expected)
+                    self.assertIs(mask, info.custom_mask)
+                    if size >= 21:
+                        self.assertIs(mask, original)
+
+    def test_eagle_swa_verify(self):
+        for case in self.EAGLE_VERIFY_CASES:
+            for topk in (1, 2) if case.extend_lens[0] == 3 else (1,):
+                with self.subTest(case=case.name, topk=topk):
+                    run_dense_spec_verify_case(
+                        self,
+                        case,
+                        topk=topk,
+                        head_dim=self.HEAD_DIM,
+                        hidden_size=self.HIDDEN_SIZE,
+                        max_context_len=2048,
+                    )
+
+    def test_eagle_swa_verify_graph_metadata(self):
+        for case in self.EAGLE_VERIFY_CASES:
+            for topk in (1, 2) if case.extend_lens[0] == 3 else (1,):
+                with self.subTest(case=case.name, topk=topk):
+                    run_dense_spec_verify_cuda_graph_case(
+                        self,
+                        case,
+                        topk=topk,
+                        head_dim=self.HEAD_DIM,
+                        hidden_size=self.HIDDEN_SIZE,
+                        max_context_len=2048,
+                    )
+
+    @torch.no_grad()
+    def test_eagle_swa_and_full_real_graph_replay(self):
+        # An irregular, multi-level tree: siblings can have equal positions.
+        parents = (-1, 0, 0, 1, 2, 1, 5, 3)
+        draft = len(parents)
+        tree = torch.zeros(draft, draft, dtype=torch.bool)
+        depths = []
+        for query in range(draft):
+            node = query
+            while node >= 0:
+                tree[query, node] = True
+                node = parents[node]
+            depths.append(int(tree[query].sum()) - 1)
+        case = DenseAttentionCase(
+            name="eagle_swa_and_full_real_graph",
+            backend="flashinfer",
+            forward_mode=ForwardMode.TARGET_VERIFY,
+            num_heads=4,
+            num_kv_heads=2,
+            page_size=16,
+            prefix_lens=(1, 1, 1),
+            extend_lens=(draft,) * 3,
+            sliding_window_size=4,
+        )
+        fixture = build_dense_attention_fixture(
+            self,
+            case,
+            head_dim=self.HEAD_DIM,
+            hidden_size=self.HIDDEN_SIZE,
+            max_context_len=2048,
+            disable_cuda_graph=False,
+        )
+        backend = fixture.backend
+        batch = fixture.forward_batch
+        inputs = dense_fixture_inputs(fixture)
+        _prepare_spec_verify_batch(
+            case, batch, topk=1, spec_kind="eagle", device="cuda"
+        )
+        batch.spec_info.positions = None  # Production's dummy capture input.
+        batch.spec_info.swa_custom_mask = None
+        backend.init_cuda_graph_state(max_bs=3, max_num_tokens=3 * draft)
+        self.assertIsNone(backend.cuda_graph_swa_custom_mask)
+        backend._create_prefill_wrappers(3, use_custom_mask=False)  # DFlash path.
+        self.assertIsNone(backend.cuda_graph_swa_custom_mask)
+
+        def forward_both():
+            outputs = []
+            for window in (case.sliding_window_size, -1):
+                fixture.actual_module.attn.sliding_window_size = window
+                outputs.append(run_dense_forward(fixture, batch, inputs))
+            return outputs
+
+        with forward_context(ForwardContext(attn_backend=backend)):
+            backend.init_forward_metadata_out_graph(batch, in_capture=True)
+            backend.init_forward_metadata_in_graph(batch)
+            for _ in range(3):
+                forward_both()
+            backend.on_after_cuda_graph_warmup()
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                actual = forward_both()
+            mask_ptrs = (
+                backend.cuda_graph_swa_custom_mask.data_ptr(),
+                backend.cuda_graph_custom_mask.data_ptr(),
+            )
+            self.assertNotEqual(*mask_ptrs)
+
+            for prefix_lens in ((12, 7), (2, 9), (9,), (325, 1220), (1, 4, 9)):
+                with self.subTest(prefix_lens=prefix_lens):
+                    real_bs = len(prefix_lens)
+                    replay_case = replace(
+                        case, prefix_lens=prefix_lens + (1,) * (3 - real_bs)
+                    )
+                    replay_inputs = make_dense_random_inputs(
+                        replay_case,
+                        fixture,
+                        dtype=inputs["input_hidden"].dtype,
+                        device="cuda",
+                    )
+                    replay_batch = _make_forward_batch(
+                        replay_case, fixture.runner, max_context_len=2048, device="cuda"
+                    )
+                    _prepare_spec_verify_batch(
+                        replay_case,
+                        replay_batch,
+                        topk=1,
+                        spec_kind="eagle",
+                        device="cuda",
+                    )
+                    full_masks, swa_masks, positions = [], [], []
+                    for prefix in replay_case.prefix_lens:
+                        full = torch.cat(
+                            (torch.ones(draft, prefix, dtype=torch.bool), tree), dim=1
+                        )
+                        swa = full.clone()
+                        key_positions = list(range(prefix)) + [
+                            prefix + d for d in depths
+                        ]
+                        for query, depth in enumerate(depths):
+                            for key, pos in enumerate(key_positions):
+                                if pos < prefix + depth - case.sliding_window_size:
+                                    swa[query, key] = False
+                        full_masks.append(full.cuda())
+                        swa_masks.append(swa.cuda())
+                        positions.extend(prefix + d for d in depths)
+                    # Real verify inputs omit padded requests from the mask and positions.
+                    original_mask = torch.cat(
+                        [m.flatten() for m in full_masks[:real_bs]]
+                    )
+                    replay_batch.spec_info.custom_mask = original_mask
+                    replay_batch.spec_info.swa_custom_mask = torch.cat(
+                        [
+                            m[:, max(0, p - case.sliding_window_size) :].flatten()
+                            for p, m in zip(prefix_lens, swa_masks[:real_bs])
+                        ]
+                    )
+                    replay_batch.spec_info.positions = torch.tensor(
+                        positions[: real_bs * draft], device="cuda"
+                    )
+                    prepare_dense_runner_inputs(
+                        fixture,
+                        replay_case,
+                        replay_batch,
+                        replay_inputs,
+                        max_context_len=2048,
+                    )
+                    expected = [
+                        dense_attention_reference_with_custom_mask(
+                            fixture.reference_module,
+                            replace(replay_case, sliding_window_size=None),
+                            replay_inputs["prefix_hidden"],
+                            replay_inputs["input_hidden"],
+                            masks,
+                        )
+                        for masks in (swa_masks, full_masks)
+                    ]
+                    inputs["input_hidden"].copy_(replay_inputs["input_hidden"])
+                    batch.out_cache_loc.copy_(replay_batch.out_cache_loc)
+                    if real_bs == 1:
+                        replay_batch.seq_lens_cpu = (
+                            None  # Exercise the device-only fallback.
+                        )
+                    backend.init_forward_metadata_out_graph(replay_batch)
+                    graph.replay()
+                    graph.replay()
+                    torch.cuda.synchronize()
+                    for output, reference in zip(actual, expected):
+                        torch.testing.assert_close(
+                            output[: real_bs * draft],
+                            reference[: real_bs * draft],
+                            atol=DENSE_ATOL,
+                            rtol=DENSE_RTOL,
+                        )
+                    torch.testing.assert_close(
+                        original_mask,
+                        torch.cat([m.flatten() for m in full_masks[:real_bs]]),
+                    )
+                    self.assertEqual(
+                        mask_ptrs,
+                        (
+                            backend.cuda_graph_swa_custom_mask.data_ptr(),
+                            backend.cuda_graph_custom_mask.data_ptr(),
+                        ),
+                    )
 
     def test_projected_swa_attention_cases(self):
         for case in self.CASES:

--- a/test/registered/kernel/attention/test_eagle_swa_backends.py
+++ b/test/registered/kernel/attention/test_eagle_swa_backends.py
@@ -1,0 +1,93 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.runtime_context import get_context
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.attention_unittest.attention_methods import (
+    dense_attention as dense,
+)
+from sglang.test.kits.attention_unittest.runner_modes import (
+    speculative_target_verify_runner as verify,
+)
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "GPU required")
+class TestEagleSWABackends(CustomTestCase):
+    def _run_backend(self, backend, *, deterministic=False):
+        original_init = dense.MockModelRunner.__init__
+        original_input = verify._make_spec_verify_input
+
+        def make_input(*args, **kwargs):
+            out = original_input(*args, **kwargs)
+            args[1].spec_algorithm = SpeculativeAlgorithm.EAGLE3
+            return out
+
+        for topk in (1, 2):
+
+            def init(runner, *args, **kwargs):
+                original_init(runner, *args, **kwargs)
+                runner.model_config.dtype = runner.dtype
+                runner.model_config.is_local_attention_model = False
+                fields = dict(runner._server_args_override._fields)
+                fields.update(
+                    page_size=runner.page_size,
+                    speculative_algorithm="EAGLE3",
+                    speculative_eagle_topk=topk,
+                    enable_deterministic_inference=deterministic,
+                )
+                override = get_context().override_server_args(**fields)
+                override.install()
+                self.addCleanup(override.restore)
+                runner.spec_algorithm = SpeculativeAlgorithm.EAGLE3
+
+            for prefixes, window in (
+                ((9, 2), None),
+                ((3, 4, 5), 4),
+                ((9, 2), 4),
+                ((1220, 325), 1023),
+            ):
+                case = dense.DenseAttentionCase(
+                    name=f"{backend}_eagle_k{topk}_w{window}_{prefixes}",
+                    backend=backend,
+                    forward_mode=ForwardMode.TARGET_VERIFY,
+                    num_heads=4,
+                    num_kv_heads=2,
+                    page_size=16,
+                    prefix_lens=prefixes,
+                    extend_lens=(3,) * len(prefixes),
+                    sliding_window_size=window,
+                )
+                for run in (
+                    verify.run_dense_spec_verify_case,
+                    verify.run_dense_spec_verify_cuda_graph_case,
+                ):
+                    with (
+                        self.subTest(case=case.name, run=run.__name__),
+                        patch.object(dense.MockModelRunner, "__init__", init),
+                        patch.object(verify, "_make_spec_verify_input", make_input),
+                    ):
+                        run(
+                            self,
+                            case,
+                            topk=topk,
+                            head_dim=64,
+                            hidden_size=256,
+                            max_context_len=2048,
+                        )
+
+    def test_triton(self):
+        self._run_backend("triton")
+
+    def test_triton_deterministic(self):
+        self._run_backend("triton", deterministic=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

EAGLE verification can produce incorrect outputs with sliding-window attention in FlashInfer and Triton. FlashInfer clips the prefix but gathers from offset zero and retains the full-prefix mask layout. Triton's deterministic path also reads the full mask with a shortened row width, while its normal path applies the window using flattened query indices, which differ from tree depth for sibling nodes.

The DFlash fix in [#27469](https://github.com/sgl-project/sglang/pull/27469) handles the KV start offset for sliding-window verification. EAGLE additionally needs a matching tree mask and window bounds based on each node's position.

Cross-backend validation also found a missing causal mask in TRT-LLM MHA's XQA verification call. This is already addressed by the open PRs [#32269](https://github.com/sgl-project/sglang/pull/32269) and [#36038](https://github.com/sgl-project/sglang/pull/36038), so it is outside the scope of this PR.

AITER may have similar issues, but is outside the scope of this PR.

## Modifications

- Reuse the existing tree builder with retained prefix lengths to produce a compact SWA mask, preserving the original positions and retrieval indices. Apply the logical window bound only at the tree-sized edge of the mask; reuse the original mask when the whole tree fits.
- Pass the retained KV offset and SWA mask through FlashInfer and Triton EAGLE/SWA verification. Keep SWA and full-attention graph buffers separate, and preserve the mask across batch splitting and stream recording.

The tree builder and attention kernel sources are unchanged.

## Accuracy Tests

Evaluated on one RTX PRO 6000 Blackwell 96GB with TP=1, temperature=0, max_new_tokens=8192, concurrency=16 and paged prefill. MT-Bench uses the Qwen3-30B-A3B-Instruct-2507 judge; LiveCodeBench uses the official checker.

| Model | Backend | Task | N | Score | Acc. Length |
| --- | --- | --- | ---: | ---: | ---: |
| Gemma3-27B AWQ (EAGLE3) | FlashInfer | MT-Bench | 80 | 6.1063 → 8.9313 | 1.026 → 1.041 |
| Gemma3-27B AWQ (EAGLE3) | FlashInfer | LiveCodeBench v6 increment | 175 | 21.14% → 25.71% | 1.194 → 1.369 |

This PR also addresses the verification issue behind the degradation reported in [#39286](https://github.com/sgl-project/sglang/pull/39286). Results with both fixes applied:

| Model | Backend | Task | N | Score | Acc. Length |
| --- | --- | --- | ---: | ---: | ---: |
| Gemma3-27B AWQ (EAGLE3) | FlashInfer | MT-Bench | 80 | 8.8000 | 1.563 |
| Gemma3-27B AWQ (EAGLE3) | FlashInfer | LiveCodeBench v6 increment | 175 | 25.71% | 1.840 |

## Speed Tests and Profiling

Same model and GPU. End-to-end throughput using `sglang.benchmark.offline_throughput`, 2048 input tokens and 256 output tokens (`ignore_eos=True`), with the default warmup. Median of two runs per variant in Before/After/After/Before order, comparing upstream `e91c9480` with the patched checkout. Timing includes mask construction and first-use SWA compilation.

```bash
C=16
N=16  # For concurrency 1, use C=1 and N=4.
SGLANG_FLASHINFER_USE_PAGED=1 SGLANG_SWA_EVICTION_INTERVAL=1 \
python -m sglang.benchmark.offline_throughput \
  --model-path gaunernst/gemma-3-27b-it-int4-awq \
  --revision 7cf8bdc81343c635390dd1e1bf590ab22dd6f366 \
  --speculative-draft-model-path witcheer/gemma-3-27b-eagle3-drafter \
  --speculative-draft-model-revision 66d6a10655c1729fe26df5cd15545f02041a0161 \
  --speculative-algorithm EAGLE3 --speculative-num-steps 3 \
  --speculative-eagle-topk 4 --speculative-num-draft-tokens 8 \
  --attention-backend flashinfer --speculative-draft-attention-backend flashinfer \
  --dtype bfloat16 --tp-size 1 --trust-remote-code \
  --context-length 32768 --max-total-tokens 65536 \
  --chunked-prefill-size 2048 --mem-fraction-static 0.9 --disable-radix-cache \
  --cuda-graph-backend-prefill disabled --cuda-graph-max-bs-decode "$C" \
  --max-running-requests "$C" --random-seed 0 \
  --dataset-name random --random-input-len 2048 --random-output-len 256 \
  --random-range-ratio 1 --num-prompts "$N" --seed 42 \
  --result-filename result.jsonl
```

| Concurrent requests | Before tok/s | After tok/s | Change |
| ---: | ---: | ---: | ---: |
| 1 | 44.2 | 43.0 | -2.9% |
| 16 | 241.1 | 241.1 | <0.1% |

## Checklist

- [x] Code formatted.
- [x] Unit tests added.
- [x] No documentation update is needed.
- [x] Accuracy and speed benchmark results provided.
- [x] Follow the SGLang code style.

Assisted-by: OpenAI Codex

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34747886719](https://github.com/sgl-project/sglang/actions/runs/34747886719)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34747886591](https://github.com/sgl-project/sglang/actions/runs/34747886591)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34747886684](https://github.com/sgl-project/sglang/actions/runs/34747886684)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->