### PR TITLE
[DeepSeek-V4] Forward auxiliary hidden states across PP stages

### DIFF
--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -88,6 +88,7 @@ def _allocate_decode_buffers(
     hc_hidden_size: Optional[int] = None,
     pp_proxy_topk_size: Optional[int] = None,
     pp_proxy_residual_num_blocks: Optional[int] = None,
+    pp_proxy_aux_hidden_state_keys: tuple[str, ...] = (),
     allocate_logits_buffer: bool = True,
 ) -> SimpleNamespace:
     """Allocate the FB-shared decode buffers."""
@@ -140,6 +141,10 @@ def _allocate_decode_buffers(
             if pp_proxy_topk_size is not None:
                 pp_proxy_tensors["topk_indices"] = torch.zeros(
                     (max_num_token, pp_proxy_topk_size), dtype=torch.int32
+                )
+            for key in pp_proxy_aux_hidden_state_keys:
+                pp_proxy_tensors[key] = torch.zeros(
+                    (max_num_token, hidden_size), dtype=dtype
                 )
         else:
             pp_proxy_tensors = None
@@ -377,6 +382,9 @@ class BaseRunner(ABC):
             hc_hidden_size=getattr(mr.model_config, "hc_hidden_size", None),
             pp_proxy_topk_size=mr.get_pp_proxy_topk_size(),
             pp_proxy_residual_num_blocks=mr.get_pp_proxy_residual_num_blocks(),
+            pp_proxy_aux_hidden_state_keys=getattr(
+                mr.model, "pp_proxy_aux_hidden_state_keys", ()
+            ),
             allocate_logits_buffer=allocate_logits_buffer,
         )
 

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -413,6 +413,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             pp_proxy_residual_num_blocks=(
                 self.model_runner.get_pp_proxy_residual_num_blocks()
             ),
+            pp_proxy_aux_hidden_state_keys=getattr(
+                self.model_runner.model, "pp_proxy_aux_hidden_state_keys", ()
+            ),
         )
         self.buffers.share_buffers()
         # FB-shared slot registry adopting DecodeInputBuffers storage (same

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -362,6 +362,9 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             pp_proxy_residual_num_blocks=(
                 self.model_runner.get_pp_proxy_residual_num_blocks()
             ),
+            pp_proxy_aux_hidden_state_keys=getattr(
+                self.model_runner.model, "pp_proxy_aux_hidden_state_keys", ()
+            ),
         )
         self.buffers.share_buffers()
         # Token-axis FB-shared slot registry adopting PrefillInputBuffers

--- a/python/sglang/srt/model_executor/runner_utils/buffers.py
+++ b/python/sglang/srt/model_executor/runner_utils/buffers.py
@@ -64,6 +64,7 @@ def _allocate_pp_proxy_tensors(
     hc_hidden_size: Optional[int] = None,
     pp_proxy_topk_size: Optional[int] = None,
     pp_proxy_residual_num_blocks: Optional[int] = None,
+    pp_proxy_aux_hidden_state_keys: Tuple[str, ...] = (),
 ) -> Dict[str, torch.Tensor]:
     """Allocate the stable buffers consumed by an incoming PP proxy."""
     is_mhc = hc_hidden_size is not None
@@ -83,6 +84,10 @@ def _allocate_pp_proxy_tensors(
     if pp_proxy_topk_size is not None:
         pp_proxy_tensors["topk_indices"] = torch.zeros(
             (max_num_tokens, pp_proxy_topk_size), dtype=torch.int32
+        )
+    for key in pp_proxy_aux_hidden_state_keys:
+        pp_proxy_tensors[key] = torch.zeros(
+            (max_hidden_tokens, hidden_size), dtype=dtype
         )
     return pp_proxy_tensors
 
@@ -133,6 +138,7 @@ class DecodeInputBuffers(ForwardInputBuffers):
         hc_hidden_size: Optional[int] = None,
         pp_proxy_topk_size: Optional[int] = None,
         pp_proxy_residual_num_blocks: Optional[int] = None,
+        pp_proxy_aux_hidden_state_keys: Tuple[str, ...] = (),
     ) -> DecodeInputBuffers:
         with torch.device(device):
             input_ids = torch.zeros((max_num_token,), dtype=torch.int64)
@@ -165,6 +171,7 @@ class DecodeInputBuffers(ForwardInputBuffers):
                     hc_hidden_size=hc_hidden_size,
                     pp_proxy_topk_size=pp_proxy_topk_size,
                     pp_proxy_residual_num_blocks=pp_proxy_residual_num_blocks,
