### PR TITLE
fix(unified-memory): recover joint capacity before token allocation

### DIFF
--- a/docs/docs/advanced_features/radix_eviction_policy.mdx
+++ b/docs/docs/advanced_features/radix_eviction_policy.mdx
@@ -14,6 +14,16 @@ The policy scores each candidate and the **lowest score is evicted first**. Once
 
 A policy only scores. It does not decide how much to free, and it cannot pin KV in memory — a node protected by the policy is still evicted if reclaiming everything else is not enough.
 
+## Allocation-driven eviction with unified memory
+
+With `--enable-unified-memory`, hybrid models share one device byte buffer across full-attention KV, sliding-window KV, and, when present, Mamba state pools. The individual FULL and SWA capacity views can count the same free bytes. Do not add these capacities or assume that satisfying each view separately guarantees a combined allocation. For example, each pool may report room for four tokens while the shared buffer can fit only three FULL+SWA token pairs.
+
+For a pending FULL+SWA allocation, the allocator checks both component capacities and the joint capacity. It first applies deferred frees and attempts recoverable layout changes when needed, such as moving SWA storage to open a short band. If the allocation still cannot fit, allocation-driven eviction follows the selected victim policy and continues until the complete request is allocatable or eligible cache entries are exhausted. Meeting an initial component shortfall alone does not stop this recovery. The same complete-capacity check applies before decode allocation.
+
+This recovery uses the existing shared buffer; it does not increase the memory budget or release slots held by live requests. Locked entries remain protected, so eviction cannot guarantee that every request fits. You do not need a new eviction-policy setting to enable joint-capacity checks.
+
+Unified memory currently cannot be combined with `--enable-hierarchical-cache` (HiCache) or `--enable-lmcache`; server configuration rejects these combinations. See [server arguments](/docs/advanced_features/server_arguments) for the memory and cache options.
+
 ## Available policies
 
 Select one with `--radix-eviction-policy`. All of them fall back to least-recently-used order within a tie.

--- a/python/sglang/srt/mem_cache/allocator/base.py
+++ b/python/sglang/srt/mem_cache/allocator/base.py
@@ -24,6 +24,16 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import KVCache
 
 
+class TokenAllocationRecovery(Protocol):
+    """Complete feasibility of the next token allocation, including shared pools."""
+
+    def token_allocation_ready(self, num_tokens: int) -> bool: ...
+
+    def prepare_token_allocation(self, num_tokens: int) -> bool:
+        """Apply safe deferred reclaim and report whether allocation can proceed."""
+        ...
+
+
 class MambaFullCacheDonor(Protocol):
     """Allocator capability for reclaiming Full KV on Mamba byte pressure."""
 
@@ -87,6 +97,9 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
         """Idle-time diagnostic: recompute byte/slot accounting and return
         violation strings, empty when healthy. Static pools have no byte model."""
         return []
+
+    def token_allocation_recovery(self) -> TokenAllocationRecovery | None:
+        return None
 
     def mamba_full_cache_donor(self) -> MambaFullCacheDonor | None:
         """Return the shared-pool donor capability, if this allocator has one."""

--- a/python/sglang/srt/mem_cache/allocator/unified_hybrid_swa.py
+++ b/python/sglang/srt/mem_cache/allocator/unified_hybrid_swa.py
@@ -248,8 +248,31 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
             or self.swa_available_size() < num_tokens
         ):
             return False
+        if self._token_allocation_byte_shortfall(num_tokens) > 0:
+            return False
         return _relieve_for_alloc(self, num_tokens) and self.token_allocation_ready(
             num_tokens
+        )
+
+    def _token_allocation_byte_shortfall(self, num_tokens: int) -> int:
+        """Minimum bytes that must be freed before layout recovery can succeed.
+
+        Credit every non-live byte, including holes and pending reuse. Only the
+        sink prefix excluded by ALL members is subtracted; alignment and layout
+        restrictions can make less space usable. This optimistic bound may allow
+        an unsuccessful recovery, but cannot skip one that could satisfy demand.
+        """
+        members = self._flush_targets()
+        sink_bytes = min(m.min_page_index * m.entry_bytes_per_page for m in members)
+        live_bytes = sum(m.allocated_count() * m.entry_bytes for m in members)
+        pages = -(-num_tokens // self.page_size)
+        required_bytes = pages * (
+            self.full_attn_allocator.entry_bytes_per_page
+            + self.swa_attn_allocator.entry_bytes_per_page
+        )
+        return max(
+            0,
+            required_bytes + live_bytes + sink_bytes - self.unified_buffer.total_bytes,
         )
 
     # Slot-conservation views for the leak invariant only; the byte-coordinated

--- a/python/sglang/srt/mem_cache/allocator/unified_hybrid_swa.py
+++ b/python/sglang/srt/mem_cache/allocator/unified_hybrid_swa.py
@@ -242,10 +242,10 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         )
         if self.token_allocation_ready(num_tokens):
             return True
-        # Preserve per-component recovery before moving the shared layout.
+        # Movement can open a short band, but cannot free occupied logical slots.
         if (
-            self.full_available_size() < num_tokens
-            or self.swa_available_size() < num_tokens
+            self._conserve_full_available_size() < num_tokens
+            or self._conserve_swa_available_size() < num_tokens
         ):
             return False
         if self._token_allocation_byte_shortfall(num_tokens) > 0:

