### PR TITLE
Fix power-of-two activation scales for DSV4 fp8_einsum

### DIFF
--- a/python/sglang/kernels/jit/csrc/gemm/per_token_group_quant.cuh
+++ b/python/sglang/kernels/jit/csrc/gemm/per_token_group_quant.cuh
@@ -216,6 +216,7 @@ template <
     typename QuantType_,
     uint32_t kGroupSize_,
     bool kUe8m0_,
+    bool kPackedScale_,
     bool kRowMajor_,
     bool kAligned_,
     bool kFuseSiluAndMul_>
@@ -224,7 +225,9 @@ struct QuantTrait {
   using InputType = InputType_;
   using QuantType = QuantType_;
   static constexpr uint32_t kGroupSize = kGroupSize_;
+  // Numeric rounding and storage are independent: FP32 can store power-of-two scales.
   static constexpr bool kUe8m0 = kUe8m0_;
+  static constexpr bool kPackedScale = kPackedScale_;
   static constexpr bool kRowMajor = kRowMajor_;
   static constexpr bool kAligned = kAligned_;
   static constexpr bool kFuseSiluAndMul = kFuseSiluAndMul_;
@@ -236,6 +239,7 @@ struct QuantTrait {
   static_assert(16 <= kGroupSize && kGroupSize <= 256, "supported group sizes are 16..256");
   static_assert(kGroupSize % kVecSize == 0 && 1 <= kNumLanes && kNumLanes <= device::kWarpThreads);
   static_assert(!kUe8m0 || std::is_same_v<QuantType, fp8_e4m3_t>, "ue8m0 scales imply fp8 output");
+  static_assert(!kPackedScale || kUe8m0, "packed scales require power-of-two values");
 
   SGL_DEVICE static void
   run(const QuantKernelParams& params,
@@ -298,8 +302,8 @@ struct QuantTrait {
     const float raw_scale = amax * kMaxValueInv;  // the dequant scale the GEMM consumes
 
     out_vec_t out;
-    detail::scale_t<kUe8m0> scale_inv;
-    if constexpr (kUe8m0) {
+    detail::scale_t<kPackedScale> scale_inv;
+    if constexpr (kPackedScale) {
       // ue8m0 scale: pow-2 quant multiplier is exact in float16/bfloat16 type
       static_assert(std::is_same_v<Q, fp8_e4m3_t>, "ue8m0 scales imply fp8 quantization");
       const auto exp = cast_to_ue8m0(raw_scale);
@@ -317,9 +321,17 @@ struct QuantTrait {
         out[i] = static_cast<Q2>(__hmin2(__hmul2(in[i], scale2), max_clip2));
       }
     } else {
-      // fp32 scale: multiply in fp32 (hmul2 brings too much precision loss)
+      // FP32 storage is independent of scale rounding. Multiply in FP32:
+      // the reciprocal of a small power-of-two scale can overflow fp16.
       scale_inv = raw_scale;
-      const float quant_scale = kMaxValue / amax;
+      float quant_scale;
+      if constexpr (kUe8m0) {
+        const auto exp = cast_to_ue8m0(raw_scale);
+        scale_inv = __uint_as_float(static_cast<uint32_t>(exp) << 23);
+        quant_scale = inv_scale_ue8m0(exp);
+      } else {
+        quant_scale = kMaxValue / amax;
+      }
       const float2 quant_scale2 = {quant_scale, quant_scale};
 #pragma unroll
       for (uint32_t i = 0; i < kVecSize / 2; ++i) {
@@ -328,7 +340,7 @@ struct QuantTrait {
     }
 
     out.store(params.output.get<Q>(expert_idx, token_idx) + group_offset, lane_id);
-    params.scale.store<kUe8m0, kRowMajor, kAligned>(expert_idx, token_idx, group_idx, scale_inv);
+    params.scale.store<kPackedScale, kRowMajor, kAligned>(expert_idx, token_idx, group_idx, scale_inv);
   }
 
   SGL_DEVICE static void run_fp32(
@@ -369,12 +381,16 @@ struct QuantTrait {
     const float raw_scale = amax * kMaxValueInv;
 
     out_vec_t out;
-    detail::scale_t<kUe8m0> scale_inv;
+    detail::scale_t<kPackedScale> scale_inv;
     float quant_scale;
     if constexpr (kUe8m0) {
       static_assert(std::is_same_v<Q, fp8_e4m3_t>, "ue8m0 scales imply fp8 quantization");
       const auto exp = cast_to_ue8m0(raw_scale);
-      scale_inv = static_cast<uint8_t>(exp);
+      if constexpr (kPackedScale) {
+        scale_inv = static_cast<uint8_t>(exp);
+      } else {
+        scale_inv = __uint_as_float(static_cast<uint32_t>(exp) << 23);
+      }
       quant_scale = inv_scale_ue8m0(exp);
     } else {
       scale_inv = raw_scale;
@@ -387,7 +403,7 @@ struct QuantTrait {
     }
 
     out.store(params.output.get<Q>(expert_idx, token_idx) + group_offset, lane_id);
-    params.scale.store<kUe8m0, kRowMajor, kAligned>(expert_idx, token_idx, group_idx, scale_inv);
+    params.scale.store<kPackedScale, kRowMajor, kAligned>(expert_idx, token_idx, group_idx, scale_inv);
   }
 };
 
@@ -467,7 +483,7 @@ QuantHostContext<Trait> build_quant_context( //
   using namespace host;
   using T = typename Trait::InputType;
   using Q = typename Trait::QuantType;
-  using S = std::conditional_t<Trait::kUe8m0, int32_t, float>;
+  using S = std::conditional_t<Trait::kPackedScale, int32_t, float>;
   constexpr int64_t kSiluFactor = Trait::kFuseSiluAndMul ? 2 : 1;
 
   auto device = SymbolicDevice{};
@@ -505,12 +521,12 @@ QuantHostContext<Trait> build_quant_context( //
   const uint32_t num_scale_groups = G.unwrap();
   CHECK_HOST(hidden_size % Trait::kGroupSize == 0);
   CHECK_HOST(input.size(-1) == hidden_size * kSiluFactor);
-  CHECK_HOST(num_scale_groups == (Trait::kUe8m0 ? div_ceil(num_groups, 4) : num_groups));
+  CHECK_HOST(num_scale_groups == (Trait::kPackedScale ? div_ceil(num_groups, 4) : num_groups));
   // Pack-tail alignment only exists for the 4-per-int32 ue8m0 layouts; fp32
   // scales are unpacked (kAligned is fixed true by the static_assert). Exact
   // match: kAligned = false with an aligned num_groups would make
   // fill_unaligned zero bytes past the row.
-  if constexpr (Trait::kUe8m0) {
+  if constexpr (Trait::kPackedScale) {
     CHECK_HOST(Trait::kAligned == (num_groups % 4 == 0));
   }
   auto scale_args = detail::ScaleStoreArgs{
@@ -522,13 +538,13 @@ QuantHostContext<Trait> build_quant_context( //
   };
   if constexpr (Trait::kRowMajor) {
     CHECK_HOST(scale_args.group_stride == 1);
-    if constexpr (Trait::kUe8m0) {
+    if constexpr (Trait::kPackedScale) {
       scale_args.expert_stride *= 4;  // i32 -> u8
       scale_args.token_stride *= 4;   // i32 -> u8
     }
   } else {  // col major
     CHECK_HOST(scale_args.token_stride == 1);
-    if constexpr (Trait::kUe8m0) {
+    if constexpr (Trait::kPackedScale) {
       scale_args.expert_stride *= 4;  // i32 -> u8
       scale_args.group_stride *= 4;   // i32 -> u8
       // The device store hardcodes token_idx * 4 bytes in this layout (it
@@ -567,12 +583,14 @@ template <
     typename QuantType,
     uint32_t kGroupSize,
     bool kUe8m0,
+    bool kPackedScale,
     bool kRowMajor,
     bool kAligned,
     bool kFuseSiluAndMul,
     bool kUsePDL>
 struct PerTokenGroupQuantFlatKernel {
-  using Trait = QuantTrait<InputType, QuantType, kGroupSize, kUe8m0, kRowMajor, kAligned, kFuseSiluAndMul>;
+  using Trait =
+      QuantTrait<InputType, QuantType, kGroupSize, kUe8m0, kPackedScale, kRowMajor, kAligned, kFuseSiluAndMul>;
 
   static void run(tvm::ffi::TensorView input, tvm::ffi::TensorView output_q, tvm::ffi::TensorView output_s) {
     using namespace host;
@@ -591,12 +609,14 @@ template <
     typename QuantType,
     uint32_t kGroupSize,
     bool kUe8m0,
+    bool kPackedScale,
     bool kRowMajor,
     bool kAligned,
     bool kFuseSiluAndMul,
     bool kUsePDL>
 struct PerTokenGroupQuantMaskedKernel {
-  using Trait = QuantTrait<InputType, QuantType, kGroupSize, kUe8m0, kRowMajor, kAligned, kFuseSiluAndMul>;
+  using Trait =
+      QuantTrait<InputType, QuantType, kGroupSize, kUe8m0, kPackedScale, kRowMajor, kAligned, kFuseSiluAndMul>;
 
   // expected_m: optional host-side expected-tokens-per-expert hint (the same
   // hint SGLang passes to deep_gemm's masked grouped GEMM); <= 0 means

--- a/python/sglang/kernels/ops/quantization/fp8_kernel.py
+++ b/python/sglang/kernels/ops/quantization/fp8_kernel.py
@@ -540,35 +540,14 @@ def _run_per_token_group_quant_8bit_kernel(
 ) -> None:
     """Quantize into caller-owned ``x_q`` / ``x_s``.
 
-    CUDA routes to the JIT per_token_group_quant kernel; MUSA stays on the AOT
-    v2 op (the JIT kernel is CUDA-only), and the fp32-pow-2 storage flavor of
-    row-major UE8M0 (float32 ``x_s``, deep_gemm ``ceil_to_ue8m0`` convention)
-    stays on the JIT v2 baseline — per_token_group_quant only packs UE8M0 as
-    int32. The kernel bakes the quant constants in at compile time, so
-    drifted constants are rejected loudly here instead of silently quantizing
+    CUDA routes to the JIT per_token_group_quant kernel, including FP32
+    buffers containing power-of-two scales; MUSA stays on the AOT v2 op
+    (the JIT kernel is CUDA-only). The kernel bakes the quant constants in at
+    compile time, so drifted constants are rejected loudly instead of quantizing
     with different ones; unsupported shapes/layouts error inside its host
     checks. Whole-row (per-token) quantization is a different op:
     ``sglang_per_token_quant_fp8``.
     """
-    if scale_ue8m0 and x_s.dtype == torch.float32 and not _is_musa:
-        from sglang.kernels.ops.quantization.per_token_group_quant_8bit_v2 import (
-            per_token_group_quant_8bit_v2,
-        )
-
-        per_token_group_quant_8bit_v2(
-            input=x,
-            output_q=x_q,
-            output_s=x_s,
-            group_size=group_size,
-            eps=eps,
-            min_8bit=fp8_min,
-            max_8bit=fp8_max,
-            scale_ue8m0=scale_ue8m0,
-            fuse_silu_and_mul=fuse_silu_and_mul,
-            masked_m=masked_m,
-        )
-        return
-
     if _is_musa:
         sgl_per_token_group_quant_8bit(
             x,

--- a/python/sglang/kernels/ops/quantization/per_token_group_quant.py
+++ b/python/sglang/kernels/ops/quantization/per_token_group_quant.py
@@ -27,6 +27,7 @@ def _jit_module(
     out_dtype: torch.dtype,
     group_size: int,
     scale_ue8m0: bool,
+    packed_scale: bool,
     row_major: bool,
     aligned: bool,
     fuse_silu_and_mul: bool,
@@ -41,6 +42,7 @@ def _jit_module(
         out_dtype,
         group_size,
         scale_ue8m0,
+        packed_scale,
         row_major,
         aligned,
         fuse_silu_and_mul,
@@ -76,8 +78,6 @@ def _infer_scale_layout(
         aligned = num_groups % 4 == 0
         return row_major, aligned
     if output_s.dtype == torch.float32:
-        if scale_ue8m0:
-            raise ValueError("scale_ue8m0=True requires an int32-packed output_s")
         return row_major, True
     raise ValueError(f"Unsupported output_s dtype {output_s.dtype}")
 
@@ -103,6 +103,7 @@ def _per_token_group_quant_custom_op(
         output_q.dtype,
         int(group_size),
         bool(scale_ue8m0),
+        output_s.dtype == torch.int32,
         row_major,
         aligned,
         bool(fuse_silu_and_mul),
@@ -190,7 +191,10 @@ def per_token_group_quant(
       float32 transposed  -> col-major fp32 scales (TMA-aligned view)
       int32 transposed    -> col-major UE8M0 bytes packed 4-per-int32
       int32 contiguous    -> row-major UE8M0 bytes packed 4-per-int32
-    The packed layouts require ``scale_ue8m0=True``.
+    ``scale_ue8m0=True`` rounds scale values up to powers of two. A supplied
+    float32 ``output_s`` stores those values unpacked; int32 buffers pack the
+    exponent bytes and require ``scale_ue8m0=True``. Automatic allocation with
+    ``scale_ue8m0=True`` continues to select packed int32 storage.
 
     ``expected_m`` (masked only) is an optional expected-tokens-per-expert hint.
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1847,11 +1847,12 @@ class MQALayer(MqaAttentionBase):
                     o_fp8, o_s = sglang_per_token_group_quant_fp8_dsv4_wo_a(o)
                     recipe = (1, 1, 128)
                 else:
-                    # sm90 (Hopper): fp32 scales.
+                    # Keep row-major FP32 storage, but use power-of-two scale values:
+                    # some fp8_einsum backends convert these scales to UE8M0.
                     o_fp8, o_s = sglang_per_token_group_quant_fp8(
                         o.reshape(T * G, D).contiguous(),
                         group_size=128,
-                        scale_ue8m0=False,
+                        scale_ue8m0=True,
                     )
                     o_fp8 = o_fp8.view(T, G, D)
                     o_s = o_s.view(T, G, -1)

--- a/test/manual/dsv4/test_wo_a_fp8_sm90.py
+++ b/test/manual/dsv4/test_wo_a_fp8_sm90.py
@@ -3,8 +3,8 @@
 Mirrors models/deepseek_v4.py MQALayer wo_a: quantize the token-major attention
 output [T, G, D] per-token-group(128) to fp8, then run the grouped matmul over the
 group/head dim via deep_gemm.fp8_einsum("bhr,hdr->bhd") -> [T, G, R], and compare
-against a bf16 einsum reference. sm100 (Blackwell) uses ue8m0 scales + recipe
-(1,1,128); sm90 (Hopper) uses fp32 scales + recipe (1,128,128). Covers the Flash
+against FP32 references before and after quantization. Exercises FP32 storage
+with power-of-two values + recipe (1,128,128) on SM90 and SM12x. Covers the Flash
 (G=8) and Pro (G=16) shapes for both prefill (T=1024) and decode (small T).
 
     CUDA_VISIBLE_DEVICES=0 python3 test/manual/dsv4/test_wo_a_fp8_sm90.py
@@ -17,8 +17,6 @@ from dataclasses import dataclass
 
 import torch
 import torch.nn.functional as F
-
-from sglang.srt.layers import deep_gemm_wrapper
 
 
 @dataclass(frozen=True)
@@ -47,7 +45,7 @@ def quantize_weight_by_group(
     )
     for group in range(groups):
         weight_fp8[group], weight_scale[group] = per_block_cast_to_fp8(
-            weight[group], use_ue8m0=False, gran_k=128
+            weight[group], use_ue8m0=True, gran_k=128
         )
     return weight_fp8, weight_scale
 
@@ -56,7 +54,9 @@ def run_wo_a_einsum(
     o: torch.Tensor,  # [T, G, D] bf16
     weight_fp8: torch.Tensor,  # [G, N, K] fp8
     weight_scale: torch.Tensor,  # [G, N/128, K/128] fp32
-) -> torch.Tensor:
+    *,
+    scale_ue8m0: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
     """Mirror models/deepseek_v4.py MQALayer wo_a fp8 einsum path."""
     import deep_gemm
 
@@ -69,6 +69,24 @@ def run_wo_a_einsum(
     o_fp8, o_s = sglang_per_token_group_quant_fp8(
         o.reshape(T * G, D).contiguous(),
         group_size=128,
+        scale_ue8m0=scale_ue8m0,
+    )
+
+    assert o_s.dtype == torch.float32
+    assert o_s.shape == (T * G, D // 128)
+    assert o_s.stride() == (D // 128, 1)
+    assert torch.isfinite(o_s).all() and (o_s > 0).all()
+    assert (o_s >= torch.finfo(torch.float32).tiny).all()
+    if scale_ue8m0:
+        assert (o_s.view(torch.int32) & 0x7FFFFF).eq(0).all(), (
+            "fp8_einsum activation scales must have power-of-two values"
+        )
+    o_dequant = (o_fp8.float().unflatten(-1, (-1, 128)) * o_s.unsqueeze(-1)).flatten(-2)
+    torch.testing.assert_close(
+        o_dequant,
+        o.reshape(T * G, D).float(),
+        rtol=0.063,
+        atol=o_s.max().item() * 2**-10,
     )
 
     recipe = (1, 128, 128)
@@ -80,7 +98,20 @@ def run_wo_a_einsum(
         output,
         recipe=recipe,
     )
-    return output
+    weight_dequant = weight_fp8.float() * weight_scale.repeat_interleave(
+        128, dim=-2
+    ).repeat_interleave(128, dim=-1)
+    ref = torch.einsum("tgd,grd->tgr", o_dequant.view(T, G, D), weight_dequant)
+    return output, ref
+
+
+def relative_errors(actual: torch.Tensor, ref: torch.Tensor) -> tuple[float, float]:
+    """Global max and L2 relative errors, stable when individual outputs are zero."""
+    diff = actual.float() - ref.float()
+    return (
+        (diff.abs().max() / ref.abs().max().clamp_min(1e-12)).item(),
+        (diff.norm() / ref.norm().clamp_min(1e-12)).item(),
+    )
 
 
 def check(case: WoACase, args: argparse.Namespace) -> None:
@@ -98,14 +129,29 @@ def check(case: WoACase, args: argparse.Namespace) -> None:
     )
     weight_fp8, weight_scale = quantize_weight_by_group(weight)
 
-    out = run_wo_a_einsum(o, weight_fp8, weight_scale)
-    bf16_ref = torch.einsum("tgd,grd->tgr", o.float(), weight.float()).to(
-        torch.bfloat16
-    )
+    out, dequant_ref = run_wo_a_einsum(o, weight_fp8, weight_scale)
+    fp32_ref = torch.einsum("tgd,grd->tgr", o.float(), weight.float())
+    bf16_ref = fp32_ref.to(torch.bfloat16)
     torch.cuda.synchronize()
 
     cb = cosine(out, bf16_ref)
-    print(f"{case.name}: G={case.groups} T={case.tokens} cos_bf16={cb:.6f}")
+    kernel_error = relative_errors(out, dequant_ref)
+    total_error = relative_errors(out, fp32_ref)
+    floor_error = relative_errors(dequant_ref.bfloat16(), dequant_ref)
+    bf16_error = relative_errors(bf16_ref, fp32_ref)
+    print(
+        f"{case.name}: G={case.groups} T={case.tokens} cos_bf16={cb:.6f}\n"
+        f"  max_relative,l2_relative: fixed_kernel={kernel_error} "
+        f"fixed_total={total_error} fp8_bf16_floor={floor_error} "
+        f"bf16_rounding={bf16_error}"
+    )
+    if args.compare_legacy:
+        old_out, old_ref = run_wo_a_einsum(
+            o, weight_fp8, weight_scale, scale_ue8m0=False
+        )
+        print(f"  old_kernel={relative_errors(old_out, old_ref)}")
+    if kernel_error[0] >= 0.01 or kernel_error[1] >= 0.005:
+        raise AssertionError(f"{case.name}: excessive kernel error {kernel_error}")
     if cb <= args.cos_gate:
         raise AssertionError(f"{case.name} cos_bf16 {cb} <= {args.cos_gate}")
 
@@ -116,20 +162,22 @@ def main() -> None:
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--cos-gate", type=float, default=0.999)
     parser.add_argument("--decode-tokens", type=int, default=16)
+    parser.add_argument("--prefill-tokens", type=int, default=1024)
+    parser.add_argument(
+        "--compare-legacy",
+        action="store_true",
+        help="Also run the old non-power-of-two path (may assert on some DeepGEMM layouts)",
+    )
     args = parser.parse_args()
 
-    if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
-        print(
-            "SKIP: this manual test validates the sm90 fp32-scale wo_a einsum path; "
-            "the sm100/Blackwell production path uses ue8m0 scales + a weight-scale "
-            "transform not reproduced here."
-        )
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9:
+        print("SKIP: FP8 einsum requires an SM90 or newer CUDA GPU.")
         return
 
     cases = [
-        WoACase("flash prefill", groups=8, tokens=1024),
+        WoACase("flash prefill", groups=8, tokens=args.prefill_tokens),
         WoACase("flash decode", groups=8, tokens=args.decode_tokens),
-        WoACase("pro prefill", groups=16, tokens=1024),
+        WoACase("pro prefill", groups=16, tokens=args.prefill_tokens),
         WoACase("pro decode", groups=16, tokens=args.decode_tokens),
     ]
     for case in cases:

--- a/test/registered/kernels/ops/attention/test_fp8_wo_a.py
+++ b/test/registered/kernels/ops/attention/test_fp8_wo_a.py
@@ -25,8 +25,72 @@ from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 
 _GROUP_SIZE = 128
+
+
+class TestDeepSeekV4FP8WoAFp32(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available() or get_device_sm() < 90:
+            raise unittest.SkipTest("FP8 einsum requires SM90 or newer")
+        try:
+            import deep_gemm
+        except ImportError as exc:
+            raise unittest.SkipTest("deep_gemm is required") from exc
+        cls.deep_gemm = deep_gemm
+
+    def test_fp32_activation_scales_and_einsum(self):
+        """The FP32 branch must also survive DeepGEMM's UE8M0 conversion."""
+        torch.manual_seed(39193)
+        D, R = 4096, 256
+        for T in (1, 7, 128):
+            for G in (8, 16):
+                with self.subTest(T=T, G=G):
+                    o = torch.randn(T, G, D, device="cuda").clamp(-1, 1).bfloat16()
+                    raw_scale = o.float().unflatten(-1, (-1, 128)).abs().amax(-1) / 448
+                    self.assertTrue(
+                        (raw_scale.view(torch.int32) & 0x7FFFFF).ne(0).any()
+                    )
+                    q, s = sglang_per_token_group_quant_fp8(
+                        o.view(T * G, D), 128, scale_ue8m0=True
+                    )
+                    self.assertEqual(s.dtype, torch.float32)
+                    self.assertEqual(s.shape, (T * G, D // 128))
+                    self.assertEqual(s.stride(), (D // 128, 1))
+                    self.assertTrue(torch.isfinite(s).all())
+                    self.assertTrue((s >= torch.finfo(torch.float32).tiny).all())
+                    self.assertTrue((s.view(torch.int32) & 0x7FFFFF).eq(0).all())
+                    o_dequant = (
+                        q.float().unflatten(-1, (-1, 128)) * s.unsqueeze(-1)
+                    ).view(T, G, D)
+                    torch.testing.assert_close(
+                        o_dequant, o.float(), rtol=0.063, atol=s.max().item() * 2**-10
+                    )
+
+                    weight = torch.randn(G, R, D, device="cuda").bfloat16()
+                    weight_q, weight_s = quant_weight_ue8m0(
+                        weight, weight_block_size=[128, 128]
+                    )
+                    out = torch.empty(T, G, R, device="cuda", dtype=torch.bfloat16)
+                    self.deep_gemm.fp8_einsum(
+                        "bhr,hdr->bhd",
+                        (q.view(T, G, D), s.view(T, G, D // 128)),
+                        (weight_q, weight_s),
+                        out,
+                        recipe=(1, 128, 128),
+                    )
+                    weight_dequant = block_quant_dequant(
+                        weight_q, weight_s, block_size=[128, 128], dtype=torch.float32
+                    )
+                    ref = torch.einsum("tgd,grd->tgr", o_dequant, weight_dequant)
+                    # Normalize globally: per-element relative error is unstable
+                    # near zero. These bounds leave room for BF16 output rounding
+                    # but reject the large error from dropping scale mantissas.
+                    diff = out.float() - ref
+                    self.assertLess((diff.abs().max() / ref.abs().max()).item(), 0.01)
+                    self.assertLess((diff.norm() / ref.norm()).item(), 0.005)
 
 
 class TestDeepSeekV4FP8WoA(CustomTestCase):

--- a/test/registered/kernels/ops/quantization/test_per_token_group_quant.py
+++ b/test/registered/kernels/ops/quantization/test_per_token_group_quant.py
@@ -218,6 +218,35 @@ def test_ue8m0_row_packed_bitexact(hidden):
 
 
 # --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize("num_tokens,hidden", [(1, 128), (7, 384), (33, 4096)])
+def test_ue8m0_fp32_scale(dtype, num_tokens, hidden):
+    """FP8 einsum's UE8M0 conversion needs power-of-two values in FP32 storage."""
+    x = torch.linspace(-1, 1, hidden, device="cuda").repeat(num_tokens, 1).to(dtype)
+    if num_tokens > 1:
+        x[0].zero_()
+    raw_scale = _group_amax(x, G) / FMAX
+    assert (raw_scale.view(torch.int32) & 0x7FFFFF).ne(0).any()
+
+    x_q = torch.empty_like(x, dtype=fp8_dtype)
+    x_s = torch.empty(num_tokens, hidden // G, device=x.device, dtype=torch.float32)
+    per_token_group_quant(x, x_q, x_s, G, scale_ue8m0=True)
+
+    assert x_s.dtype == torch.float32
+    assert x_s.shape == (num_tokens, hidden // G)
+    assert x_s.stride() == (hidden // G, 1)
+    assert torch.isfinite(x_s).all() and (x_s > 0).all()
+    # The amax floor makes these positive NORMAL FP32 values, so zero
+    # mantissa bits are equivalent to exact powers of two (exclude 0/inf/NaN).
+    assert (x_s >= torch.finfo(torch.float32).tiny).all()
+    assert (x_s.view(torch.int32) & 0x7FFFFF).eq(0).all()
+    expected_scale = torch.exp2(torch.ceil(torch.log2(raw_scale)))
+    torch.testing.assert_close(x_s, expected_scale, rtol=0, atol=0)
+    q_ref, _ = ref_fp8_ue8m0(x, G)
+    assert torch.equal(x_q.view(torch.int8), q_ref.view(torch.int8))
+    assert _dequant_rel_err(x_q, x_s, x, G) < 0.04
+
+
 # fp32 / int8 scale paths: exact stored scale + dequant round-trip (the codes
 # are not bit-reproducible under fast-math division).
 # --------------------------------------------------------------------------- #

--- a/test/registered/kernels/ops/quantization/test_per_token_group_quant_8bit_v2.py
+++ b/test/registered/kernels/ops/quantization/test_per_token_group_quant_8bit_v2.py
@@ -119,12 +119,8 @@ def test_v2_jit_matches_aot(dtype, num_tokens, hidden, fuse_silu_and_mul, scale_
 #      the JIT per_token_group_quant kernel and pinned bit-exact in test_per_token_group_quant
 #      (test_v3_ue8m0_row_packed_bitexact);
 #   2. fp32 [T, G] storing power-of-two VALUES (the deep_gemm.fp8_einsum
-#      format) -- v2-only. No srt caller requests it (production ties
-#      scale_ue8m0 and column_major_scales to the same DEEPGEMM_SCALE_UE8M0
-#      flag), so the srt entry `sglang_per_token_group_quant_fp8`, which now
-#      routes to the JIT kernel, rejects it loudly instead of allocating an fp32
-#      buffer the kernel cannot fill. The v2 JIT kernel itself still implements it and is
-#      covered by test_v2_jit_matches_aot above.
+#      format) -- supported by the current JIT per_token_group_quant kernel
+#      with a supplied float32 output_s; covered by test_ue8m0_fp32_scale.
 
 
 # Masked (EP-MoE) path: the v2 op only has a masked scheduler for the


### PR DESCRIPTION
## Summary

Fix the DeepSeek-V4 `wo_a` FP32 activation-scale branch for DeepGEMM `fp8_einsum`. Keep row-major FP32 storage while producing power-of-two scale values required by affected backends.

## Root cause

The branch selected when `DEEPGEMM_SCALE_UE8M0` is false produced arbitrary `amax / 448` activation scales. On SM100/SM12x, DeepGEMM converts the FP32 scale factors into exponent-only UE8M0. The relevant noncontiguous batched conversion can drop the mantissa without validating it or requantizing the FP8 codes. The codes still reflect the original arbitrary scale, so the GEMM uses a smaller scale than the quantizer used and produces large output errors.

SM90 preserves ordinary FP32 scales. This branch is selected by policy and can also reach backends that convert scale factors to UE8M0. Physical storage/layout and the numeric scale contract must be separate.

## Fix

- Separate power-of-two rounding from packed storage inside the existing per-token/group JIT quantizer. Infer packing from the output buffer dtype; keep automatic packed allocation unchanged.
- Support `scale_ue8m0=True` numeric semantics with unpacked FP32 output storage in the current JIT implementation and remove the wrapper's deprecated v2 fallback.
- Request power-of-two activation scale values in the DSV4 FP32 branch, retaining its layout and `(1, 128, 128)` recipe.
- Add quantizer and direct `fp8_einsum` regressions; extend the existing manual test to report old/fixed errors against dequantized FP32 references and the BF16 output-rounding floor.

## Tests

Validated on one NVIDIA RTX PRO 4000 Blackwell (SM120), CUDA 13.0, PyTorch 2.13.0+cu130, and `sgl-deep-gemm==0.1.7`.

Before the production change, the regression-first manual assertion failed because activation scales had nonzero mantissas. Nine new quantizer cases also failed because the JIT API rejected FP32 power-of-two scale storage. The nine cases pass after the change.

```bash
python -m pytest -q \
  test/registered/kernels/ops/quantization/test_per_token_group_quant.py \
  test/registered/kernels/ops/attention/test_fp8_wo_a.py

python test/manual/dsv4/test_wo_a_fp8_sm90.py --compare-legacy --decode-tokens 7
python test/manual/dsv4/test_wo_a_fp8_sm90.py --decode-tokens 1

python -m pytest -q \
  test/registered/kernels/ops/quantization/test_per_token_quant_fp8.py \
  test/registered/kernels/ops/quantization/test_per_tensor_quant_fp8.py \
  test/registered/kernels/ops/quantization/test_per_token_group_quant_8bit_v2.py
```

The current quantizer and `wo_a` suites pass (114 + 6 tests, with 14 `wo_a` subcases). The broader subset has 166 passes and 66 failures. The same 66 deprecated v2/AOT bit-parity tests fail on unmodified upstream in the same environment; the failing node-ID sets are identical.

SM90 specializations compile for BF16, FP16, and FP32 input. Physical SM90 numerical execution and physical SM100/SM121 validation were not performed. Ruff, isort, clang-format, codespell, diff whitespace checks, and registered-test lint checks pass.

## Numerical evidence

Synthetic layer-isolation inputs; D=4096, R=1024, seed=0. The metric is `max(abs(output - reference)) / max(abs(reference))`. It measures kernel error against FP32 matmul of each path's dequantized operands; it is not total FP8 or model error.

| Groups | Tokens | Old | Fixed | BF16 output-rounding floor |
|---|---:|---:|---:|---:|
| 8 | 7 | 0.251160 | 0.002693 | 0.002693 |
| 8 | 1024 | 0.267305 | 0.002287 | 0.002286 |
| 16 | 7 | 0.297109 | 0.002863 | 0.002863 |
| 16 | 1024 | 0.262895 | 0.002239 | 0.002239 |

Fixed-path relative L2 kernel error is approximately 0.00165; total relative L2 error against the original unquantized operands is approximately 0.0373, consistent with ordinary FP8 quantization. The regression uses global max/L2 tolerances rather than unstable per-element relative errors or exact reporter numbers.

## Risk / scope

FP32 row-major layout is unchanged; scale values now round upward. The packed UE8M0 path (including rounding, padding, and TMA strides), global `DEEPGEMM_SCALE_UE8M0` policy, weight processing, and MoE call sites are unchanged. Existing shared-quantizer FP32, INT8, fused, masked, allocation, and dedicated packed `wo_a` cases pass on SM120.

The FP8 path is selected by `SGLANG_OPT_FP8_WO_A_GEMM`, and CUDA weight setup still assumes 128×128 blocks. This change adds no checkpoint reblocking or support changes and does not claim full-model DeepSeek-V4.1 validation.

The Dots3 absorbed FP8 matmul also supplies arbitrary FP32 activation scales to `fp8_einsum`; it is reported separately as a similar consumer and is not migrated here.

Fixes #39193

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34748143754](https://github.com/sgl-project/sglang/actions/runs/34748143754)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34748143635](https://github.com/sgl-project/sglang/actions/runs/34748143635)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34748143732](https://github.com/sgl-project/sglang/actions/runs/34748143732)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->