### PR TITLE
[Fix] SM120 sparse MLA: zero-initialise the 64-token page-split scratch so masked candidates never gather NaN from slot 0

### DIFF
--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -485,8 +485,11 @@ def _split_kv_pages_to_64(
     SWA pool, -1 = invalid) is provided, only the source pages that actually
     contain a referenced token are copied. This avoids rewriting the entire KV
     pool on every decode step (only ~2*batch pages are touched vs the full
-    pool). The output buffer is persistent and reused across steps; untouched
-    dst pages simply retain their (unreferenced) stale data.
+    pool). The output buffer is persistent and reused across steps. Untouched
+    dst pages are never addressed by a valid index, but FlashInfer <= 0.6.18
+    clamps every masked (-1) candidate to slot 0 and gathers that slot's bytes,
+    so the buffer is zero-initialized instead of left as allocator garbage (see
+    the allocation below).
     """
     assert src_pbs % _PBS_DST == 0 and src_pbs >= _PBS_DST
     if src_pbs == _PBS_DST:
@@ -507,8 +510,23 @@ def _split_kv_pages_to_64(
         # The first allocation can happen under inference mode (autotune), but
         # the buffer is written again during CUDA graph capture outside
         # inference mode, where an inference tensor cannot be mutated.
+        #
+        # torch.zeros, not torch.empty: only the source pages a step references
+        # are copied into this grow-only scratch, so dst page 0 (slot 0) is
+        # written only when source page 0 is referenced. The FlashInfer SM120
+        # sparse-MLA prefill and decode kernels (<= 0.6.18: kv_cache_io.cuh
+        # io_bulk_gather_tile / io_gather_scales, prefill_kernel.cuh
+        # prefill_kv_entry_base, `idx = (idx >= 0) ? idx : 0`) clamp every
+        # masked (-1) candidate index to slot 0 and gather that slot's bytes
+        # with only the score masked, so NaN-encoded fp8 bytes recycled into
+        # page 0 by the caching allocator turn into P(0) * V(NaN) = NaN for
+        # every query row with -1 padding (DeepSeek-V4 on RTX PRO 6000: cold
+        # prompts of 65+ tokens returned garbage, 64 were correct). One memset
+        # per (re)allocation, no per-step cost. The kernel-side fix is
+        # flashinfer-ai/flashinfer#5075 (masked candidates gather a shared
+        # zero row), which is not in 0.6.18.
         with torch.inference_mode(False):
-            buf = torch.empty(
+            buf = torch.zeros(
                 num_dst_pages,
                 _BYTES_PER_DST_PAGE_PADDED,
                 dtype=torch.uint8,
@@ -613,8 +631,10 @@ def _flash_mla_flashinfer(
     idx = indices.squeeze(1) if indices.dim() == 3 else indices
 
     # --- Page-split: convert pbs=N kv_cache to pbs=64 view ---
-    # Only the SWA pages actually referenced by `idx` are copied (the rest of
-    # the persistent dst buffer is left untouched and never read).
+    # Only the SWA pages actually referenced by `idx` are copied; the rest of
+    # the persistent dst buffer is left untouched. It is zero-initialized
+    # because FlashInfer <= 0.6.18 gathers slot 0 for every masked (-1)
+    # candidate (see _split_kv_pages_to_64).
     kv_u8 = k_cache.view(torch.uint8) if k_cache.dtype != torch.uint8 else k_cache
     src_pbs = k_cache.shape[1] if k_cache.ndim >= 3 else _PBS_SRC
     kv_64 = (

--- a/test/registered/unit/kernels/ops/attention/test_sm120_split_scratch.py
+++ b/test/registered/unit/kernels/ops/attention/test_sm120_split_scratch.py
@@ -1,0 +1,424 @@
+"""The SM120 sparse-MLA page-split scratch is zero-initialized.
+
+``_split_kv_pages_to_64`` in ``sglang/kernels/ops/attention/flash_mla_sm120.py``
+re-pages the 256-token SWA pool into a persistent, grow-only 64-token scratch
+and copies only the source pages a step references. FlashInfer <= 0.6.18's
+SM120 sparse-MLA prefill and decode kernels clamp every masked (-1) candidate
+index to slot 0 and gather that slot's bytes with only the score masked, so a
+``torch.empty`` scratch whose page 0 is never written hands the kernel whatever
+the caching allocator recycled there: NaN-encoded fp8 bytes turn into
+``P(0) * V(NaN) = NaN`` for every query row with -1 padding (DeepSeek-V4 on
+RTX PRO 6000: cold prompts of 65+ tokens returned garbage, 64 were correct).
+
+These tests pin the ``torch.zeros`` allocation without a GPU, torch or triton:
+the module is loaded by file path with a recording ``torch`` stub and
+passthrough ``triton`` / ``sglang.srt`` stubs (the way ``unit/tools/`` loads
+``ci_register``), and ``_split_kv_pages_to_64`` is driven directly with its two
+Triton kernels replaced by launch recorders.
+
+    python test/registered/unit/kernels/ops/attention/test_sm120_split_scratch.py
+"""
+
+import ast
+import contextlib
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[6]
+CI_REGISTER_PATH = REPO_ROOT / "python" / "sglang" / "test" / "ci" / "ci_register.py"
+MODULE_PATH = (
+    REPO_ROOT
+    / "python"
+    / "sglang"
+    / "kernels"
+    / "ops"
+    / "attention"
+    / "flash_mla_sm120.py"
+)
+MODULE_NAME = "flash_mla_sm120_under_test"
+
+# The DSv4 row and the 64-token split page the module hard-codes.
+BYTES_PER_TOKEN = 584
+SPLIT_PAGE_BYTES = 37440
+SRC_PBS = 256
+DST_PBS = 64
+RATIO = SRC_PBS // DST_PBS
+
+
+def _load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+register_cpu_ci = _load_module("ci_register", CI_REGISTER_PATH).register_cpu_ci
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _StubModule(ModuleType):
+    """A module whose every attribute is a permissive callable.
+
+    Covers ``@triton.jit`` (returns the decorated function), ``tl.constexpr``
+    in kernel annotations, ``triton.cdiv`` and ``torch.*`` names in type
+    annotations.
+    """
+
+    def __getattr__(self, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+
+        def _passthrough(*args, **kwargs):
+            return args[0] if args else _passthrough
+
+        return _passthrough
+
+
+class _FakeTensor:
+    """The slice of tensor surface ``_split_kv_pages_to_64`` touches."""
+
+    def __init__(
+        self,
+        shape,
+        dtype="uint8",
+        device="cuda:0",
+        strides=None,
+        fill=None,
+        origin=None,
+    ):
+        self.shape = tuple(shape)
+        self.dtype = dtype
+        self.device = device
+        self._strides = strides
+        self.fill = fill  # 0 for torch.zeros, None for torch.empty
+        self.origin = origin  # the tensor this one is a view of
+        self.zeroed = 0
+
+    @property
+    def ndim(self):
+        return len(self.shape)
+
+    def numel(self):
+        n = 1
+        for d in self.shape:
+            n *= d
+        return n
+
+    def stride(self, dim):
+        if self._strides is not None:
+            return self._strides[dim]
+        strides, acc = [], 1
+        for d in reversed(self.shape):
+            strides.append(acc)
+            acc *= d
+        return list(reversed(strides))[dim]
+
+    def __getitem__(self, item):
+        assert isinstance(item, slice) and item.start is None and item.step is None
+        n = self.shape[0] if item.stop is None else item.stop
+        return _FakeTensor(
+            (n,) + self.shape[1:], self.dtype, self.device, fill=self.fill, origin=self
+        )
+
+    def as_strided(self, size, stride):
+        return _FakeTensor(
+            size, self.dtype, self.device, strides=stride, fill=self.fill, origin=self
+        )
+
+    def reshape(self, *shape):
+        return self
+
+    def contiguous(self):
+        return self
+
+    def to(self, dtype):
+        return _FakeTensor(self.shape, dtype, self.device, fill=self.fill, origin=self)
+
+    def zero_(self):
+        self.zeroed += 1
+        self.fill = 0
+        return self
+
+
+class _FakeTorch(_StubModule):
+    """Permissive torch stub that records ``zeros`` / ``empty`` allocations."""
+
+    uint8 = "uint8"
+    int8 = "int8"
+    int32 = "int32"
+    float32 = "float32"
+    bfloat16 = "bfloat16"
+
+    def __init__(self):
+        super().__init__("torch")
+        self.zeros_calls = []
+        self.empty_calls = []
+
+    def zeros(self, *shape, dtype=None, device=None):
+        self.zeros_calls.append((shape, {"dtype": dtype, "device": device}))
+        return _FakeTensor(shape, dtype, device, fill=0)
+
+    def empty(self, *shape, dtype=None, device=None):
+        self.empty_calls.append((shape, {"dtype": dtype, "device": device}))
+        return _FakeTensor(shape, dtype, device, fill=None)
+
+    def inference_mode(self, enabled=True):
+        return contextlib.nullcontext()
+
+    def as_strided(self, tensor, size, stride):
+        return tensor.as_strided(size, stride)
+
+
+class _Launchable:
+    """Stands in for a ``@triton.jit`` kernel: ``kernel[grid](*args)``."""
+
+    def __init__(self):
+        self.launches = []
+
+    def __getitem__(self, grid):
+        def _launch(*args):
+            self.launches.append((grid, args))
+
+        return _launch
+
+
+class _Knob:
+    def __init__(self, value):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+
+def _package(name):
+    module = ModuleType(name)
+    module.__path__ = []
+    return module
+
+
+@contextlib.contextmanager
+def _loaded():
+    """Load flash_mla_sm120.py against stubs; yield (module, torch_stub, buffers).
+
+    ``buffers`` is the process buffer registry (``get_resources().buffers``)
+    the split scratch is stored in. The two Triton kernels are replaced by
+    launch recorders so the function can run without a GPU.
+    """
+    environ = ModuleType("sglang.srt.environ")
+    environ.envs = SimpleNamespace(SGLANG_SM120_FLASHMLA_BACKEND=_Knob("flashinfer"))
+    utils = ModuleType("sglang.srt.utils")
+    utils.is_hip = lambda: False
+    buffers = {}
+    runtime_context = ModuleType("sglang.srt.runtime_context")
+    runtime_context.get_resources = lambda: SimpleNamespace(buffers=buffers)
+
+    torch_stub = _FakeTorch()
+    triton_stub = _StubModule("triton")
+    triton_language = _StubModule("triton.language")
+    # ``import triton.language as tl`` binds ``tl`` via getattr on the parent.
+    triton_stub.language = triton_language
+
+    stubs = {
+        "torch": torch_stub,
+        "triton": triton_stub,
+        "triton.language": triton_language,
+        "sglang": _package("sglang"),
+        "sglang.srt": _package("sglang.srt"),
+        "sglang.srt.environ": environ,
+        "sglang.srt.utils": utils,
+        "sglang.srt.runtime_context": runtime_context,
+    }
+    with patch.dict(sys.modules, stubs):
+        module = _load_module(MODULE_NAME, MODULE_PATH)
+        module._page_split_kernel = _Launchable()
+        module._page_mark_kernel = _Launchable()
+        yield module, torch_stub, buffers
+
+
+def _split(module, num_src_pages, num_rows=65, device="cuda:0"):
+    # A pbs=256 SWA pool view (N, 256, 1, 584) and the (rows, topk) int32
+    # index tensor the backend passes, -1 padded (values are not read here).
+    kv_u8 = _FakeTensor((num_src_pages, SRC_PBS, 1, BYTES_PER_TOKEN), device=device)
+    idx = _FakeTensor((num_rows, 2048), dtype="int32", device=device)
+    return module._split_kv_pages_to_64(kv_u8, SRC_PBS, touched_indices=idx)
+
+
+def _uint8_empty_calls(torch_stub):
+    return [c for c in torch_stub.empty_calls if c[1]["dtype"] == "uint8"]
+
+
+def _split_key(device="cuda:0"):
+    return f"flash_mla_sm120_split:{device}"
+
+
+class TestSplitScratchIsZeroInitialized(unittest.TestCase):
+    def test_first_allocation_is_torch_zeros_and_is_registered(self):
+        with _loaded() as (module, torch_stub, buffers):
+            out = _split(module, num_src_pages=3)
+            num_dst_pages = 3 * RATIO
+            self.assertEqual(
+                torch_stub.zeros_calls,
+                [
+                    (
+                        (num_dst_pages, SPLIT_PAGE_BYTES),
+                        {"dtype": "uint8", "device": "cuda:0"},
+                    )
+                ],
+            )
+            # The only torch.empty is the int8 page mask, which is zeroed per call.
+            self.assertEqual(_uint8_empty_calls(torch_stub), [])
+            self.assertEqual([c[1]["dtype"] for c in torch_stub.empty_calls], ["int8"])
+            buf = buffers[_split_key()]
+            self.assertEqual(buf.fill, 0)
+            self.assertEqual(buf.shape, (num_dst_pages, SPLIT_PAGE_BYTES))
+            # The split kernel writes into a slice of that zeroed buffer, masked
+            # to the touched pages only (which is why page 0 needs the zeros).
+            ((grid, args),) = module._page_split_kernel.launches
+            self.assertEqual(grid, (num_dst_pages,))
+            dst = args[1]
+            self.assertIs(dst.origin, buf)
+            self.assertEqual(dst.shape, (num_dst_pages, SPLIT_PAGE_BYTES))
+            self.assertIs(args[-1], True)  # HAS_MASK
+            # The returned view addresses the same zeroed buffer as 64-token pages.
+            self.assertIs(out.origin.origin, buf)
+            self.assertEqual(out.shape, (num_dst_pages, DST_PBS, 1, BYTES_PER_TOKEN))
+            self.assertEqual(
+                out._strides, (SPLIT_PAGE_BYTES, BYTES_PER_TOKEN, BYTES_PER_TOKEN, 1)
+            )
+
+    def test_same_or_smaller_pool_reuses_the_buffer(self):
+        with _loaded() as (module, torch_stub, buffers):
+            _split(module, num_src_pages=3)
+            first = buffers[_split_key()]
+            _split(module, num_src_pages=3)
+            out_small = _split(module, num_src_pages=2)
+            self.assertEqual(len(torch_stub.zeros_calls), 1)
+            self.assertEqual(_uint8_empty_calls(torch_stub), [])
+            self.assertIs(buffers[_split_key()], first)
+            # The smaller call is served from a prefix slice of the same buffer.
+            self.assertIs(out_small.origin.origin, first)
+            self.assertEqual(out_small.shape[0], 2 * RATIO)
+
+    def test_grow_reallocates_with_torch_zeros(self):
+        with _loaded() as (module, torch_stub, buffers):
+            _split(module, num_src_pages=3)
+            first = buffers[_split_key()]
+            _split(module, num_src_pages=5)
+            grown = buffers[_split_key()]
+            self.assertIsNot(grown, first)
+            self.assertEqual(grown.fill, 0)
+            self.assertEqual(
+                torch_stub.zeros_calls[1],
+                ((5 * RATIO, SPLIT_PAGE_BYTES), {"dtype": "uint8", "device": "cuda:0"}),
+            )
+            self.assertEqual(len(torch_stub.zeros_calls), 2)
+            self.assertEqual(_uint8_empty_calls(torch_stub), [])
+            # The launch after the grow writes into the new zeroed buffer.
+            self.assertIs(module._page_split_kernel.launches[-1][1][1].origin, grown)
+
+    def test_one_scratch_per_device(self):
+        with _loaded() as (module, torch_stub, buffers):
+            _split(module, num_src_pages=3, device="cuda:0")
+            _split(module, num_src_pages=3, device="cuda:1")
+            devices = [c[1]["device"] for c in torch_stub.zeros_calls]
+            self.assertEqual(devices, ["cuda:0", "cuda:1"])
+            self.assertEqual(
+                sorted(k for k in buffers if k.startswith("flash_mla_sm120_split:")),
+                [_split_key("cuda:0"), _split_key("cuda:1")],
+            )
+
+    def test_page_mask_is_zeroed_on_every_call(self):
+        with _loaded() as (module, _, buffers):
+            _split(module, num_src_pages=3)
+            _split(module, num_src_pages=3)
+            mbuf = buffers["flash_mla_sm120_mask:cuda:0"]
+            self.assertEqual(mbuf.dtype, "int8")
+            self.assertEqual(len(module._page_mark_kernel.launches), 2)
+            for _, args in module._page_mark_kernel.launches:
+                mask = args[1]
+                self.assertIs(mask.origin, mbuf)
+                self.assertEqual(mask.zeroed, 1)
+                self.assertEqual(args[3], SRC_PBS)  # SRC_PBS constexpr
+
+    def test_64_token_pool_needs_no_scratch(self):
+        with _loaded() as (module, torch_stub, buffers):
+            kv_u8 = _FakeTensor((3, DST_PBS, 1, BYTES_PER_TOKEN))
+            idx = _FakeTensor((65, 2048), dtype="int32")
+            self.assertIs(module._split_kv_pages_to_64(kv_u8, DST_PBS, idx), kv_u8)
+            self.assertEqual(torch_stub.zeros_calls, [])
+            self.assertEqual(torch_stub.empty_calls, [])
+            self.assertEqual(buffers, {})
+
+
+def _calls_named(tree, dotted):
+    """All ``ast.Call`` nodes whose callee unparses to ``dotted``."""
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and ast.unparse(node.func) == dotted
+    ]
+
+
+def _kwarg(call, name):
+    for kw in call.keywords:
+        if kw.arg == name:
+            return ast.unparse(kw.value)
+    return None
+
+
+class TestSplitScratchSourcePins(unittest.TestCase):
+    """AST pins so the fix survives a stub-independent read of the module."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.source = MODULE_PATH.read_text(encoding="utf-8")
+        cls.tree = ast.parse(cls.source)
+        (cls.split_fn,) = [
+            node
+            for node in cls.tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "_split_kv_pages_to_64"
+        ]
+
+    def test_split_scratch_is_the_only_uint8_allocation_and_uses_zeros(self):
+        zeros_u8 = [
+            c
+            for c in _calls_named(self.tree, "torch.zeros")
+            if _kwarg(c, "dtype") == "torch.uint8"
+        ]
+        empty_u8 = [
+            c
+            for c in _calls_named(self.tree, "torch.empty")
+            if _kwarg(c, "dtype") == "torch.uint8"
+        ]
+        self.assertEqual(len(zeros_u8), 1)
+        self.assertEqual(
+            empty_u8, [], "a torch.empty uint8 buffer would re-expose slot 0"
+        )
+        # ... and that one allocation is the split scratch inside
+        # _split_kv_pages_to_64, sized (num_dst_pages, _BYTES_PER_DST_PAGE_PADDED)
+        # on the split's device.
+        (call,) = zeros_u8
+        self.assertEqual(_calls_named(self.split_fn, "torch.zeros"), [call])
+        self.assertEqual(
+            [ast.unparse(a) for a in call.args],
+            ["num_dst_pages", "_BYTES_PER_DST_PAGE_PADDED"],
+        )
+        self.assertEqual(_kwarg(call, "device"), "dev")
+        # No torch.empty inside the split function except the int8 page mask.
+        empties = _calls_named(self.split_fn, "torch.empty")
+        self.assertEqual([_kwarg(c, "dtype") for c in empties], ["torch.int8"])
+
+    def test_allocation_comment_documents_the_slot_0_gather(self):
+        segment = ast.get_source_segment(self.source, self.split_fn)
+        for needle in ("torch.zeros(", "slot 0", "masked", "FlashInfer"):
+            self.assertIn(needle, segment)
+        self.assertNotIn("stale data", segment)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