--- a/python/sglang/srt/mem_cache/allocator/unified_hybrid_swa.py
+++ b/python/sglang/srt/mem_cache/allocator/unified_hybrid_swa.py
@@ -23,7 +23,10 @@ import torch
 from torch.profiler import record_function
 
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
-from sglang.srt.mem_cache.allocator.base import MambaFullCacheDonor
+from sglang.srt.mem_cache.allocator.base import (
+    MambaFullCacheDonor,
+    TokenAllocationRecovery,
+)
 from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
 from sglang.srt.mem_cache.allocator.unified_sub_pool import (
     FloatMultiEndedAllocator,
@@ -217,6 +220,37 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         K_total = K1 + K2 + K3
         K_total = min(K_total, H_f + R_f, H_s + R_s)  # index-space caps
         return K_total * self.page_size
+
+    def token_allocation_recovery(self) -> TokenAllocationRecovery:
+        return self
+
+    def token_allocation_ready(self, num_tokens: int) -> bool:
+        return (
+            self.full_available_size() >= num_tokens
+            and self.swa_available_size() >= num_tokens
+            and self.available_size() >= num_tokens
+        )
+
+    def check_decode_capacity(self, *, num_tokens: int, tree_cache) -> bool:
+        self.evict_to_free_tokens(tree_cache, num_tokens)
+        return self.token_allocation_ready(num_tokens)
+
+    def prepare_token_allocation(self, num_tokens: int) -> bool:
+        _flush_deferred_free_group(
+            self,
+            (self.free_group, self.free_page_reps_group, self.full_free_group),
+        )
+        if self.token_allocation_ready(num_tokens):
+            return True
+        # Preserve per-component recovery before moving the shared layout.
+        if (
+            self.full_available_size() < num_tokens
+            or self.swa_available_size() < num_tokens
+        ):
+            return False
+        return _relieve_for_alloc(self, num_tokens) and self.token_allocation_ready(
+            num_tokens
+        )
 
     # Slot-conservation views for the leak invariant only; the byte-coordinated
     # value would flag spurious leaks. `allocated_count()` is in TOKENS.
@@ -907,20 +941,6 @@ class UnifiedMambaSWATokenToKVPoolAllocator(UnifiedSWATokenToKVPoolAllocator):
         # `out_cache_loc`, so its in-flight write-set is None.
         super().set_inflight_forward(forward_done, out_cache_loc_virtual)
         self.mamba_allocator.set_inflight_forward(forward_done, None)
-
-    def evict_to_free_tokens(self, tree_cache, num_tokens: int) -> None:
-        """Joint-aware eviction: one tri-lifetime node frees bytes on several sides
-        at once, so re-check the JOINT gate instead of the per-side shortfall."""
-        from sglang.srt.mem_cache.common import evict_from_tree_cache
-
-        # Arbitrary retry bound; a round that frees nothing ends the loop anyway.
-        for _ in range(4):
-            before = self.available_size()
-            if before >= num_tokens:
-                return
-            evict_from_tree_cache(tree_cache, num_tokens)
-            if self.available_size() <= before:
-                return  # no progress
 
     def verify_byte_accounting(self) -> List[str]:
         return (

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -428,14 +428,23 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
     def evict(self, params: EvictParams) -> EvictResult:
         pass
 
-    def evict_for_alloc(self, params: EvictParams) -> EvictResult:
+    def evict_for_alloc(
+        self,
+        params: EvictParams,
+        *,
+        allocation_ready: Optional[Callable[[], bool]] = None,
+    ) -> EvictResult:
         """Evict cache entries to cover allocator shortfalls.
 
         The default implementation preserves the component-count semantics of
         :meth:`evict`. Multi-component caches backed by shared memory can
         override this entry point to stop once collateral frees make the
-        requested allocation feasible.
+        requested allocation feasible. ``allocation_ready`` is an optional
+        allocator-owned check of the complete request; shared caches also use it
+        to continue past component-count quotas.
         """
+        if allocation_ready is not None and allocation_ready():
+            return EvictResult()
         return self.evict(params)
 
     @abstractmethod

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -160,6 +160,20 @@ def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int):
     allocator = tree_cache.token_to_kv_pool_allocator
 
     if isinstance(allocator, SWATokenToKVPoolAllocator):
+        recovery = allocator.token_allocation_recovery()
+        if recovery is not None:
+            if recovery.token_allocation_ready(num_tokens):
+                return
+            if recovery.prepare_token_allocation(num_tokens):
+                return
+            tree_cache.evict_for_alloc(
+                EvictParams(
+                    num_tokens=max(0, num_tokens - allocator.full_available_size()),
+                    swa_num_tokens=max(0, num_tokens - allocator.swa_available_size()),
+                ),
+                allocation_ready=lambda: recovery.prepare_token_allocation(num_tokens),
+            )
+            return
         # Hybrid allocator
         full_available_size = allocator.full_available_size()
         swa_available_size = allocator.swa_available_size()

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -6,7 +6,15 @@ import threading
 import time
 from dataclasses import replace
 from queue import Queue
-from typing import TYPE_CHECKING, Iterator, NamedTuple, Optional, Sequence, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Iterator,
+    NamedTuple,
+    Optional,
+    Sequence,
+    TypeVar,
+)
 
 import torch
 
@@ -584,13 +592,22 @@ class UnifiedRadixCache(BasePrefixCache):
     def evict(self, params: EvictParams) -> EvictResult:
         return self._evict(params)
 
-    def evict_for_alloc(self, params: EvictParams) -> EvictResult:
+    def evict_for_alloc(
+        self,
+        params: EvictParams,
+        *,
+        allocation_ready: Optional[Callable[[], bool]] = None,
+    ) -> EvictResult:
         """Evict until the requested component allocations become feasible.
 
         ``params`` contains allocator shortfalls, not absolute eviction quotas.
         A component eviction can cascade to its peers; with a shared memory pool,
         those collateral frees can satisfy the original allocation before the
         triggering component's requested count is reached.
+
+        ``allocation_ready`` checks the entire pending allocation and may prepare
+        allocator-owned reclaim. Component targets retain the normal victim
+        policy; any remaining shared shortfall is walked to readiness/exhaustion.
         """
         if self.disable:
             return EvictResult()
@@ -617,7 +634,9 @@ class UnifiedRadixCache(BasePrefixCache):
                 swa_num_tokens=params.swa_num_tokens,
                 mamba_num=mamba_id_shortfall,
             )
-        result = self._evict(initial_params, available_size_targets)
+        result = self._evict(
+            initial_params, available_size_targets, allocation_ready=allocation_ready
+        )
 
         if mamba_target is not None and mamba_full_donor is not None:
             mamba_full_donor.prepare_mamba_allocation(mamba_target[1])
@@ -652,6 +671,24 @@ class UnifiedRadixCache(BasePrefixCache):
                         )
                         result.mamba_num_evicted += fallback_result.mamba_num_evicted
 
+        if allocation_ready is not None and not allocation_ready():
+            # Initial shortfalls are not walk limits for a coupled allocation.
+            # Keep the ordinary victim policy first, then search remaining cache.
+            remaining = self._evict(
+                EvictParams(
+                    num_tokens=self.full_evictable_size(),
+                    swa_num_tokens=(
+                        self.swa_evictable_size() if self.supports_swa() else 0
+                    ),
+                    mamba_num=(
+                        self.mamba_evictable_size() if self.supports_mamba() else 0
+                    ),
+                ),
+                allocation_ready=allocation_ready,
+            )
+            result.num_tokens_evicted += remaining.num_tokens_evicted
+            result.swa_num_tokens_evicted += remaining.swa_num_tokens_evicted
+            result.mamba_num_evicted += remaining.mamba_num_evicted
         return result
 
     @staticmethod
@@ -685,6 +722,7 @@ class UnifiedRadixCache(BasePrefixCache):
         available_size_targets: Optional[
             dict[ComponentType, tuple[ComponentType, int]]
         ] = None,
+        allocation_ready: Optional[Callable[[], bool]] = None,
     ) -> EvictResult:
         if self.disable:
             return EvictResult()
@@ -696,6 +734,7 @@ class UnifiedRadixCache(BasePrefixCache):
             request_by_type,
             tracker,
             available_size_targets=available_size_targets,
+            allocation_ready=allocation_ready,
         )
 
         if (
@@ -788,6 +827,7 @@ class UnifiedRadixCache(BasePrefixCache):
         available_size_targets: Optional[
             dict[ComponentType, tuple[ComponentType, int]]
         ] = None,
+        allocation_ready: Optional[Callable[[], bool]] = None,
     ) -> None:
         # Buffer mode: eviction always wins over queued backup intents — a
         # destroyed victim's intent is stale-swept and the content rewrites