+                    pp_proxy_aux_hidden_state_keys=pp_proxy_aux_hidden_state_keys,
                 )
                 if pp_size > 1
                 else None
@@ -267,6 +274,7 @@ class PrefillInputBuffers(ForwardInputBuffers):
         hc_hidden_size: Optional[int] = None,
         pp_proxy_topk_size: Optional[int] = None,
         pp_proxy_residual_num_blocks: Optional[int] = None,
+        pp_proxy_aux_hidden_state_keys: Tuple[str, ...] = (),
     ) -> PrefillInputBuffers:
         with torch.device(device):
             input_ids = torch.zeros((max_num_tokens,), dtype=torch.int64)
@@ -303,6 +311,7 @@ class PrefillInputBuffers(ForwardInputBuffers):
                     hc_hidden_size=hc_hidden_size,
                     pp_proxy_topk_size=pp_proxy_topk_size,
                     pp_proxy_residual_num_blocks=pp_proxy_residual_num_blocks,
+                    pp_proxy_aux_hidden_state_keys=pp_proxy_aux_hidden_state_keys,
                 )
                 if pp_size > 1 and not is_first_pp_rank
                 else None

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -3099,7 +3099,15 @@ class DeepseekV4Model(nn.Module):
             input_ids_global = getattr(forward_batch, "input_ids_global", input_ids)
 
         capture_dspark = self.dspark_layers_to_capture is not None
-        dspark_aux_hidden_states: List[torch.Tensor] = []
+        dspark_aux_hidden_states: dict[int, torch.Tensor] = {}
+        if capture_dspark and not self.pp_group.is_first_rank:
+            # Carry completed captures from earlier stages without concatenating
+            # or projecting them at each PP boundary.
+            dspark_aux_hidden_states = {
+                layer_id: pp_proxy_tensors[f"dspark_aux_hidden_states_{layer_id}"]
+                for layer_id in self.dspark_layers_to_capture
+                if layer_id < self.start_layer
+            }
         # DSpark aux capture needs the per-layer eager loop (TBO's overlapped
         # execution cannot expose per-layer completed hidden states), so skip
         # TBO when capturing -- a perf-only downgrade, not a correctness one.
@@ -3163,7 +3171,7 @@ class DeepseekV4Model(nn.Module):
                         )
                     else:
                         completed = hidden_states
-                    dspark_aux_hidden_states.append(completed.mean(dim=1))
+                    dspark_aux_hidden_states[i] = completed.mean(dim=1)
             if use_fused and last_layer is not None:
                 hidden_states = last_layer.hc_post(
                     hidden_states, prev_residual, prev_post, prev_comb
@@ -3171,7 +3179,15 @@ class DeepseekV4Model(nn.Module):
 
         if not self.pp_group.is_last_rank:
             # Flatten 3D mHC tensor for PP IPC.
-            return PPProxyTensors({"hidden_states": hidden_states.flatten(1)})
+            return PPProxyTensors(
+                {
+                    "hidden_states": hidden_states.flatten(1),
+                    **{
+                        f"dspark_aux_hidden_states_{layer_id}": aux
+                        for layer_id, aux in dspark_aux_hidden_states.items()
+                    },
+                }
+            )
 
         pre_hc_head = hidden_states.flatten(1)
 
@@ -3181,7 +3197,10 @@ class DeepseekV4Model(nn.Module):
         hidden_states = self.norm(hidden_states)
 
         if capture_dspark:
-            return (hidden_states, pre_hc_head), dspark_aux_hidden_states
+            return (hidden_states, pre_hc_head), [
+                dspark_aux_hidden_states[layer_id]
+                for layer_id in self.dspark_layers_to_capture
+            ]
 
         return hidden_states, pre_hc_head
 
@@ -3255,14 +3274,26 @@ class DeepseekV4ForCausalLM(nn.Module):
         return self.model.get_input_embeddings()
 
     def set_dspark_layers_to_capture(self, layer_ids: List[int]) -> None:
-        if not self.pp_group.is_last_rank:
-            return
+        """Configure global capture layers on every PP rank before graph capture."""
         if layer_ids is None:
             raise ValueError(
                 "DSPARK requires explicit layer_ids for aux hidden capture."
             )
+        layer_ids = list(layer_ids)
+        if not layer_ids or len(set(layer_ids)) != len(layer_ids):
+            raise ValueError("DSPARK capture layer_ids must be nonempty and unique.")
+        if any(i < 0 or i >= self.config.num_hidden_layers for i in layer_ids):
+            raise ValueError(
+                "DSPARK capture layer_ids must be valid model layer indices."
+            )
         self.capture_aux_hidden_states = True
-        self.model.dspark_layers_to_capture = list(layer_ids)
+        self.model.dspark_layers_to_capture = layer_ids
+        # Graph and warmup inputs only need captures produced before this stage.
+        self.pp_proxy_aux_hidden_state_keys = tuple(
+            f"dspark_aux_hidden_states_{layer_id}"
+            for layer_id in layer_ids
+            if layer_id < self.model.start_layer
+        )
 
     @classmethod
     def shared_experts_fusion_disable_reason(cls, hf_config, quant_config):

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_runner_helpers.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_runner_helpers.py
@@ -11,12 +11,16 @@ from sglang.srt.model_executor.cuda_graph_buffer_registry import (
     build_prefill_registry,
 )
 from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
+from sglang.srt.model_executor.runner.base_runner import _allocate_decode_buffers
 from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
     PrefillCudaGraphRunner,
     _build_layer_model_forward_kwargs,
     _resolve_transformer_layer_model,
 )