On SM120 (RTX PRO 6000 Blackwell) with the FlashInfer sparse-MLA backend (`SGLANG_SM120_FLASHMLA_BACKEND=flashinfer`, the default) and the pinned FlashInfer 0.6.18, DeepSeek-V4 family models return wrong attention for prefill calls with more than 64 query rows. Observed on DeepSeek-V4.1-Flash, TP4, 4x RTX PRO 6000:

- exact-fit oracle over 20 cold prompts: 60 and 64 prompt tokens -> 8/8 correct; 65 / 66 / 80 tokens -> 0/12 (garbage; `prompt_tokens` confirmed via `/tokenize` and `usage`);
- planted-code recall sweep over 23 cold prompts of 36..32k tokens: the code is retrieved 4/23 on one box and 5/23 on an independent one, only for the prompts of 64 tokens or fewer; tool-call arguments come back as `{}`, vision descriptions are garbage;
- the same sweep is 23/23 with the Triton implementation (`SGLANG_SM120_FLASHMLA_BACKEND=triton`), which is how the defect was first contained.

The boundary is `SM120_DECODE_MAX_TOKENS = 64` in `python/sglang/kernels/ops/attention/flash_mla_sm120.py`: at most 64 rows go to the FlashInfer decode (split-K) kernel, more rows go to the FlashInfer prefill kernel via `_flash_mla_sm120_prefill`.

