### PR TITLE
[HiCache] Preserve L2/L3 hit attribution across scheduling retries

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -219,6 +219,7 @@ def split_cached_prefix_by_tier(
     storage_hit_len: int,
     storage_hit_start: Optional[int] = None,
     host_hit_is_storage: bool = False,
+    host_loaded_spans: Optional[list[tuple[int, int]]] = None,
 ) -> tuple[int, int, int]:
     """Split a request's cached prefix into (device, host, storage) tokens.
 
@@ -226,28 +227,30 @@ def split_cached_prefix_by_tier(
     preserved after H2D promotion, while an evicted tail is clipped by
     ``prefix_len``. In buffer mode host memory is only L3 staging.
     """
-    host_hit_len = min(prefix_len, host_hit_len)
-    host_start = prefix_len - host_hit_len
+    spans = host_loaded_spans
+    if spans is None:
+        spans = [(max(0, prefix_len - host_hit_len), prefix_len)]
+    storage_start = prefix_len if storage_hit_start is None else storage_hit_start
+    storage_end = storage_start + storage_hit_len
+    host_hit_len = storage_in_host = previous_end = 0
+    # Merge overlapping H2D retries and clip spans to the admitted prefix.
+    for start, end in sorted(spans):
+        start, end = max(0, start, previous_end), min(prefix_len, end)
+        if end > start:
+            host_hit_len += end - start
+            storage_in_host += max(0, min(end, storage_end) - max(start, storage_start))
+            previous_end = end
+
     if storage_hit_start is None:
-        if host_hit_is_storage:
-            storage = host_hit_len
-            host = 0
-        else:
-            storage = min(host_hit_len, storage_hit_len)
-            host = host_hit_len - storage
+        storage = storage_in_host = min(host_hit_len, storage_hit_len)
     else:
-        storage_end = storage_hit_start + storage_hit_len
-        storage = max(
-            0,
-            min(prefix_len, storage_end) - max(0, storage_hit_start),
-        )
-        storage_in_host = max(
-            0,
-            min(prefix_len, storage_end) - max(host_start, storage_hit_start),
-        )
-        host = 0 if host_hit_is_storage else host_hit_len - storage_in_host
-    device = prefix_len - host - storage
-    return device, host, storage
+        storage = max(0, min(prefix_len, storage_end) - max(0, storage_start))
+    host = host_hit_len - storage_in_host
+    if host_hit_is_storage:
+        if host_loaded_spans is not None or storage_hit_start is None:
+            storage += host
+        host = 0
+    return prefix_len - host - storage, host, storage
 
 
 def _compute_pad_value(hash: int) -> int:
@@ -1119,6 +1122,8 @@ class Req(ReqDllmMixin):
         # admission; less than host_hit_length when the load-back was declined
         # or the staged splice dropped (that shortfall is re-prefilled).
         self.host_loaded_length = 0
+        # Absolute [start, end) H2D spans, independent of live prefix matches.
+        self.host_loaded_spans: list[tuple[int, int]] = []
         # Buffer-mode host memory is transport staging, not an L2 cache tier.
         self.host_hit_is_storage = False
         # Storage prefetch retry state while queued
@@ -2676,6 +2681,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                         storage_hit_len=req.storage_hit_length,
                         storage_hit_start=req.storage_hit_start,
                         host_hit_is_storage=req.host_hit_is_storage,
+                        host_loaded_spans=req.host_loaded_spans,
                     )
                     req._cache_breakdown_computed = True
 

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -961,6 +961,7 @@ class PrefillAdder:
                 storage_hit_len=req.storage_hit_length,
                 storage_hit_start=req.storage_hit_start,
                 host_hit_is_storage=req.host_hit_is_storage,
+                host_loaded_spans=req.host_loaded_spans,
             )
             self.log_device_hit_tokens += device_hit
             self.log_host_hit_tokens += host_hit
@@ -1391,6 +1392,9 @@ class PrefillAdder:
                     )
                 )
                 req.host_loaded_length = len(new_indices)