-from sglang.srt.model_executor.runner_utils.buffers import PrefillInputBuffers
+from sglang.srt.model_executor.runner_utils.buffers import (
+    DecodeInputBuffers,
+    PrefillInputBuffers,
+)
 from sglang.srt.model_loader.utils import resolve_language_model
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -187,6 +191,91 @@ class TestPrefillCudaGraphRunnerHelpers(CustomTestCase):
 
         finalized = runner._finalize_execute_output(output)
         self.assertEqual(finalized["hidden_states"].shape, (3, 8))
+
+    def test_aux_capture_buffers_are_available_for_graphs_and_warmup(self):
+        aux_keys = ("dspark_aux_hidden_states_0", "dspark_aux_hidden_states_3")
+        common = dict(
+            device=torch.device("cpu"),
+            max_bs=4,
+            hidden_size=3,
+            dtype=torch.bfloat16,
+            enable_mamba_track=False,
+            pp_size=3,
+            hc_hidden_size=12,
+            pp_proxy_aux_hidden_state_keys=aux_keys,
+            cache_loc_dtype=torch.int64,
+        )
+        prefill = PrefillInputBuffers.create(
+            **common, max_num_tokens=8, is_multimodal=False, is_first_pp_rank=False
+        )
+        decode_args = dict(
+            **common,
+            max_num_token=8,
+            dp_size=1,
+            is_encoder_decoder=False,
+            require_mlp_tp_gather=False,
+            seq_len_fill_value=1,
+            encoder_len_fill_value=0,
+            num_tokens_per_req=2,
+        )
+        decode = DecodeInputBuffers.create(
+            **decode_args, next_token_logits_buffer=torch.zeros(8, 10)
+        )
+        warmup = _allocate_decode_buffers(**decode_args, vocab_size=10)
+        for buffers in (prefill, decode, warmup):
+            self.assertEqual(
+                {
+                    key: tuple(value.shape)
+                    for key, value in buffers.pp_proxy_tensors.items()
+                },
+                {"hidden_states": (8, 12), **{key: (8, 3) for key in aux_keys}},
+            )
+            for value in buffers.pp_proxy_tensors.values():
+                self.assertEqual(value.dtype, torch.bfloat16)
+
+        registry = build_prefill_registry(
+            device=torch.device("cpu"),
+            max_bs=4,
+            max_num_token=8,
+            cache_loc_dtype=torch.int64,
+            share_pool=False,
+            source=prefill,
+        )
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        runner.buffers = prefill
+        runner.model_runner = SimpleNamespace(
+            pp_group=SimpleNamespace(is_first_rank=False)
+        )
+        for num_tokens in (5, 2):
+            proxy = PPProxyTensors(
+                {
+                    key: torch.full_like(value[:num_tokens], num_tokens)
+                    for key, value in prefill.pp_proxy_tensors.items()
+                }
+            )
+            values = torch.arange(num_tokens)
+            registry.fill_from(
+                SimpleNamespace(
+                    input_ids=values, positions=values, out_cache_loc=values
+                ),
+                raw_bs=1,
+                padded_bs=1,
+                raw_num_tokens=num_tokens,
+                padded_num_tokens=8,
+                pp_proxy_tensors=proxy,
+            )
+            capture_proxy = runner._capture_pp_proxy_tensors(8)
+            runner.raw_num_tokens = num_tokens
+            output = runner._finalize_execute_output(capture_proxy)
+            torch.testing.assert_close(output.tensors, proxy.tensors)
+            for key in aux_keys:
+                self.assertEqual(
+                    capture_proxy[key].data_ptr(),
+                    prefill.pp_proxy_tensors[key].data_ptr(),
+                )
+                self.assertEqual(
+                    torch.count_nonzero(capture_proxy[key][num_tokens:]), 0
+                )
 
     def test_bcg_eager_tail_uses_live_multimodal_embeddings(self):
         live_embeds = object()