### Root cause

An interaction between the FlashInfer kernels and the way sglang feeds them the KV pages:

1. **FlashInfer <= 0.6.18 gathers slot 0 for masked candidates.** The SM120 sparse-MLA prefill and decode kernels clamp every padding index (`-1`) to slot 0 and gather that slot's bytes, masking only the score: `include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh` (`io_bulk_gather_tile`, `io_gather_scales`) and `.../prefill_kernel.cuh` (`prefill_kv_entry_base`, `idx = (idx >= 0) ? idx : 0`). With the score masked to `-1e30` the probability is 0, but `0 * NaN = NaN` in the value MMA, so whenever slot 0 of the cache the kernel is handed holds NaN-encoded fp8 / ue8m0 bytes (`0x7F`, `0xFF`), every query row that carries a `-1` in its indices comes out NaN. (The scalar RoPE-V path in `xv_rope_mma` already returned 0 for `idx < 0` with a comment describing exactly this hazard; the bulk NOPE-V gather did not.)
2. **sglang hands the kernel a scratch whose slot 0 is uninitialized.** The SWA pool uses 256-token pages; the FlashInfer fast path wants 64-token pages, so `_split_kv_pages_to_64` re-pages the pool into a persistent, grow-only scratch registered in `get_resources().buffers`. That buffer is allocated with `torch.empty`, and since the touched-page optimization only copies the source pages a step references, dst page 0 (slot 0) keeps whatever the caching allocator recycled into it unless source page 0 happens to be referenced. Every cold prompt has `-1` padding in its top-k indices until the context exceeds the top-k width, so the NaN reaches every row of the prompt.