@@ -797,6 +837,8 @@ class UnifiedRadixCache(BasePrefixCache):
 
         def target_reached(component_type: ComponentType) -> bool:
             nonlocal last_mamba_donor_check, mamba_donor_prepared
+            if allocation_ready is not None and allocation_ready():
+                return True
             if available_size_targets is None:
                 return False
             target = available_size_targets.get(component_type)

--- a/python/sglang/srt/session/streaming_session.py
+++ b/python/sglang/srt/session/streaming_session.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 
 import torch
 
@@ -363,8 +363,15 @@ class StreamingSession(BasePrefixCache):
     def evict(self, params: EvictParams) -> EvictResult:
         return self.inner.evict(params)
 
-    def evict_for_alloc(self, params: EvictParams) -> EvictResult:
-        return self.inner.evict_for_alloc(params)
+    def evict_for_alloc(
+        self,
+        params: EvictParams,
+        *,
+        allocation_ready: Optional[Callable[[], bool]] = None,
+    ) -> EvictResult:
+        if allocation_ready is None:
+            return self.inner.evict_for_alloc(params)
+        return self.inner.evict_for_alloc(params, allocation_ready=allocation_ready)
 
     def inc_lock_ref(self, node: Any) -> IncLockRefResult:
         result = self.try_inc_lock_ref(node)

--- a/test/registered/unit/mem_cache/test_unified_joint_allocation_eviction.py
+++ b/test/registered/unit/mem_cache/test_unified_joint_allocation_eviction.py
@@ -205,11 +205,14 @@ class TestUnifiedJointAllocationEviction(CustomTestCase):
                     kv_pool = bundle.token_to_kv_pool
                     full = allocator.full_attn_allocator
                     swa = allocator.swa_attn_allocator
+                    markers = slots.to(torch.float16).view(-1, 1, 1)
                     for layer in range(6):
                         member = full if layer < 4 else swa
                         kernel_ids = member.translate_kv_loc_for_kernel(slots)
-                        kv_pool.get_key_buffer(layer)[kernel_ids] = layer + 1
-                        kv_pool.get_value_buffer(layer)[kernel_ids] = layer + 11
+                        kv_pool.get_key_buffer(layer)[kernel_ids] = markers + 10 * layer
+                        kv_pool.get_value_buffer(layer)[kernel_ids] = (
+                            markers + 100 + 10 * layer
+                        )
                     # FULL-only bindings model tokens whose SWA window has retired.
                     extra = full.alloc(full.available_size() - 2)
                     self.assertIsNotNone(extra)
@@ -240,13 +243,14 @@ class TestUnifiedJointAllocationEviction(CustomTestCase):
                         kernel_ids = member.translate_kv_loc_for_kernel(slots)
                         self.assertTrue(
                             torch.all(
-                                kv_pool.get_key_buffer(layer)[kernel_ids] == layer + 1
+                                kv_pool.get_key_buffer(layer)[kernel_ids]
+                                == markers + 10 * layer
                             )
                         )
                         self.assertTrue(
                             torch.all(
                                 kv_pool.get_value_buffer(layer)[kernel_ids]
-                                == layer + 11
+                                == markers + 100 + 10 * layer
                             )
                         )
                     self.assertFalse(allocator.verify_byte_accounting())

--- a/test/registered/unit/mem_cache/test_unified_joint_allocation_eviction.py
+++ b/test/registered/unit/mem_cache/test_unified_joint_allocation_eviction.py
@@ -3,11 +3,15 @@
 import unittest
 from array import array
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 
-from sglang.srt.mem_cache.base_prefix_cache import EvictParams, InsertParams
+from sglang.srt.mem_cache.base_prefix_cache import (
+    EvictParams,
+    InsertParams,
+    MatchPrefixParams,
+)
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.common import evict_from_tree_cache
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
@@ -188,7 +192,12 @@ class TestUnifiedJointAllocationEviction(CustomTestCase):
 
     def test_sufficient_capacity_preserves_all_prefixes(self):
         allocator, cache = self.build_cache()
-        evict_from_tree_cache(cache, 3)
+        with patch.object(
+            allocator,
+            "prepare_token_allocation",
+            side_effect=AssertionError("unexpected recovery"),
+        ):
+            evict_from_tree_cache(cache, 3)
         self.assertEqual(cache.full_evictable_size(), 96)
         self.assertIsNotNone(allocator.alloc(3))
 
@@ -225,6 +234,26 @@ class TestUnifiedJointAllocationEviction(CustomTestCase):
         self.assertFalse(
             allocator.check_decode_capacity(num_tokens=2, tree_cache=cache)
         )
+
+    def test_locked_cache_cannot_satisfy_joint_shortfall(self):
+        allocator, cache = self.build_cache()
+        node_ids = [
+            cache.match_prefix(
+                MatchPrefixParams(key=RadixKey(array("q", [i * 1000])))
+            ).last_device_node
+            for i in range(96)
+        ]
+        locks = [(node_id, cache.inc_lock_ref(node_id)) for node_id in node_ids]
+        try:
+            self.assertEqual(cache.full_evictable_size(), 0)
+            evict_from_tree_cache(cache, 4)
+            self.assertFalse(allocator.token_allocation_ready(4))
+            self.assertEqual(allocator.available_size(), 3)
+            self.assertFalse(allocator.verify_byte_accounting())
+        finally:
+            for node_id, lock in locks:
+                cache.dec_lock_ref(node_id, lock.to_dec_params())
+        self.assertEqual(cache.full_evictable_size(), 96)
 
     def test_explicit_eviction_keeps_count_semantics(self):
         allocator, cache = self.build_cache()

--- a/test/registered/unit/mem_cache/test_unified_joint_allocation_eviction.py
+++ b/test/registered/unit/mem_cache/test_unified_joint_allocation_eviction.py
@@ -39,7 +39,10 @@ class TestUnifiedJointAllocationEviction(CustomTestCase):
     def tearDown(self):
         reset_context()
 
-    def build_cache(self, *, occupancy=96, lazy=False, page_size=1):
+    def build_cache(
+        self, *, occupancy=96, lazy=False, page_size=1, ratio=(1, 1), total_bytes=None
+    ):
+        full_layers, swa_layers = ratio
         bundle = init_unified_swa_pools(
             device="cpu",
             kv_cache_dtype=torch.float16,
@@ -51,14 +54,15 @@ class TestUnifiedJointAllocationEviction(CustomTestCase):
             swa_v_head_dim=8,
             page_size=page_size,
             start_layer=0,
-            end_layer=2,
-            swa_attention_layer_ids=[1],
-            full_attention_layer_ids=[0],
+            end_layer=full_layers + swa_layers,
+            swa_attention_layer_ids=list(range(full_layers, full_layers + swa_layers)),
+            full_attention_layer_ids=list(range(full_layers)),
             full_max_total_num_tokens=100 * page_size,
             swa_max_total_num_tokens=100 * page_size,
             enable_memory_saver=False,
             need_sort=False,
             lazy_compaction=lazy,
+            unified_total_bytes=total_bytes,
         )
         allocator = bundle.token_to_kv_pool_allocator
         req_pool = ReqToTokenPool(
@@ -88,6 +92,37 @@ class TestUnifiedJointAllocationEviction(CustomTestCase):
             )
         return allocator, cache
 