+                if len(new_indices):
+                    start = len(req.prefix_indices)
+                    req.host_loaded_spans.append((start, start + len(new_indices)))
                 req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
                 prefix_len = len(req.prefix_indices)
                 req.kv.cache_protected_len = prefix_len

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3878,12 +3878,9 @@ class Scheduler(
                 if held_tokens > 0:
                     req.host_hit_length = held_tokens
                     req.swa_host_hit_length = held_swa_tokens
-                    req.storage_hit_length = held_tokens
-                    req.storage_hit_start = len(req.prefix_indices)
+                    # Preserve the completed L3 span, including peer-covered KV.
                     req.host_hit_is_storage = True
                 elif not (req.host_hit_is_storage and req.host_loaded_length > 0):
-                    req.storage_hit_length = 0
-                    req.storage_hit_start = None
                     req.host_hit_is_storage = False
             res = adder.add_one_req(
                 req,

--- a/python/sglang/srt/mem_cache/buffer_mode/pipeline.py
+++ b/python/sglang/srt/mem_cache/buffer_mode/pipeline.py
@@ -1009,8 +1009,10 @@ class BufferModePipeline:
             # Nothing spliced: keep the surfaced host-hit fields truthful.
             req.host_hit_length = 0
             req.swa_host_hit_length = 0
-            req.storage_hit_length = 0
-            req.storage_hit_start = None
+            # A peer-covered prefix remains an L3 hit even if the tail drops.
+            req.storage_hit_length = req.fulfilled_storage_hit_len(
+                len(req.prefix_indices)
+            )
             req.host_hit_is_storage = False
             return unchanged
 
@@ -1018,6 +1020,7 @@ class BufferModePipeline:
         # must never splice (wrong-namespace publish = duplicate slot
         # ownership); unreachable while the prefetch key is request-derived.
         if f.extra_key != req.extra_key or f.cache_salt != req.cache_salt:
+            req.storage_hit_length = 0
             logger.error(
                 "HiCache staged prefetch dropped req=%s reason=namespace "
                 "staged=%s req=%s",

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -202,6 +202,7 @@ class HiRadixCache(RadixCache):
         # track per-request tokens loaded from storage (L3 hits)
         # key: request_id, value: number of tokens actually loaded from storage
         self.prefetch_loaded_tokens_by_reqid: dict[str, int] = {}
+        self.prefetch_loaded_start_by_reqid: dict[str, int] = {}
         self.work_list: List[torch.distributed.Work] = []
         # todo: dynamically adjust the threshold
         self.write_through_threshold = (
@@ -795,6 +796,7 @@ class HiRadixCache(RadixCache):
         self.token_to_kv_pool_host.clear()
         # Clear per-request tracking dicts
         self.prefetch_loaded_tokens_by_reqid.clear()
+        self.prefetch_loaded_start_by_reqid.clear()
         self.evictable_host_leaves.clear()
         super().reset()
 
@@ -1681,9 +1683,16 @@ class HiRadixCache(RadixCache):
         last_host_node.release_host()
         self.cache_controller.prefetch_tokens_occupied -= len(prefetch_key)
 
-        # Track tokens actually loaded from storage for this request (L3 hits)
+        # Attribute the completed L3 span, including concurrent insert dedup.
         loaded_from_storage = min_completed_tokens - matched_length
-        self.prefetch_loaded_tokens_by_reqid[req_id] = loaded_from_storage
+        self.prefetch_loaded_tokens_by_reqid[req_id] = min_completed_tokens
+        if min_completed_tokens > 0:
+            storage_start = 0
+            node = last_host_node
+            while node.parent is not None:
+                storage_start += len(node.key)
+                node = node.parent
+            self.prefetch_loaded_start_by_reqid[req_id] = storage_start
 
         if self.enable_storage_metrics:
             self.storage_metrics_collector.log_prefetched_tokens(loaded_from_storage)
@@ -1724,7 +1733,13 @@ class HiRadixCache(RadixCache):
         Returns 0 if no prefetch was done or was revoked.
         This should be called after check_prefetch_progress() returns True.
         """
-        return self.prefetch_loaded_tokens_by_reqid.pop(req_id, 0)
+        return self.pop_prefetch_loaded_span(req_id)[0]
+
+    def pop_prefetch_loaded_span(self, req_id: str) -> tuple[int, Optional[int]]:
+        return (
+            self.prefetch_loaded_tokens_by_reqid.pop(req_id, 0),
+            self.prefetch_loaded_start_by_reqid.pop(req_id, None),
+        )
 
     def pop_storage_prefetch_miss(self, req_id: str) -> bool:
         """Storage prefetch miss markers are not tracked on the dense path;
@@ -2002,6 +2017,7 @@ class HiRadixCache(RadixCache):
     def release_aborted_request(self, rid: str):
         # Clean up storage hit tracking for aborted request
         self.prefetch_loaded_tokens_by_reqid.pop(rid, None)
+        self.prefetch_loaded_start_by_reqid.pop(rid, None)
 
         if rid not in self.ongoing_prefetch:
             return

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -2074,19 +2074,19 @@ class UnifiedRadixCache(BasePrefixCache):
                 host_indices[: insert_result.prefix_len]
             )
             loaded_from_storage = completed_tokens - insert_result.prefix_len
-            # Cache mode has only completed L3 -> L2 here. Keep the usable
-            # storage span unresolved until admission proves that L2 -> L1
-            # load-back actually materialized it for this request.
-            self._resolve_storage_prefetch_tokens(req_id, insert_result.prefix_len)
+            # Resolve the full completed span at admission, including tokens
+            # concurrently inserted by another request.
 
         self.dec_host_lock_ref(last_host_node_id, anchor_lock_params)
         del self.ongoing_prefetch[req_id]
         self.cache_controller.prefetch_tokens_occupied -= len(prefetch_key)
 
-        self.prefetch_loaded_tokens_by_reqid[req_id] = loaded_from_storage
-        if loaded_from_storage > 0:
+        self.prefetch_loaded_tokens_by_reqid[req_id] = (
+            0 if insert_result.host_insert_dropped else completed_tokens
+        )
+        if not insert_result.host_insert_dropped and completed_tokens > 0:
             self.prefetch_loaded_storage_start_by_reqid[req_id] = (
-                operation.storage_start + insert_result.prefix_len
+                operation.storage_start
             )
         else:
             self.prefetch_loaded_storage_start_by_reqid.pop(req_id, None)

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -104,6 +104,7 @@ class TestPrefillAdder(CustomTestCase):
         req.storage_hit_start = None
         req.host_hit_is_storage = False
         req.host_loaded_length = 0
+        req.host_loaded_spans = None
         req.materialized_host_hit_len.return_value = 0
         req.fulfilled_storage_hit_len.return_value = 0
         req.finished.return_value = False
@@ -155,6 +156,44 @@ class TestPrefillAdder(CustomTestCase):
         self.mock_tree_cache.finish_storage_prefetch_admission.assert_called_once_with(
             "storage-hit", fulfilled_tokens=0, reason="device_capacity"
         )
+
+    def test_load_back_then_alignment_rejection_preserves_tiers(self):
+        import torch
+
+        self.mock_token_allocator.available_size.return_value = 100_000
+        self.mock_token_allocator.full_available_size.return_value = 100_000
+        req = self._create_delayer_req(num_tokens=1280)
+        req.prefix_indices = torch.arange(256)
+        req.kv = SimpleNamespace(cache_protected_len=256, holds_mamba=False)
+        req.best_match_node = req.last_node
+        req.host_hit_length = 768
+        req.storage_hit_start = 768
+        req.storage_hit_length = 256
+        req.fulfilled_storage_hit_len.return_value = 256
+        req.needs_host_load_back.return_value = True
+        req.host_loaded_spans = []
+        self.mock_tree_cache.init_load_back.return_value = (
+            torch.arange(256, 1024),
+            req.last_node,
+        )
+        first = self.create_adder(self.create_running_batch(), rem_chunk_tokens=64)
+        result = first.add_one_req(
+            req, has_chunked_req=False, truncation_align_size=128
+        )
+        self.assertIs(result, AddReqResult.OTHER)
+        self.assertEqual(first.can_run_list, [])
+        self.assertEqual(req.host_loaded_spans, [(256, 1024)])
+
+        # Next round's match sees the promoted KV as a device hit.
+        req.host_hit_length = 0
+        req.needs_host_load_back.return_value = False
+        retry = self.create_adder(self.create_running_batch(), rem_chunk_tokens=512)
+        retry.add_one_req(req, has_chunked_req=False, truncation_align_size=128)
+        self.assertIn(req, retry.can_run_list)
+        self.assertEqual(retry.log_device_hit_tokens, 256)
+        self.assertEqual(retry.log_host_hit_tokens, 512)
+        self.assertEqual(retry.log_storage_hit_tokens, 256)
+        self.mock_tree_cache.init_load_back.assert_called_once()
 
     def test_retracted_storage_prefetch_accounting_is_omitted(self):
         adder = self.create_adder(self.create_running_batch())

--- a/test/registered/unit/managers/test_schedule_batch_out_of_place.py
+++ b/test/registered/unit/managers/test_schedule_batch_out_of_place.py
@@ -82,6 +82,31 @@ class TestCachedPrefixTierAttribution(unittest.TestCase):
             with self.subTest(**kwargs):
                 self.assertEqual(split_cached_prefix_by_tier(**kwargs), expected)
 
+    def test_loaded_spans_survive_rematch(self):
+        # Retry, clipped L3 tail, overlapping/disjoint loads, and declined H2D.
+        for prefix, spans, expected in [
+            (1024, [(256, 1024)], (256, 512, 256)),
+            (640, [(256, 1024)], (256, 384, 0)),
+            (896, [(256, 1024)], (256, 512, 128)),
+            (1024, [(512, 1024), (256, 768)], (256, 512, 256)),
+            (1024, [(256, 512), (768, 1024)], (512, 256, 256)),
+            (256, [], (256, 0, 0)),
+            (1024, [], (768, 0, 256)),  # Entire L3 span supplied by a peer.
+        ]:
+            with self.subTest(prefix=prefix, spans=spans):
+                self.assertEqual(
+                    split_cached_prefix_by_tier(
+                        prefix, 0, 256, 768, host_loaded_spans=spans
+                    ),
+                    expected,
+                )
+        self.assertEqual(
+            split_cached_prefix_by_tier(
+                1024, 0, 768, 256, True, host_loaded_spans=[(256, 1024)]
+            ),
+            (256, 0, 768),
+        )
+
 
 def make_schedule_batch(bs: int, **overrides) -> ScheduleBatch:
     batch = ScheduleBatch(reqs=overrides.pop("reqs"))

--- a/test/registered/unit/mem_cache/test_hiradix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_hiradix_cache_unit.py
@@ -3,6 +3,8 @@
 import os
 import unittest
 from array import array
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import torch
 
@@ -21,6 +23,51 @@ register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=15, stage="stage-b", runner_config="1-gpu-small-amd")
 
 PAGE_SIZE = 2
+
+
+class TestHiRadixPrefetchAttribution(unittest.TestCase):
+    def make_completed_prefetch(self, matched_length=128):
+        cache = HiRadixCache.__new__(HiRadixCache)
+        root = SimpleNamespace(parent=None)
+        parent = SimpleNamespace(parent=root, key=list(range(128)))
+        anchor = SimpleNamespace(
+            parent=parent, key=list(range(128)), release_host=MagicMock()
+        )
+        operation = SimpleNamespace(
+            request_id="prefetch",
+            completed_tokens=512,
+            host_indices=list(range(512)),
+            hash_value=["hash"] * 4,
+        )
+        cache.page_size = 128
+        cache.ongoing_prefetch = {"prefetch": (anchor, list(range(512)), operation)}
+        cache.cache_controller = MagicMock()
+        cache.cache_controller.prefetch_tokens_occupied = 512
+        cache.enable_storage_metrics = False
+        cache.prefetch_loaded_tokens_by_reqid = {}
+        cache.prefetch_loaded_start_by_reqid = {}
+        cache._clamp_prefetch_result = MagicMock(return_value=512)
+        # Another request has already inserted the first 128 fetched tokens.
+        cache._insert_helper_host = MagicMock(return_value=matched_length)
+        cache._handle_prefetch_result(operation)
+        return cache
+
+    def test_storage_span_includes_concurrently_inserted_prefix(self):
+        for matched in (0, 128, 512):
+            with self.subTest(matched=matched):
+                cache = self.make_completed_prefetch(matched)
+                self.assertEqual(cache.pop_prefetch_loaded_span("prefetch"), (512, 256))
+                self.assertEqual(cache.pop_prefetch_loaded_span("prefetch"), (0, None))
+
+    def test_legacy_pop_cleans_up_span(self):
+        cache = self.make_completed_prefetch()
+        self.assertEqual(cache.pop_prefetch_loaded_tokens("prefetch"), 512)
+        self.assertEqual(cache.prefetch_loaded_start_by_reqid, {})
+
+    def test_abort_cleans_up_span(self):
+        cache = self.make_completed_prefetch()
+        cache.release_aborted_request("prefetch")
+        self.assertEqual(cache.pop_prefetch_loaded_span("prefetch"), (0, None))
 
 
 class TestHiRadixCacheKVEvents(CustomTestCase):

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -8900,6 +8900,7 @@ class TestPrefetchCommitOrdering(CustomTestCase):
         operation = mock.MagicMock()
         operation.request_id = "req"
         operation.completed_tokens = 8
+        operation.storage_start = 16
         cache.ongoing_prefetch = {
             operation.request_id: (
                 7,
@@ -8917,6 +8918,7 @@ class TestPrefetchCommitOrdering(CustomTestCase):
         cache._check_hybrid_prefetch_result.return_value = 8
         cache.cache_controller.prefetch_tokens_occupied = 100
         cache.prefetch_loaded_tokens_by_reqid = {}
+        cache.prefetch_loaded_storage_start_by_reqid = {}
         cache._can_terminate_prefetch.return_value = True
         cache.pp_rank = 0
 
@@ -8944,6 +8946,10 @@ class TestPrefetchCommitOrdering(CustomTestCase):
             order.commit.call_args.kwargs["cache_actions"], insert_result.cache_actions
         )
         self.assertEqual(cache.ongoing_prefetch, {})
+        # Dedup changes ownership, not the source of this request's cache hit.
+        self.assertEqual(cache.prefetch_loaded_tokens_by_reqid["req"], 8)
+        self.assertEqual(cache.prefetch_loaded_storage_start_by_reqid["req"], 16)
+        cache._resolve_storage_prefetch_tokens.assert_not_called()
 
 
 class TestUnifiedRadixPrefetchCorruption(CustomTestCase):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fix prefill cache-hit attribution so L2/L3 hits retain their source after promotion to GPU. Apply the same attribution to request responses and prefill metrics.

This fixes:
- **Scheduling retries after H2D:** preserve L2/L3 attribution when a request loads KV onto GPU but is deferred by admission checks and rematches the prefix in a later round.
- **Concurrent L3 prefetch deduplication:** retain the full completed L3 fetch span, including tokens already inserted by another request.
- **Buffer-only shared-prefix coverage:** preserve L3 attribution when another request partially or fully populates the GPU prefix while prefetch is staged.
- **Partial eviction or failed load-back:** clip attribution to the cached prefix actually used and count overlapping H2D loads only once.

Reuse existing L3 span tracking in UnifiedCache, add it to HiRadixCache, and keep prefetch lifecycle accounting consistent with admission-time attribution.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35556009597](https://github.com/sgl-project/sglang/actions/runs/35556009597)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35556009338](https://github.com/sgl-project/sglang/actions/runs/35556009338)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35556009528](https://github.com/sgl-project/sglang/actions/runs/35556009528)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->