On upstream `main` the exposure is on the SWA split and depends on what the allocator recycled into the scratch and on whether the step references source page 0. A downstream variant of this module that also re-pages the ratio-1/2 extra cache through the same splitter hit it deterministically (sglang reserves full-pool page 0, so that scratch's page 0 was never written), which is how the 64/65 boundary was isolated; the fix is the same.

Kernel harness confirmation (direct `_sparse_mla_sm120_paged_attention` calls, single 64-page cache, H=16, indices with `-1` padding):

| kernel | T | slot 0 bytes | result | rows with a -1 | NaN rows |
|---|---|---|---|---|---|
| FI prefill | 65 | `0xFF` | 308,224 non-finite elements | 43 | 43 |
| FI prefill | 65 | random | 4,128 non-finite | 43 | 43 |
| FI prefill | 65 | zeros | ok, max row rel err 0.034 | 43 | 0 |
| FI decode | 64 | `0xFF` | non-finite | 42 | 42 |
| FI decode | 64 | zeros | ok, 0.056 | 42 | 0 |
| Triton / torch ref | 65 | `0xFF` | ok, 0.007 / 0.001 | 43 | 0 |

The NaN rows are exactly the rows containing a `-1`. Every sglang stage of `_flash_mla_sm120_prefill` is byte-exact in isolation (256->64 split, index identity, gather + dequant through the 64-view, wrapper == direct call), and the kernels are numerically fine for every shape tested (T=8..1024 incl. 64/65/66, H=8..64, topk 128..2048, 1..6000 pages, causal / mixed lengths) once slot 0 is finite.

Realistic allocator recycling (a freed `0xFF`-filled block is recycled by the caching allocator into the split scratch, then a production-shaped cold prompt runs):

| T | path | `torch.empty` (current) | `torch.zeros` (this PR) |
|---|---|---|---|
| 64 | decode | ok 0.065 | ok 0.065 |
| 65 | prefill | 65/65 rows NaN | ok 0.033, 0 NaN |
| 128 | prefill | 127/128 rows NaN | ok 0.033, 0 NaN |

The kernel-level reproduction script (poisons slot 0 of a small paged cache and calls the FlashInfer kernel directly) is available on request.

## Modifications

One line in `_split_kv_pages_to_64` (`python/sglang/kernels/ops/attention/flash_mla_sm120.py`): allocate the persistent split scratch with `torch.zeros` instead of `torch.empty`, so slot 0 is finite from the first use and stays so (it is only ever overwritten with real page-0 data). The buffer is grow-only, so the re-allocation path goes through the same line. The docstring and the decode-path comment that said untouched pages are "never read" are corrected: they are never addressed by a valid index, but slot 0 is gathered for every masked candidate by FlashInfer <= 0.6.18.

```diff
-            buf = torch.empty(
+            buf = torch.zeros(
                 num_dst_pages,
                 _BYTES_PER_DST_PAGE_PADDED,
                 dtype=torch.uint8,
                 device=dev,
             )
```

New test `test/registered/unit/kernels/ops/attention/test_sm120_split_scratch.py` (`base-a-test-cpu`, no GPU / torch / triton needed: the module is loaded by file path with a recording `torch` stub, the way `unit/tools/` loads `ci_register`, and `_split_kv_pages_to_64` is driven directly with its two Triton kernels replaced by launch recorders). It pins:

- the first allocation is `torch.zeros((num_dst_pages, 37440), dtype=uint8, device)` registered under `flash_mla_sm120_split:<device>`; the split kernel writes into a slice of that buffer with `HAS_MASK=True`; the returned view addresses it as 64-token pages;
- a same-size or smaller call reuses the buffer; a grow re-allocates with `torch.zeros` again; one scratch per device;
- the int8 page mask is `zero_()`ed on every call; a 64-token pool needs no scratch;
- AST: the only uint8 allocation in the module is that `torch.zeros` inside `_split_kv_pages_to_64`, no `torch.empty` uint8 buffer anywhere, and the allocation comment documents the slot-0 gather.

8 tests; 6 of them fail on the `torch.empty` variant (negative control run locally), all pass with the fix.

### Relation to other changes

- **flashinfer-ai/flashinfer#5075** (`zero_row.cuh`: masked candidates gather a shared zero row via `mask_idx_past_len`; merged 2026-09-11) fixes the kernel side. It is not in 0.6.18 (`python/pyproject.toml` pins `flashinfer_python[cu13]==0.6.18`) nor in any FlashInfer tag as of today (v0.6.18.post1 and the v0.7.0rc1 tag predate it). Either fix alone suffices; this PR makes sglang correct on the pinned FlashInfer and stays harmless once the pin moves past #5075 (the scratch can then be left zeroed or dropped with the splitter).
- **#38969** ("fall back to Triton per call when FlashInfer lacks the prefill shape") is orthogonal: it adds `_flashinfer_covers()` envelope routing and leaves the `torch.empty` allocation in place, so covered shapes would still hand FlashInfer a poisoned slot 0.
- **#29927** (SM120 paged-MQA indexer + page split) introduced the scratch; **#35116** wrapped the same allocation in `inference_mode(False)` for CUDA-graph capture; **#36655** (exact query-head widths for decode) and **#39235** (SM120 decode q pad) touch the same dispatch and are unaffected. **#34027** / **#35833** (int32 offset overflow in `_page_split_kernel`) are about kernel indexing, not initialization.

## Accuracy Tests

End to end (4x RTX PRO 6000, DeepSeek-V4.1-Flash, TP4, FlashInfer 0.6.18, FlashInfer >64-row path, no Triton fallback), same box patched vs unpatched:

| | unpatched (`torch.empty`) | this PR (`torch.zeros`) |
|---|---|---|
| boot smoke: basic / structured / tools / vision | tools and vision FAIL 5x each | all pass |
| planted-code recall sweep, 23 cold prompts 36..32k tokens | 5/23 (only prompts <= 64 tokens) | 23/23, twice |
| 262k-token cold prefill | wrong | correct |
| exact-fit oracle, 64 / 65 prompt tokens | 4/4 correct / 0/4 | correct / correct |

With the fix the FlashInfer prefill path sits at ~3% max row relative error (BF16 P x V) against an fp32 reference, Triton at <1%; both far from garbage.

`python test/registered/unit/kernels/ops/attention/test_sm120_split_scratch.py` passes on CPU (8 tests).

## Speed Tests and Profiling

No per-step cost: one memset per (re)allocation of the grow-only scratch (1.14 GiB at 2,097,152 SWA tokens in 256-token pages), i.e. once at the first split and once per grow. The per-step touched-page copy is unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (ruff format, ruff check F401/F821/UP037, isort, codespell run locally on the two files)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (none: no user-facing knob)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34747908972](https://github.com/sgl-project/sglang/actions/runs/34747908972)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34747908830](https://github.com/sgl-project/sglang/actions/runs/34747908830)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34747909096](https://github.com/sgl-project/sglang/actions/runs/34747909096)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->