+    def test_byte_shortfall_skips_recovery_until_first_sufficient_eviction(self):
+        for lazy in (False, True):
+            for page_size in (1, 4, 16):
+                with self.subTest(lazy=lazy, page_size=page_size):
+                    allocator, cache = self.build_cache(lazy=lazy, page_size=page_size)
+                    with patch(
+                        "sglang.srt.mem_cache.allocator.unified_hybrid_swa._relieve_for_alloc",
+                        side_effect=AssertionError("recovery cannot create bytes"),
+                    ):
+                        evict_from_tree_cache(cache, 4 * page_size)
+                    self.assertEqual(cache.full_evictable_size(), 95 * page_size)
+                    self.assertIsNotNone(allocator.alloc(4 * page_size))
+                    self.assertFalse(allocator.verify_byte_accounting())
+
+    def test_byte_bound_allows_recovery_from_unequal_peer_holes(self):
+        allocator, cache = self.build_cache(
+            occupancy=0, lazy=True, ratio=(1, 4), total_bytes=256 * 32
+        )
+        slots = allocator.alloc(50)
+        self.assertIsNotNone(slots)
+        # Window retirement preserves live Full bindings. Larger SWA holes can
+        # fund both members after compaction despite the immediate joint limit.
+        allocator.free_swa(slots[:4])
+        self.assertLess(allocator.available_size(), 3)
+        self.assertGreaterEqual(allocator.full_available_size(), 3)
+        self.assertGreaterEqual(allocator.swa_available_size(), 3)
+        evict_from_tree_cache(cache, 3)
+        self.assertEqual(allocator.full_attn_allocator.allocated_count(), 50)
+        self.assertIsNotNone(allocator.alloc(3))
+        self.assertFalse(allocator.verify_byte_accounting())
+
     def test_joint_shortfall_enters_eviction_when_individual_targets_fit(self):
         for lazy in (False, True):
             with self.subTest(lazy=lazy):
@@ -114,8 +149,18 @@ class TestUnifiedJointAllocationEviction(CustomTestCase):
 
     def test_tri_pool_token_allocation_with_live_state(self):
         for temporal in ((0, 0, 0), (1, 4, 8)):
-            for lazy in (False, True):
-                with self.subTest(temporal=temporal, lazy=lazy):
+            cases = [(False, 96, 3), (True, 96, 3)]
+            if temporal == (0, 0, 0):
+                cases += [
+                    (False, 80, 24),
+                    (True, 80, 24),
+                    (False, 96, 8),
+                    (True, 96, 8),
+                ]
+            for lazy, occupancy, state_count in cases:
+                with self.subTest(
+                    temporal=temporal, lazy=lazy, state_count=state_count
+                ):
                     state_config = SimpleNamespace(
                         shape=SimpleNamespace(conv=[(3, 8)], temporal=temporal),
                         dtype=SimpleNamespace(
@@ -168,11 +213,11 @@ class TestUnifiedJointAllocationEviction(CustomTestCase):
                             ),
                         )
                     )
-                    slots = allocator.alloc(96)
-                    states = req_pool.mamba_allocator.alloc(3)
+                    slots = allocator.alloc(occupancy)
+                    states = req_pool.mamba_allocator.alloc(state_count)
                     self.assertIsNotNone(slots)
                     self.assertIsNotNone(states)
