### PR TITLE
[Diffusion] Don't route an unreadable checkpoint into the native fallback

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
@@ -397,6 +397,12 @@ class ComponentLoader(ABC):
             ComponentAttentionBackendNotAppliedError,
             ComponentCheckpointUnsupportedError,
             ComponentResidencyError,
+            # the native fallback answers "there is no customized implementation
+            # for this architecture"; a checkpoint that cannot be read is a
+            # different failure and the fallback cannot read it either, so let
+            # the original error name the file instead of reporting it as a
+            # missing implementation
+            OSError,
         ):
             raise
         except Exception as e:

--- a/python/sglang/multimodal_gen/test/unit/test_transformer_loader_fallback.py
+++ b/python/sglang/multimodal_gen/test/unit/test_transformer_loader_fallback.py
@@ -129,6 +129,39 @@ class TestTransformerLoaderFallbackAdmission(unittest.TestCase):
                         self._server_args(**overrides), "transformer_2"
                     )
 
+    def test_unreadable_checkpoint_is_not_a_missing_implementation(self):
+        # the native fallback answers "no customized implementation for this
+        # architecture"; a checkpoint that cannot be read is a different failure,
+        # and routing it into the fallback reports a missing implementation for a
+        # model that has one
+        loader = TransformerLoader()
+        missing_shard = FileNotFoundError(
+            2, "No such file or directory", "/cache/transformer/shard-00002.safetensors"
+        )
+        customized_load = mock.patch.object(
+            loader, "_load_customized_with_context", side_effect=missing_shard
+        )
+        native_load = mock.patch.object(
+            loader, "_load_native_with_context", return_value=object()
+        )
+        available_memory = mock.patch(
+            "sglang.multimodal_gen.runtime.loader.component_loaders."
+            "component_loader.current_platform.get_available_gpu_memory",
+            return_value=0.0,
+        )
+
+        with customized_load, native_load as native, available_memory:
+            with self.assertRaises(FileNotFoundError) as caught:
+                loader.load(
+                    "/model/transformer_2",
+                    self._server_args(),
+                    "transformer_2",
+                    "diffusers",
+                )
+
+        self.assertIn("shard-00002.safetensors", str(caught.exception))
+        native.assert_not_called()
+
     def test_replicated_execution_keeps_native_fallback_available(self):
         self.assertIsNone(
             TransformerLoader().validate_native_fallback(


### PR DESCRIPTION
## Motivation

The native fallback answers one question: this architecture has no customized implementation, so load it with the library's. An I/O error answers a different one — and the fallback cannot read the file either, so it converts a missing shard into a report about a missing implementation, for a model that has one.

What that looks like when a cached snapshot is incomplete (an interrupted or concurrent download, an evicted blob):

```
FileNotFoundError: .../transformer/diffusion_pytorch_model-00002-of-00003.safetensors
  -> Native Diffusers fallback for transformer component 'transformer' cannot
     honor requested distributed execution: tp_size=2
  -> sglang server exited before health check passed (exit 1)
```

Only the first line says what happened, and it is the one that scrolls past. The visible message points at the model's implementation status and at `tp_size`, neither of which is involved.

## Modifications

`ComponentLoader.load` already routes `ComponentAttentionBackendNotAppliedError`, `ComponentCheckpointUnsupportedError` and `ComponentResidencyError` straight past the fallback. Add `OSError` to that tuple. Re-raising unchanged keeps the filename in the message, which is the most useful thing to show.

## Accuracy Tests

No numerical change — this only affects which exception surfaces when a component fails to load.

## Benchmarking and Profiling

Not a performance change.

## Checklist

- [x] Extends `test_transformer_loader_fallback.py`; the new case fails on the current code because the native loader is called instead of the error propagating
- [x] `pre-commit` passes

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34750161986](https://github.com/sgl-project/sglang/actions/runs/34750161986)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #34750161850](https://github.com/sgl-project/sglang/actions/runs/34750161850)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34750161956](https://github.com/sgl-project/sglang/actions/runs/34750161956)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->