--- a/test/registered/unit/models/test_deepseek_v4_pipeline_aux_capture.py
+++ b/test/registered/unit/models/test_deepseek_v4_pipeline_aux_capture.py
@@ -1,0 +1,225 @@
+import unittest
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+from torch import nn
+
+from sglang.srt.layers.aux_hidden_states import pack_aux_hidden_states
+from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
+from sglang.srt.models import deepseek_v4
+from sglang.srt.models.deepseek_v4 import DeepseekV4ForCausalLM, DeepseekV4Model
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+
+
+class _Layer(nn.Module):
+    """Defer a stream-dependent residual update in the fused mHC path."""
+
+    def __init__(self, layer_id, fused):
+        super().__init__()
+        self.layer_id = layer_id
+        self.fused = fused
+
+    def forward(self, *, hidden_states, prev_residual, prev_post, prev_comb, **kwargs):
+        if prev_residual is not None:
+            hidden_states = self.hc_post(
+                hidden_states, prev_residual, prev_post, prev_comb
+            )
+        residual = hidden_states
+        delta = torch.full_like(hidden_states[:, 0], self.layer_id + 1)
+        post = torch.arange(1, hidden_states.shape[1] + 1).view(1, -1, 1)
+        if self.fused:
+            return delta, residual, post, None
+        return self.hc_post(delta, residual, post, None), None, None, None
+
+    @staticmethod
+    def hc_post(hidden_states, residual, post, comb):
+        return residual + hidden_states.unsqueeze(1) * post
+
+
+class TestDeepseekV4PipelineAuxCapture(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        for name, kwargs in (
+            ("get_parallel", {"return_value": SimpleNamespace(attn_dp_size=1)}),
+            ("check_cuda_graph_backend", {"return_value": True}),
+            ("_is_npu", {"new": False}),
+            (
+                "get_attn_tp_context",
+                {
+                    "return_value": SimpleNamespace(
+                        maybe_input_scattered=lambda _: nullcontext()
+                    )
+                },
+            ),
+        ):
+            patcher = patch.object(deepseek_v4, name, **kwargs)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    @staticmethod
+    def _make_stage(start, end, *, fused=False):
+        model = DeepseekV4Model.__new__(DeepseekV4Model)
+        nn.Module.__init__(model)
+        model.start_layer, model.end_layer = start, end
+        model.hidden_size, model.hc_mult = 3, 4
+        model.pp_group = SimpleNamespace(
+            is_first_rank=start == 0, is_last_rank=end == 6
+        )
+        model.layers = nn.ModuleList(
+            _Layer(i, fused) if start <= i < end else nn.Identity() for i in range(6)
+        )
+        model.use_fused_mhc_post_pre = fused
+        model._can_run_tbo = lambda _: False
+        model.dspark_layers_to_capture = None
+        model.hc_head = lambda hidden, *_: hidden.mean(dim=1)
+        model.hc_head_fn = model.hc_head_scale = model.hc_head_base = None
+        model.norm = nn.Identity()
+
+        wrapper = DeepseekV4ForCausalLM.__new__(DeepseekV4ForCausalLM)
+        nn.Module.__init__(wrapper)
+        wrapper.model = model
+        wrapper.pp_group = model.pp_group
+        wrapper.config = SimpleNamespace(num_hidden_layers=6)
+        wrapper.capture_aux_hidden_states = False
+        wrapper.lm_head = nn.Identity()
+        wrapper.logits_processor = Mock(side_effect=lambda *args, **kwargs: args[4])
+        return wrapper
+
+    @staticmethod
+    def _forward(stage, embeds, proxy=None):
+        num_tokens = embeds.shape[0]
+        return stage.model.forward(
+            input_ids=torch.zeros(num_tokens, dtype=torch.long),
+            positions=torch.arange(num_tokens),
+            forward_batch=SimpleNamespace(),
+            input_embeds=embeds,
+            pp_proxy_tensors=proxy,
+        )
+
+    def test_cross_stage_capture_matches_single_stage_and_requested_order(self):
+        for fused in (False, True):
+            for num_tokens in (0, 1, 5):
+                # Include boundaries, non-monotonic order, and stages that
+                # forward captures but produce none themselves.
+                for layer_ids in ([5, 0, 2, 1, 4, 3], [0], [2], [5], [4, 0]):
+                    with self.subTest(fused=fused, tokens=num_tokens, layers=layer_ids):
+                        embeds = torch.arange(num_tokens * 3, dtype=torch.float32).view(
+                            num_tokens, 3
+                        )
+                        single = self._make_stage(0, 6, fused=fused)
+                        single.set_dspark_layers_to_capture(layer_ids)
+                        expected_output, expected_aux = self._forward(single, embeds)
+
+                        proxy = None
+                        for start, end in ((0, 2), (2, 4), (4, 6)):
+                            stage = self._make_stage(start, end, fused=fused)
+                            stage.set_dspark_layers_to_capture(layer_ids)
+                            output = self._forward(stage, embeds, proxy)
+                            if end == 6:
+                                actual_output, actual_aux = output
+                                break
+                            expected_keys = {"hidden_states"} | {
+                                f"dspark_aux_hidden_states_{i}"
+                                for i in layer_ids
+                                if i < end
+                            }
+                            self.assertEqual(set(output.tensors), expected_keys)
+                            self.assertEqual(
+                                output["hidden_states"].shape, (num_tokens, 12)
+                            )
+                            if proxy is not None:
+                                for key in proxy.tensors:
+                                    if key != "hidden_states":
+                                        self.assertIs(output[key], proxy[key])
+                            # Receive into independent storage, as the PP transport does.
+                            proxy = PPProxyTensors(
+                                {
+                                    key: value.clone()
+                                    for key, value in output.tensors.items()
+                                }
+                            )
+
+                        torch.testing.assert_close(actual_output, expected_output)
+                        torch.testing.assert_close(actual_aux, expected_aux)
+                        torch.testing.assert_close(
+                            pack_aux_hidden_states(actual_aux),
+                            torch.cat(
+                                [
+                                    embeds + 2.5 * (i + 1) * (i + 2) / 2
+                                    for i in layer_ids
+                                ],
+                                dim=-1,
+                            ),
+                        )
+
+    def test_configuration_enables_all_stages_and_sizes_only_incoming_captures(self):
+        layer_ids = [4, 0, 3]
+        for start, end in ((0, 2), (2, 4), (4, 6)):
+            stage = self._make_stage(start, end)
+            stage.set_dspark_layers_to_capture(layer_ids)
+            self.assertTrue(stage.capture_aux_hidden_states)
+            self.assertEqual(stage.model.dspark_layers_to_capture, layer_ids)
+            self.assertEqual(
+                stage.pp_proxy_aux_hidden_state_keys,
+                tuple(f"dspark_aux_hidden_states_{i}" for i in layer_ids if i < start),
+            )
+
+    def test_invalid_layers_fail_on_every_stage(self):
+        for start, end in ((0, 2), (2, 4), (4, 6)):
+            for layer_ids in (None, [], [0, 0], [-1], [6]):
+                with self.subTest(start=start, layers=layer_ids):
+                    stage = self._make_stage(start, end)
+                    with self.assertRaises(ValueError):
+                        stage.set_dspark_layers_to_capture(layer_ids)
+                    self.assertFalse(stage.capture_aux_hidden_states)
+
+    def test_missing_upstream_capture_fails_instead_of_returning_partial_features(self):
+        stage = self._make_stage(4, 6)
+        stage.set_dspark_layers_to_capture([0, 5])
+        with self.assertRaisesRegex(KeyError, "dspark_aux_hidden_states_0"):
+            self._forward(
+                stage,
+                torch.zeros(2, 3),
+                PPProxyTensors({"hidden_states": torch.zeros(2, 12)}),
+            )
+
+    def test_capture_disabled_preserves_pipeline_outputs(self):
+        embeds = torch.arange(6, dtype=torch.float32).view(2, 3)
+        expected = self._forward(self._make_stage(0, 6), embeds)
+        proxy = None
+        for start, end in ((0, 2), (2, 4), (4, 6)):
+            output = self._forward(self._make_stage(start, end), embeds, proxy)
+            if end < 6:
+                self.assertEqual(set(output.tensors), {"hidden_states"})
+                proxy = output
+        torch.testing.assert_close(output, expected)
+
+    def test_wrapper_only_passes_assembled_captures_to_last_stage_logits(self):
+        embeds = torch.zeros(2, 3)
+        proxy = None
+        for start, end in ((0, 2), (2, 4), (4, 6)):
+            stage = self._make_stage(start, end)
+            stage.set_dspark_layers_to_capture([2, 0])
+            output = stage.forward(
+                torch.zeros(2, dtype=torch.long),
+                torch.arange(2),
+                SimpleNamespace(),
+                input_embeds=embeds,
+                pp_proxy_tensors=proxy,
+            )
+            if end < 6:
+                self.assertIsInstance(output, PPProxyTensors)
+                stage.logits_processor.assert_not_called()
+                proxy = output
+            else:
+                stage.logits_processor.assert_called_once()
+                torch.testing.assert_close(output, [embeds + 15, embeds + 2.5])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

DeepSeek V4 auxiliary hidden-state capture currently only enables the last pipeline stage. Captures from earlier stages are consequently unavailable to the final logits processor. For example, capture layers `[4, 0, 3]` spread over three stages cannot produce the complete feature tensor on the last stage.

This PR forwards the captured auxiliary tensors through pipeline stages and assembles them in the configured layer order on the last stage. It provides target-model capture plumbing for consumers such as draft-model training. Full DSpark speculative serving with PP and transport to a training process remain follow-up work; the existing speculative-serving PP validation is unchanged.

## Modifications

- Enable `set_dspark_layers_to_capture` on every PP rank, using global layer IDs and validating the selection before enabling capture. Configure all ranks before CUDA graph initialization.
- Carry one `dspark_aux_hidden_states_<layer_id>` tensor per completed capture in `PPProxyTensors`. Stages retain earlier captures and append their local captures, including stages without any locally selected layers.
- Preserve V4's existing capture semantics: complete deferred mHC post-processing when necessary, then take `mean(dim=1)` to obtain `[tokens, hidden_size]`. The last stage returns the complete ordered list to the existing logits processor, which performs the final packing. There is no intermediate projection or concatenation.
- Allocate incoming auxiliary buffers for prefill/decode graph capture and dummy warmup. Only captures produced before the current stage need incoming buffers. Existing PP communication, buffer filling, and output slicing support the additional named tensors.

## Accuracy Tests

Passed locally on CPU with Python 3.10 and PyTorch 2.13.0:

```bash
PYTHONPATH=python python test/registered/unit/models/test_deepseek_v4_pipeline_aux_capture.py
# 6 tests passed, including 30 numerical subcases

PYTHONPATH=python python test/registered/unit/model_executor/test_prefill_cuda_graph_runner_helpers.py
# 13 tests passed

PYTHONPATH=python python scripts/lint/check_registered_tests.py
```

The model tests invoke the actual V4 forward methods with deterministic CPU layer stubs. They compare three-stage execution with one-stage execution and an independently computed feature reference, covering fused/non-fused mHC, zero/one/multiple tokens, stage boundaries, non-monotonic capture order, stages without local captures, missing upstream features, disabled capture, and final-stage logits handoff. The buffer test covers prefill/decode/warmup allocation, stable storage, repeated input filling, and padded output trimming.

`pre-commit run --files <all seven changed files>` passed, including isort, Ruff, codespell, syntax/whitespace checks, and CI registration checks.

No real-weight DeepSeek V4 multi-GPU inference or CUDA graph replay has been run. This PR is a draft pending that validation.

## Speed Tests and Profiling

Not measured: the local environment has no usable CUDA device. Each selected layer adds one `[tokens, hidden_size]` tensor to the remaining PP hops. Intermediate stages forward the individual tensors without repeatedly packing the accumulated captures. Multi-GPU memory and throughput measurements are still needed.

## Checklist

- [x] Run pre-commit on all changed files.
- [x] Add focused tests registered in `base-a-test-cpu`.
- [x] Document the internal capture setup contract in the model method.
- [ ] Run real-model multi-GPU accuracy and speed checks.
- [x] Follow the existing model, proxy, and graph-buffer conventions.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34748805289](https://github.com/sgl-project/sglang/actions/runs/34748805289)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34748805137](https://github.com/sgl-project/sglang/actions/runs/34748805137)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34748805276](https://github.com/sgl-project/sglang/actions/runs/34748805276)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->