-                    for i, (lo, hi) in enumerate(((0, 1), (1, 2), (2, 96))):
+                    for i, (lo, hi) in enumerate(((0, 1), (1, 2), (2, occupancy))):
                         cache.insert(
                             InsertParams(
                                 key=RadixKey(
@@ -183,7 +228,23 @@ class TestUnifiedJointAllocationEviction(CustomTestCase):
                             )
                         )
                     demand = allocator.available_size() + 1
+                    if state_count == 8:
+                        demand += 1
+                    if state_count == 24:
+                        demand = min(
+                            allocator.full_available_size(),
+                            allocator.swa_available_size(),
+                        )
+                        with patch(
+                            "sglang.srt.mem_cache.allocator.unified_hybrid_swa._relieve_for_alloc",
+                            side_effect=AssertionError(
+                                "live state consumes shared bytes"
+                            ),
+                        ):
+                            self.assertFalse(allocator.prepare_token_allocation(demand))
                     evict_from_tree_cache(cache, demand)
+                    if state_count == 8:
+                        self.assertEqual(cache.full_evictable_size(), 95)
                     self.assertTrue(allocator.token_allocation_ready(demand))
                     self.assertIsNotNone(allocator.alloc(demand))
                     self.assertGreaterEqual(allocator.conserve_full_available_size(), 0)

--- a/test/registered/unit/mem_cache/test_unified_joint_allocation_eviction.py
+++ b/test/registered/unit/mem_cache/test_unified_joint_allocation_eviction.py
@@ -147,6 +147,110 @@ class TestUnifiedJointAllocationEviction(CustomTestCase):
                     self.assertGreaterEqual(allocator.conserve_swa_available_size(), 0)
                     self.assertFalse(allocator.verify_byte_accounting())
 
+    def test_float_recovery_preserves_prefix_when_full_band_is_short(self):
+        for lazy in (False, True):
+            for recovery in ("prepare", "eviction", "decode"):
+                with self.subTest(lazy=lazy, recovery=recovery):
+                    temporal = (0, 0, 0)
+                    state_config = SimpleNamespace(
+                        shape=SimpleNamespace(conv=[(3, 8)], temporal=temporal),
+                        dtype=SimpleNamespace(
+                            conv=torch.bfloat16, temporal=torch.float32
+                        ),
+                        layers=[0, 1],
+                    )
+                    bundle = init_unified_mamba_swa_pools(
+                        device="cpu",
+                        kv_cache_dtype=torch.float16,
+                        head_num=1,
+                        head_dim=8,
+                        v_head_dim=8,
+                        swa_head_num=1,
+                        swa_head_dim=8,
+                        swa_v_head_dim=8,
+                        page_size=1,
+                        start_layer=0,
+                        end_layer=6,
+                        swa_attention_layer_ids=[4, 5],
+                        full_attention_layer_ids=[0, 1, 2, 3],
+                        full_max_total_num_tokens=32,
+                        swa_max_total_num_tokens=24,
+                        enable_memory_saver=False,
+                        need_sort=False,
+                        lazy_compaction=lazy,
+                        mamba_layer_ids=[0, 1],
+                        mamba2_cache_params=state_config,
+                        max_mamba_cache_size=8,
+                        model_context_len=256,
+                        extra_max_context_len=1,
+                        max_num_reqs=4,
+                        enable_mamba_extra_buffer=False,
+                        disable_overlap_schedule=True,
+                        sliding_window_size=8,
+                    )
+
+                    allocator = bundle.token_to_kv_pool_allocator
+                    cache = UnifiedRadixCache(
+                        CacheInitParams(
+                            disable=False,
+                            req_to_token_pool=bundle.req_to_token_pool,
+                            token_to_kv_pool_allocator=allocator,
+                            page_size=1,
+                            sliding_window_size=128,
+                            tree_components=(ComponentType.FULL, ComponentType.SWA),
+                        )
+                    )
+                    slots = allocator.alloc(4)
+                    self.assertIsNotNone(slots)
+                    kv_pool = bundle.token_to_kv_pool
+                    full = allocator.full_attn_allocator
+                    swa = allocator.swa_attn_allocator
+                    for layer in range(6):
+                        member = full if layer < 4 else swa
+                        kernel_ids = member.translate_kv_loc_for_kernel(slots)
+                        kv_pool.get_key_buffer(layer)[kernel_ids] = layer + 1
+                        kv_pool.get_value_buffer(layer)[kernel_ids] = layer + 11
+                    # FULL-only bindings model tokens whose SWA window has retired.
+                    extra = full.alloc(full.available_size() - 2)
+                    self.assertIsNotNone(extra)
+                    key = RadixKey(array("q", [1, 2, 3, 4]))
+                    cache.insert(InsertParams(key=key, value=slots))
+                    self.assertEqual(allocator.full_available_size(), 2)
+                    self.assertGreaterEqual(allocator.conserve_full_available_size(), 6)
+                    self.assertGreaterEqual(allocator.swa_available_size(), 6)
+                    self.assertLess(allocator.available_size(), 6)
+                    self.assertEqual(allocator._token_allocation_byte_shortfall(6), 0)
+                    if recovery == "prepare":
+                        self.assertTrue(allocator.prepare_token_allocation(6))
+                    elif recovery == "decode":
+                        self.assertTrue(
+                            allocator.check_decode_capacity(
+                                num_tokens=6, tree_cache=cache
+                            )
+                        )
+                    else:
+                        evict_from_tree_cache(cache, 6)
+                    self.assertTrue(allocator.token_allocation_ready(6))
+                    self.assertEqual(cache.full_evictable_size(), 4)
+                    matched = cache.match_prefix(MatchPrefixParams(key=key))
+                    torch.testing.assert_close(matched.device_indices, slots)
+                    self.assertIsNotNone(allocator.alloc(6))
+                    for layer in range(6):
+                        member = full if layer < 4 else swa
+                        kernel_ids = member.translate_kv_loc_for_kernel(slots)
+                        self.assertTrue(
+                            torch.all(
+                                kv_pool.get_key_buffer(layer)[kernel_ids] == layer + 1
+                            )
+                        )
+                        self.assertTrue(
+                            torch.all(
+                                kv_pool.get_value_buffer(layer)[kernel_ids]
+                                == layer + 11
+                            )
+                        )
+                    self.assertFalse(allocator.verify_byte_accounting())
+
     def test_tri_pool_token_allocation_with_live_state(self):
         for temporal in ((0, 0, 0), (1, 4, 8)):
             cases = [(False, 96, 3), (True, 96, 3)]
@@ -292,9 +396,14 @@ class TestUnifiedJointAllocationEviction(CustomTestCase):
         self.assertGreaterEqual(allocator.available_size(), 2)
         self.assertEqual(allocator.full_available_size(), 1)
         self.assertFalse(allocator.token_allocation_ready(2))
-        self.assertFalse(
-            allocator.check_decode_capacity(num_tokens=2, tree_cache=cache)
-        )
+        with patch(
+            "sglang.srt.mem_cache.allocator.unified_hybrid_swa._relieve_for_alloc",
+            side_effect=AssertionError("layout recovery cannot free FULL slots"),
+        ):
+            self.assertFalse(allocator.prepare_token_allocation(2))
+            self.assertFalse(
+                allocator.check_decode_capacity(num_tokens=2, tree_cache=cache)
+            )
 
     def test_locked_cache_cannot_satisfy_joint_shortfall(self):
         allocator, cache = self.build_cache()

--- a/test/registered/unit/mem_cache/test_unified_joint_allocation_eviction.py
+++ b/test/registered/unit/mem_cache/test_unified_joint_allocation_eviction.py
@@ -1,0 +1,250 @@
+"""Real shared-pool allocation after allocation-driven cache eviction."""
+
+import unittest
+from array import array
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.mem_cache.base_prefix_cache import EvictParams, InsertParams
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.common import evict_from_tree_cache
+from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.mem_cache.unified_cache.components import ComponentType
+from sglang.srt.mem_cache.unified_memory_pool import (
+    init_unified_mamba_swa_pools,
+    init_unified_swa_pools,
+)
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sglang.srt.runtime_context import publish, reset_context
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.session.streaming_session import StreamingSession
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class TestUnifiedJointAllocationEviction(CustomTestCase):
+    def setUp(self):
+        reset_context()
+        publish(ServerArgs(model_path="Qwen/Qwen3.5-0.8B"), role="tokenizer")
+
+    def tearDown(self):
+        reset_context()
+
+    def build_cache(self, *, occupancy=96, lazy=False, page_size=1):
+        bundle = init_unified_swa_pools(
+            device="cpu",
+            kv_cache_dtype=torch.float16,
+            head_num=1,
+            head_dim=8,
+            v_head_dim=8,
+            swa_head_num=1,
+            swa_head_dim=8,
+            swa_v_head_dim=8,
+            page_size=page_size,
+            start_layer=0,
+            end_layer=2,
+            swa_attention_layer_ids=[1],
+            full_attention_layer_ids=[0],
+            full_max_total_num_tokens=100 * page_size,
+            swa_max_total_num_tokens=100 * page_size,
+            enable_memory_saver=False,
+            need_sort=False,
+            lazy_compaction=lazy,
+        )
+        allocator = bundle.token_to_kv_pool_allocator
+        req_pool = ReqToTokenPool(
+            size=4,
+            max_context_len=256 * page_size,
+            device="cpu",
+            enable_memory_saver=False,
+        )
+        cache = UnifiedRadixCache(
+            CacheInitParams(
+                disable=False,
+                req_to_token_pool=req_pool,
+                token_to_kv_pool_allocator=allocator,
+                page_size=page_size,
+                sliding_window_size=128 * page_size,
+                tree_components=(ComponentType.FULL, ComponentType.SWA),
+            )
+        )
+        slots = allocator.alloc(occupancy * page_size)
+        self.assertIsNotNone(slots)
+        for i in range(occupancy):
+            cache.insert(
+                InsertParams(
+                    key=RadixKey(array("q", range(i * 1000, i * 1000 + page_size))),
+                    value=slots[i * page_size : (i + 1) * page_size],
+                )
+            )
+        return allocator, cache
+
+    def test_joint_shortfall_enters_eviction_when_individual_targets_fit(self):
+        for lazy in (False, True):
+            with self.subTest(lazy=lazy):
+                allocator, cache = self.build_cache(lazy=lazy)
+                self.assertEqual(allocator.full_available_size(), 4)
+                self.assertEqual(allocator.swa_available_size(), 4)
+                self.assertEqual(allocator.available_size(), 3)
+                evict_from_tree_cache(cache, 4)
+                self.assertEqual(cache.full_evictable_size(), 95)
+                self.assertIsNotNone(allocator.alloc(4))
+                self.assertFalse(allocator.verify_byte_accounting())
+
+    def test_joint_shortfall_outlives_individual_eviction_quotas(self):
+        for lazy in (False, True):
+            for page_size in (1, 4, 16):
+                with self.subTest(lazy=lazy, page_size=page_size):
+                    allocator, cache = self.build_cache(lazy=lazy, page_size=page_size)
+                    evict_from_tree_cache(cache, 6 * page_size)
+                    self.assertEqual(cache.full_evictable_size(), 93 * page_size)
+                    self.assertIsNotNone(allocator.alloc(6 * page_size))
+                    self.assertGreaterEqual(allocator.conserve_full_available_size(), 0)
+                    self.assertGreaterEqual(allocator.conserve_swa_available_size(), 0)
+                    self.assertFalse(allocator.verify_byte_accounting())
+
+    def test_tri_pool_token_allocation_with_live_state(self):
+        for temporal in ((0, 0, 0), (1, 4, 8)):
+            for lazy in (False, True):
+                with self.subTest(temporal=temporal, lazy=lazy):
+                    state_config = SimpleNamespace(
+                        shape=SimpleNamespace(conv=[(3, 8)], temporal=temporal),
+                        dtype=SimpleNamespace(
+                            conv=torch.bfloat16, temporal=torch.float32
+                        ),
+                        layers=[0],
+                    )
+                    bundle = init_unified_mamba_swa_pools(
+                        device="cpu",
+                        kv_cache_dtype=torch.float16,
+                        head_num=1,
+                        head_dim=8,
+                        v_head_dim=8,
+                        swa_head_num=1,
+                        swa_head_dim=8,
+                        swa_v_head_dim=8,
+                        page_size=1,
+                        start_layer=0,
+                        end_layer=2,
+                        swa_attention_layer_ids=[1],
+                        full_attention_layer_ids=[0],
+                        full_max_total_num_tokens=100,
+                        swa_max_total_num_tokens=100,
+                        enable_memory_saver=False,
+                        need_sort=False,
+                        lazy_compaction=lazy,
+                        mamba_layer_ids=[0],
+                        mamba2_cache_params=state_config,
+                        max_mamba_cache_size=8,
+                        model_context_len=256,
+                        extra_max_context_len=1,
+                        max_num_reqs=4,
+                        enable_mamba_extra_buffer=False,
+                        disable_overlap_schedule=True,
+                        sliding_window_size=32,
+                    )
+                    allocator = bundle.token_to_kv_pool_allocator
+                    req_pool = bundle.req_to_token_pool
+                    cache = UnifiedRadixCache(
+                        CacheInitParams(
+                            disable=False,
+                            req_to_token_pool=req_pool,
+                            token_to_kv_pool_allocator=allocator,
+                            page_size=1,
+                            sliding_window_size=128,
+                            tree_components=(
+                                ComponentType.FULL,
+                                ComponentType.SWA,
+                                ComponentType.MAMBA,
+                            ),
+                        )
+                    )
+                    slots = allocator.alloc(96)
+                    states = req_pool.mamba_allocator.alloc(3)
+                    self.assertIsNotNone(slots)
+                    self.assertIsNotNone(states)
+                    for i, (lo, hi) in enumerate(((0, 1), (1, 2), (2, 96))):
+                        cache.insert(
+                            InsertParams(
+                                key=RadixKey(
+                                    array("q", range(i * 1000, i * 1000 + hi - lo))
+                                ),
+                                value=slots[lo:hi],
+                                mamba_value=states[i : i + 1],
+                            )
+                        )
+                    demand = allocator.available_size() + 1
+                    evict_from_tree_cache(cache, demand)
+                    self.assertTrue(allocator.token_allocation_ready(demand))
+                    self.assertIsNotNone(allocator.alloc(demand))
+                    self.assertGreaterEqual(allocator.conserve_full_available_size(), 0)
+                    self.assertGreaterEqual(allocator.conserve_swa_available_size(), 0)
+                    self.assertFalse(allocator.verify_byte_accounting())
+
+    def test_sufficient_capacity_preserves_all_prefixes(self):
+        allocator, cache = self.build_cache()
+        evict_from_tree_cache(cache, 3)
+        self.assertEqual(cache.full_evictable_size(), 96)
+        self.assertIsNotNone(allocator.alloc(3))
+
+    def test_impossible_target_exhausts_without_claiming_readiness(self):
+        allocator, cache = self.build_cache()
+        evict_from_tree_cache(cache, 101)
+        self.assertEqual(cache.full_evictable_size(), 0)
+        self.assertFalse(allocator.token_allocation_ready(101))
+        self.assertIsNone(allocator.alloc(101))
+
+    def test_queued_composite_free_avoids_cache_eviction(self):
+        for lazy in (False, True):
+            with self.subTest(lazy=lazy):
+                allocator, cache = self.build_cache(occupancy=94, lazy=lazy)
+                temporary = allocator.alloc(2)
+                self.assertIsNotNone(temporary)
+                allocator.free_group_begin()
+                allocator.free(temporary)
+                self.assertEqual(allocator.available_size(), 3)
+                evict_from_tree_cache(cache, 4)
+                self.assertEqual(cache.full_evictable_size(), 94)
+                self.assertIsNotNone(allocator.alloc(4))
+                self.assertEqual(allocator.free_group, [])
+                allocator.free_group_end()
+                self.assertFalse(allocator.verify_byte_accounting())
+
+    def test_decode_gate_preserves_component_limit_after_swa_release(self):
+        allocator, cache = self.build_cache(occupancy=0)
+        slots = allocator.alloc(99)
+        allocator.free_swa(slots[:50])
+        self.assertGreaterEqual(allocator.available_size(), 2)
+        self.assertEqual(allocator.full_available_size(), 1)
+        self.assertFalse(allocator.token_allocation_ready(2))
+        self.assertFalse(
+            allocator.check_decode_capacity(num_tokens=2, tree_cache=cache)
+        )
+
+    def test_explicit_eviction_keeps_count_semantics(self):
+        allocator, cache = self.build_cache()
+        result = cache.evict(EvictParams(num_tokens=2))
+        self.assertEqual(result.num_tokens_evicted, 2)
+        self.assertEqual(cache.full_evictable_size(), 94)
+
+    def test_streaming_session_forwards_allocation_readiness(self):
+        session = object.__new__(StreamingSession)
+        session.inner = MagicMock()
+
+        def ready():
+            return False
+
+        params = EvictParams()
+        session.evict_for_alloc(params, allocation_ready=ready)
+        session.inner.evict_for_alloc.assert_called_once_with(
+            params, allocation_ready=ready
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

With `--enable-unified-memory`, FULL and SWA availability can count the same shared bytes. Checking each component separately can therefore stop eviction even though the pending combined allocation cannot fit.

The regression test constructs a real shared pool with FULL availability **4**, SWA availability **4**, but joint availability **3** for a request of **4 tokens**:

| Before | This patch |
|---|---|
| Zero individual shortfall stops eviction, leaving reclaimable cache entries untouched and the allocation unable to fit. | Evicts one eligible cached page and successfully allocates all four tokens while preserving byte accounting. |

A related case requires eviction to continue beyond the initial component quotas.

This PR fixes allocation readiness for unified FULL+SWA and FULL+SWA+Mamba/state pools, including the final decode-capacity check.

## Modifications

Keeping readiness in the allocator lets the two- and three-pool FULL+SWA layouts share eviction control flow without duplicating layout rules in the cache. Checking the original demand gives eviction a stopping condition tied to actual allocation feasibility, rather than component quotas or a fixed retry count. Preparing recoverable space first can preserve cached prefixes, while the ready fast path and byte bound avoid unnecessary recovery work.

- Add the explicit allocator-owned `TokenAllocationRecovery` capability. Readiness checks FULL, SWA and joint capacity against the original pending demand.
- Carry that demand through allocation-driven eviction and streaming sessions. Preserve normal victim selection first, then continue through remaining eligible entries until the allocation is ready or the cache is exhausted. Explicit count-based eviction retains its quota contract.
- Flush deferred frees before layout preparation. An optimistic shared-byte lower bound skips recovery when more live bytes must first be freed; passing the bound still requires the complete readiness check.
- Distinguish occupied logical slots from recoverable band shortages. Use the existing recovery ladder and movement guards to relocate a SWA float when possible, preserving cached KV payloads before attempting eviction.
- Replace the tri-pool fixed four-round retry with the shared readiness path. Keep the sufficient-capacity fast path before preparation. No new CLI flags or model-kernel changes. The existing prohibition on combining unified memory with HiCache/LMCache remains; this PR does not enable host-tiered unified memory.
- Document shared-capacity accounting, allocation-driven eviction and existing HiCache/LMCache incompatibility in the radix eviction guide.

## Accuracy Tests

Validation focuses on allocation/eviction correctness, byte accounting and preserving cached KV payloads.

| Validation | Result |
|---|---|
| Allocator/cache CPU regressions | **162 tests /117 subtests passed** |
| CUDA float relocation; page interleave | **6 CUDA cases;35 CPU tests passed** |
| CPU/CUDA allocator matrices | **1,032 valid cases passed per device**;168 impossible initial setups excluded per device |
| Separate serving/accounting integration | **574 successes +482 expected queue-full responses**, zero unexpected errors;20 snapshots passed and all four empty baselines restored |

Some concurrent runs produced different output token sequences between the baseline and patched versions. Differences were also observed in same-version repeats. We have not yet determined whether the patch contributes to these differences.

<details>
<summary>Test commands, options and tested revisions</summary>

**CPU regressions.** Run from the PR checkout using a configured SGLang Python environment. The commands below retain the executed options, with the local virtualenv executable replaced by `python`:

```bash
PYTHONPATH=python FLASHINFER_WORKSPACE_BASE=/tmp/sglang-flashinfer \
  python -B -m pytest -q -p no:cacheprovider \
  test/registered/unit/mem_cache/test_multi_ended_allocator.py \
  test/registered/unit/mem_cache/test_unified_radix_allocation_eviction.py \
  test/registered/unit/mem_cache/test_unified_tri_pool.py \
  test/registered/unit/mem_cache/test_unified_joint_allocation_eviction.py

PYTHONPATH=python FLASHINFER_WORKSPACE_BASE=/tmp/sglang-flashinfer \
  python -B -m pytest -x -q -p no:cacheprovider \
  test/registered/unit/mem_cache/test_page_interleave_shard.py
```

The new test is registered in `base-a-test-cpu`. It uses production pool factories and real cache entries to cover joint shortfall, continued eviction, deferred frees, locked/exhausted caches, decode readiness, tri-pool pressure and streaming-session forwarding.

**CUDA payload checks.** A local helper ran the committed float-recovery test with its pool device changed to CUDA in memory: eager/lazy compaction × preparation/eviction/decode, checking live KV payloads and cached-prefix preservation. The equivalent helper is included here with a checkout-relative path; it requires a CUDA-enabled SGLang environment and does not edit the test file:

```bash
PYTHONPATH=python FLASHINFER_WORKSPACE_BASE=/tmp/sglang-flashinfer python -B - <<'PY'
from pathlib import Path
import unittest

path = Path("test/registered/unit/mem_cache/test_unified_joint_allocation_eviction.py")
source = path.read_text().replace('device="cpu"', 'device="cuda"')
namespace = {"__name__": "joint_review_cuda", "__file__": str(path)}
exec(compile(source, str(path), "exec"), namespace)
suite = unittest.TestSuite([
    namespace["TestUnifiedJointAllocationEviction"](
        "test_float_recovery_preserves_prefix_when_full_band_is_short"
    )
])
result = unittest.TextTestRunner(verbosity=2).run(suite)
raise SystemExit(not result.wasSuccessful())
PY
```

**Supplementary serving output checks.** Boundary diagnostics compared an intermediate implementation with the complete patch: GPT **7,331/7,331** and Inkling **11,365/11,365** paired output sequences equal. These are not whole-patch Before/This patch comparisons. Settings: unified memory, page1/concurrency1, one output token, lazy compaction ON, decode CUDA graphs OFF and overlap ON; two reversed-order pairs with60s warm-up and120s measurement including drain. Equality counts are not task-accuracy scores. Full allocator matrices and serving checks used supplementary local harnesses that are not committed CI tests; those harnesses still need to be attached for external reproduction.

**Measured revisions.** For the serving table, **Before** is `203d7e812c6c9cde8859499daf54686091714638` and **This patch** is `5a2ce77f634a5439340f4bf926340bbc08327a80`. Serving results and full matrices were collected before updating the branch to newer upstream; they have not been rerun on the submitted branch. The CPU suite, six CUDA cases and page-interleave tests were rerun at current HEAD `276771eefca951ae6d55608415f2d795cbfabdae` on upstream `14b647cf27d7f2c1a3764841f7d3770ff9f9e7d6` (197 CPU tests /117 subtests and six CUDA cases passed). All six code/test/documentation patches are unchanged according to `git range-diff`; diff checks and all-files pre-commit passed. The intermediate diagnostic revision is `b4f486722b9ba2b1ba935c025c351829d623bed7`. Inkling used the same separate prerequisite patch in each comparison checkout; it is outside this PR.

</details>

## Speed Tests and Profiling

Compared **Before / This patch** on one RTX 5090 (WSL2, Python 3.12), using four models covering **2-pool and 3-pool unified memory**. Each model used a headroom workload with **64 input tokens, 32 output tokens and concurrency 4**: 60s warm-up, then 120s measurement, repeated as two reversed-order pairs (16 fresh-server runs total).

The speed workload leaves memory headroom so **Before can also complete**: all eight Before runs finished with zero measured failures/retractions. This compares serving overhead on a working workload; the allocation-failure condition is covered separately by the regression tests, not timed as a successful Before run.

Changes below are relative to Before: **positive throughput is faster; positive latency is slower**.

| Model | Unified-memory configuration | Throughput change | TTFT p95 change | TPOT p50 change | E2E p95 change |
|---|---|---:|---:|---:|---:|
| GPT-OSS-20B |2-pool: FULL KV + SWA KV|−0.94%|+1.37%|+0.38%|+1.43%|
| Qwen3.5-0.8B |2-pool: FULL KV + GDN state|+0.13%|−0.28%|−0.09%|−1.05%|
| Kimi Linear tiny random |2-pool: FULL KV + KDA state|−1.95%|+2.83%|+0.72%|+2.34%|
| Inkling |3-pool: FULL KV + SWA KV + Mamba state|+0.94%|−1.60%|−0.89%|−2.20%|

<details>
<summary>Traffic, server options and measurement procedure</summary>

**Traffic.** A local client streamed requests to `/generate`, keeping four requests in flight and submitting a replacement as each completed. It cycled through eight synthetic 64-token prompts; this is a cache-reuse/headroom workload, not a task-accuracy benchmark. The payload for request index `i` was:

```python
payload = {
    "input_ids": [1000 + i % 8] + [300 + j % 127 for j in range(63)],
    "stream": True,
    "sampling_params": {
        "temperature": 0,
        "max_new_tokens": 32,
        "ignore_eos": True,
    },
}
```

**Procedure.** Start a fresh server for each run, warm it for 60s, then collect for 120s. Stop submitting at the phase deadline and drain outstanding requests; elapsed measurement time includes that drain. Run Before then This patch for one pair, and reverse the order for the other. Server processes used CPU cores 0–7 and the client used cores 8–15. Matching physical pool bytes were checked between compared runs.

Throughput is completed output tokens divided by measured elapsed time. TTFT measures time to the first received output token; TPOT is `(request end − first token time) / (output tokens − 1)`; E2E is total request time. Table values are percentage changes from the geometric mean of the two paired ratios.

**Server options.** All four table configurations used page size 1, lazy compaction ON, CUDA graphs OFF, overlap ON, 4,096 max total tokens, context length 4,096 and chunked prefill size 512. The following is the recorded Qwen launch command with the Python environment and source path made checkout-relative; use the measured revisions listed in the Accuracy Tests details to reproduce the historical comparison:

```bash
PYTHONPATH=python SGLANG_DISABLE_LAZY_COMPACTION=0 \
FLASHINFER_WORKSPACE_BASE=/tmp/sglang-flashinfer \
HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 MAX_JOBS=2 FLASHINFER_NVCC_THREADS=1 \
taskset -c 0-7 python -m sglang.launch_server \
  --model-path Qwen/Qwen3.5-0.8B \
  --revision 2fc06364715b967f1860aea9cf38778875588b17 \
  --enable-unified-memory --attention-backend triton \
  --cuda-graph-backend-decode disabled --cuda-graph-backend-prefill disabled \
  --mem-fraction-static 0.65 --max-total-tokens 4096 \
  --swa-full-tokens-ratio 0.8 --context-length 4096 \
  --chunked-prefill-size 512 --max-running-requests 4 --page-size 1 \
  --max-mamba-cache-size 64 --mamba-backend triton --linear-attn-backend triton \
  --mamba-full-memory-ratio 0.9 --port 31293 --random-seed 42137 \
  --incremental-streaming-output --enable-metrics
```

The original launcher cleared inherited `SGLANG_*` settings before selecting lazy compaction. Offline mode requires the pinned model snapshot to be cached. Model-specific changes to the command above were:

| Model | Model revision | Changes from the Qwen command |
|---|---|---|
| `openai/gpt-oss-20b` | `6cee5e81ee83917806bbde320786a8fb61efebee` | Static memory fraction 0.75; omit the four Mamba/linear-attention options; add `--moe-runner-backend flashinfer_mxfp4 --disable-flashinfer-autotune` |
| `yujiepan/kimi-linear-tiny-random` | `a8e383cb67f27aad25167d44e5c1824755ec7275` | Add `--skip-tokenizer-init` |
| `thinkingmachines/Inkling` | `85b071f87d9bf5ff16a213a2d825faeed3af2cbf` | Use the cached snapshot directory as model path instead of `--revision`; Mamba memory ratio 0.1; add `--moe-runner-backend triton`; apply the same separate Inkling prerequisite to both checkouts |

GDN/KDA use the runtime's Mamba-state pool infrastructure. Kimi is a tiny random checkpoint, not a production-model accuracy evaluation. The custom client, pinned environment and Inkling prerequisite still need to be packaged for external reproduction; the launch example and traffic description alone are not a complete reproduction bundle.

**Additional coverage and limits.** All 20 predefined configurations completed across 80 runs, including headroom/pressure/mixed workloads, page16/concurrency16 and single-token allocation boundaries: 192,042 measured successes, zero measured failures/retractions. Only the four headroom conditions in the main table compare the whole patch against upstream; the other conditions tested implementation stages and are not included in that table. This is the declared matrix, not every possible configuration.

All 116 applicable statistical comparisons were inconclusive; p99 cells lacked 10,000 valid requests in every independent run. The Inkling B/C comparison included in the original 80-run matrix (page16/concurrency16; B: intermediate implementation, C: this patch) showed TPOT p50 changes of +14.02%/−1.46% across its two pairs (approximately +6.0% geometric mean); the cause remains unresolved. Later stopped experiments did not complete the intended performance/stress validation. These observations do not establish a fixed whole-patch slowdown or close the output differences noted above.

</details>

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/docs/developer_guide/contribution_guide#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/docs/developer_guide/contribution_guide#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/docs/developer_guide/contribution_guide#write-documentation).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/docs/developer_guide/contribution_guide#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/docs/developer_guide/contribution_guide#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/docs/developer_guide/contribution_guide#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/docs/developer_guide/contribution_guide#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34753602420](https://github.com/sgl-project/sglang/actions/runs/34753602420)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34753602229](https://github.com/sgl-project/sglang/actions/runs/34753602229)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34753602216](https://github.com/sgl-project/sglang/actions/runs/34753602216)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->