### PR TITLE
[AMD] Add the AgentX Kimi-K3 MXFP4 agentic-coding benchmark on MI35x

### DIFF
--- a/.github/workflows/nightly-benchmark-amd.yml
+++ b/.github/workflows/nightly-benchmark-amd.yml
@@ -38,6 +38,7 @@ on:
         options:
           - 'all'
           - qwen35-mxfp4-agentic-mtp-mi35x
+          - kimi-k3-mxfp4-agentic-mi35x
       workload_env:
         description: 'Optional workload overrides, space separated (e.g. "AGENTIC_NUM_CONVERSATIONS=128 AGENTIC_MAX_TURNS=20")'
         required: false
@@ -142,5 +143,84 @@ jobs:
             -e AGENTIC_KV_OFFLOADING=${{ matrix.point.kv_offloading }} \
             -e AGENTIC_MODE=${{ matrix.point.mode }} \
             python3 run_suite.py --hw amd --suite nightly-perf-mi35x-qwen35-mxfp4-agentic-mtp --nightly --timeout-per-file 12600 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+  # ==============================================================================
+  # Kimi-K3 MXFP4, AgentX coding-agent replay and eval (no DCP, no DSPARK)
+  # ==============================================================================
+  kimi-k3-mxfp4-agentic-mi35x:
+    name: ${{ format('kimi-k3-mxfp4-agentic-mi35x {0} ({1})', matrix.point.name, matrix.rocm_version) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rocm_version: ${{ fromJson(inputs.rocm_version == 'all' && '["rocm10", "rocm724", "rocm720"]' || format('["{0}"]', inputs.rocm_version || 'rocm10')) }}
+        # The recipe sweeps concurrency 1, 4, 8, 16, 32 and 48 and launches a
+        # server per point. Each point here is one 8-GPU MI35x slot spent
+        # loading a 1.56 TB checkpoint, so the schedule takes the two ends of
+        # the sweep -- which are also the recipe's two HiCache rows, 80 GB below
+        # concurrency 8 and 145 GB above -- plus its eval pass. The rest are one
+        # workload_env override away (AGENTIC_CONCURRENCY=16).
+        point:
+          - { name: c4-hicache80, concurrency: 4, mode: replay }
+          - { name: c48-hicache145, concurrency: 48, mode: replay }
+          # AgentX scores one configuration rather than the whole sweep, so this
+          # takes the top of the sweep. It is the first point to drop if the
+          # 8-GPU MI35x budget gets tight: nightly-8-gpu-mi35x-kimi-k3-rocm720
+          # already scores K3, though on the Day-0 recipe rather than this one.
+          - { name: c48-eval-gsm8k, concurrency: 48, mode: eval }
+    if: github.repository == 'sgl-project/sglang' && (!inputs.benchmark_select || inputs.benchmark_select == 'all' || inputs.benchmark_select == 'kimi-k3-mxfp4-agentic-mi35x')
+    runs-on: linux-mi35x-gpu-8
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Setup docker (${{ matrix.rocm_version }})
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version ${{ matrix.rocm_version }}
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          ENABLE_CACHE_HOST: "1"
+
+      # Matches nightly-8-gpu-mi35x-kimi-k3-rocm720 rather than the Qwen job
+      # above: K3 runs on the aiter MXFP4 MoE and KDA kernels, so the aiter
+      # build is not skipped here.
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
+          bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
+
+      - name: Check model cache space
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout \
+            bash scripts/ci/amd/check_hf_cache_space.sh \
+            moonshotai/Kimi-K3 1600
+
+      # Longer than the Qwen points: the 1.56 TB MXFP4 checkpoint dominates
+      # startup before any turn is replayed, which is why the sibling K3
+      # accuracy and perf steps each budget 300 minutes of their own.
+      - name: Kimi-K3-MXFP4 agentic replay (${{ matrix.point.name }})
+        timeout-minutes: 360
+        env:
+          WORKLOAD_ENV: ${{ inputs.workload_env }}
+        run: |
+          > github_summary.md  # Clear summary file
+          ENV_ARGS=()
+          for override in $WORKLOAD_ENV; do
+            ENV_ARGS+=(-e "$override")
+          done
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_MOE_COPY_WEIGHT_VIEWS_BEFORE_H2D=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            "${ENV_ARGS[@]}" \
+            -e AGENTIC_CONCURRENCY=${{ matrix.point.concurrency }} \
+            -e AGENTIC_MODE=${{ matrix.point.mode }} \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-mi35x-kimi-k3-agentic --nightly --timeout-per-file 18000 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}

--- a/test/registered/amd/agentic/test_kimi_k3_mxfp4_agentic_mi35x.py
+++ b/test/registered/amd/agentic/test_kimi_k3_mxfp4_agentic_mi35x.py
@@ -55,13 +55,14 @@ What intentionally differs
   ``SGLANG_K3_AITER_{KDA_GROUP64,B2_FUSIONS,MOE_PREROUTE_FP8,LATENT_TAIL_FP8}``,
   ``SGLANG_K3_AITER_MLA_Q_CACHE_FUSION``, ``SGLANG_K3_AITER_TUNED_MOE_FRONT*``,
   ``SGLANG_K3_PREROUTE_PREACTIVATED_SHARED``, ``SGLANG_K3_MOE_LATENT_MXFP4``,
-  ``SGLANG_K3_PTPC_FP8*`` and ``AITER_FLYDSL_STAGE1_SCRATCH_REUSE`` -- are read
-  only by the pinned ``yuychang/sglang`` + ``yuychang/aiter``
-  ``kimi_k3_mxmoe_16k`` branches the recipe runs against, so exporting them here
-  would be dead configuration that reads as if it were doing something. This is
-  the recipe's own ``ENABLE_YUYUN_KERNEL_ENV=0`` ("AITER-only") arm plus the
-  in-tree subset, and it is the main reason the throughput here is expected to
-  sit below a published AgentX number on the same hardware.
+  ``SGLANG_K3_PTPC_FP8*``, ``AITER_FLYDSL_DISABLE_MXMOE_V2`` and
+  ``AITER_FLYDSL_STAGE1_SCRATCH_REUSE`` -- are read only by the pinned
+  ``yuychang/sglang`` + ``yuychang/aiter`` ``kimi_k3_mxmoe_16k`` branches the
+  recipe runs against, so exporting them here would be dead configuration that
+  reads as if it were doing something. This is the recipe's own
+  ``ENABLE_YUYUN_KERNEL_ENV=0`` ("AITER-only") arm plus the in-tree subset, and
+  it is the main reason the throughput here is expected to sit below a published
+  AgentX number on the same hardware.
 * ``HSA_NO_SCRATCH_RECLAIM`` is not set: the recipe gates it on MEC firmware
   older than 177, and ``docker/rocm.Dockerfile`` already exports it for every
   ROCm CI container.
@@ -234,7 +235,6 @@ COMMON_ENV = {
     "AITER_FLYDSL_FORCE": "1",
     "AITER_SITUV2_A4W4": "1",
     "AITER_SITUV2_A8W4": "0",
-    "AITER_FLYDSL_DISABLE_MXMOE_V2": "0",
     "SGLANG_AITER_MLA_PERSIST": "0",
     "SGLANG_AITER_FP8_PREFILL_ATTN": "0",
     "SGLANG_AITER_HONOR_EXPLICIT_MEM_FRACTION": "1",

--- a/test/registered/amd/agentic/test_kimi_k3_mxfp4_agentic_mi35x.py
+++ b/test/registered/amd/agentic/test_kimi_k3_mxfp4_agentic_mi35x.py
@@ -1,0 +1,719 @@
+"""MI35x agentic-replay throughput for Kimi-K3 MXFP4, the no-DCP / no-DSPARK arm.
+
+Port of InferenceX's AgentX recipe
+``benchmarks/single_node/agentic/kimik3_fp4_mi355x_sglang_nomtp.sh``
+(https://github.com/SemiAnalysisAI/InferenceX, config key
+``kimik3-fp4-mi355x-sglang-agentic-nomtp``, which is the orchestrator arm
+``SERVER_TARGETS=release SERVER_RECIPES=base MTP_MODES=non_dspark DCP_SIZE=1
+DCP_COMM_BACKEND=ag_rs TEST_SUITES=agentx``). Sibling of
+``test_qwen35_mxfp4_agentic_mtp_mi35x.py``: same driver, same corpus, same
+report, a different serving recipe. Dispatched by
+``.github/workflows/nightly-benchmark-amd.yml``, which is where the
+reporting-only benchmarks live.
+
+Why this exists next to ``perf/mi35x/test_kimi_k3_perf_mi35x.py``: that test
+sweeps ``bench_one_batch_server`` at 4k in / 512 out with
+``--disable-radix-cache``, so it deliberately measures K3 with prefix reuse
+turned *off*. This recipe is the opposite workload -- a 1M context window, a
+145 GB host KV tier, ``page_size=128`` and fp8 KV are all in it because the
+target is long, growing, cache-heavy coding-agent conversations. Nothing in the
+existing K3 coverage moves when prefix-cache behaviour, the HiCache host tier,
+or the KDA state pool under long context regresses; this does.
+
+What the port keeps
+-------------------
+Parallelism and the DCP pair, aiter prefill/decode attention, bf16 weights with
+fp8 KV, the mamba/KDA state-pool sizing, page size, chunked prefill and prefill
+caps, the 1M context window, the ``kimi_k3`` reasoning and tool-call parsers,
+the HiCache CPU tier, the multithreaded loader, the watchdog, and the derived
+``max_running_requests`` / ``cuda_graph_max_bs_decode`` / ``max_mamba_cache_size``
+arithmetic -- all the recipe's values, per concurrency (see :func:`recipe_arm`).
+
+The recipe launches one server per concurrency point and sizes all three derived
+numbers from that point, so this file does too: concurrency is a CI matrix axis,
+not a loop inside one server. The cost is one 1.56 TB checkpoint load per point,
+which is why the scheduled matrix carries three of the recipe's six
+concurrencies rather than all of them.
+
+What intentionally differs
+--------------------------
+* The driver is :mod:`sglang.test.agentic_trace_replay`, not aiperf, whose
+  ``inferencex-agentx-mvp`` scenario is not installable from this repo, and the
+  corpus comes from :mod:`sglang.test.agentic_trace_utils`. See that module for
+  what survives the conversion. The absolute number is therefore *not*
+  comparable to a published AgentX submission; it is comparable to this test's
+  own history, which is what a nightly needs.
+* The corpus is the uncapped ``cc-traces-weka-062126``, not the 256k-capped
+  variant the Qwen port replays: K3's native window is 1M tokens, which is the
+  cap AgentX picks the uncapped corpus for. The two only diverge past roughly
+  turn 60 of a trajectory, so at the default turn cap they are equivalent; the
+  uncapped one is the default so that raising ``AGENTIC_MAX_TURNS`` actually
+  reaches the window this recipe configures.
+* Of the recipe's ``ENABLE_YUYUN_KERNEL_ENV`` block only the flags that exist
+  upstream are exported (see :data:`YUYUN_KERNEL_ENV`). The rest --
+  ``SGLANG_K3_AITER_M16384_PROFILE``, ``SGLANG_K3_AITER_MLA_GATE``,
+  ``SGLANG_K3_AITER_{KDA_GROUP64,B2_FUSIONS,MOE_PREROUTE_FP8,LATENT_TAIL_FP8}``,
+  ``SGLANG_K3_AITER_MLA_Q_CACHE_FUSION``, ``SGLANG_K3_AITER_TUNED_MOE_FRONT*``,
+  ``SGLANG_K3_PREROUTE_PREACTIVATED_SHARED``, ``SGLANG_K3_MOE_LATENT_MXFP4``,
+  ``SGLANG_K3_PTPC_FP8*`` and ``AITER_FLYDSL_STAGE1_SCRATCH_REUSE`` -- are read
+  only by the pinned ``yuychang/sglang`` + ``yuychang/aiter``
+  ``kimi_k3_mxmoe_16k`` branches the recipe runs against, so exporting them here
+  would be dead configuration that reads as if it were doing something. This is
+  the recipe's own ``ENABLE_YUYUN_KERNEL_ENV=0`` ("AITER-only") arm plus the
+  in-tree subset, and it is the main reason the throughput here is expected to
+  sit below a published AgentX number on the same hardware.
+* ``HSA_NO_SCRATCH_RECLAIM`` is not set: the recipe gates it on MEC firmware
+  older than 177, and ``docker/rocm.Dockerfile`` already exports it for every
+  ROCm CI container.
+* DSPARK stays off, which is the arm this recipe pins
+  (``MTP_MODES=non_dspark``). ``AGENTIC_SPEC_DECODE=auto`` restores the
+  orchestrator's schedule (block size 7 up to concurrency 8, 3 up to 16, off
+  above). When it is on, acceptance length is measured rather than pinned
+  through ``SGLANG_SIMULATE_ACC_LEN``: AgentX pins it so a cross-framework
+  comparison is not confounded by draft quality, but inside sglang's own
+  nightly the draft model is fixed and a real acceptance drop is a regression we
+  want to see. ``AGENTIC_SIMULATE_ACC_LEN`` restores the pin.
+* DCP stays at 1, the recipe's arm. ``AGENTIC_DCP_SIZE`` above 1 switches the
+  comm backend to ``a2a`` and turns on the in-tree Gluon MLA DCP path, but the
+  recipe's other two DCP env vars (``SGLANG_USE_AITER_GLUON_MLA_DCP``,
+  ``SGLANG_EXPERIMENTAL_AITER_DCP_FP8``) also only exist in the fork, so that
+  arm measures the in-tree DCP path and not the recipe's.
+* The recipe's GPU-drain wait, ``hf download`` and aiperf venv bootstrap are
+  InferenceX harness concerns; CI has ``ensure_vram_clear.sh``, the runners'
+  shared HF cache, and no aiperf.
+
+There is no throughput gate -- the numbers go to the step summary and the run
+itself is the guard, since this config only completes if the aiter MXFP4 MoE
+path, the KDA state pool and the HiCache host tier all survive a long-context
+agentic workload. The one hard check beyond "every turn completed" is that the
+state pool did not clamp the batch below the concurrency in the report's title,
+because a clamped run measures a different workload than the one it is labelled
+with.
+
+Registry: nightly-perf-8-gpu-mi35x-kimi-k3-agentic suite
+"""
+
+import os
+import tempfile
+import unittest
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Optional
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.agentic_trace_replay import run_agentic_replay
+from sglang.test.agentic_trace_utils import ensure_agentic_trace_file, weka_trace_url
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+
+# The 1.56 TB MXFP4 checkpoint dominates: the sibling K3 accuracy and perf jobs
+# budget 150 min each for load plus a short measured phase, and a replay point
+# adds ~45 min of workload on top at the largest concurrency.
+register_amd_ci(
+    est_time=12600,
+    suite="nightly-perf-8-gpu-mi35x-kimi-k3-agentic",
+    nightly=True,
+)
+
+# K3's weights are natively MXFP4, so there is no separate quantized repo to
+# point at -- the same checkpoint the accuracy and perf tests serve.
+MODEL_PATH = os.environ.get("KIMI_K3_MODEL_PATH", "moonshotai/Kimi-K3")
+
+# AgentX runs this recipe twice: a throughput replay, and an EVAL_ONLY pass that
+# scores the served model. Both modes share this file and its server
+# configuration, and each skips the other's case rather than launching a second
+# 1.56 TB server it would not use.
+MODE = os.environ.get("AGENTIC_MODE", "replay")
+
+# The recipe refuses anything but TP8: MXFP4 K3 is ~195 GB per GPU of the 288 GB
+# a gfx950 carries, so TP8 is the only topology it fits in. Not a knob.
+TP_SIZE = 8
+EP_SIZE = int(os.environ.get("AGENTIC_EP_SIZE", "1"))
+CONCURRENCY = int(os.environ.get("AGENTIC_CONCURRENCY", "48"))
+
+# AgentX runs every concurrency for the same wall-clock duration, so its low
+# concurrencies simply serve fewer turns. This replay is closed-loop instead, so
+# sizing the corpus to the concurrency gives every point the same per-channel
+# work, which keeps the sweep comparable and each point inside the job timeout.
+# The floor keeps the lowest concurrencies from measuring a handful of turns.
+NUM_CONVERSATIONS = int(
+    os.environ.get("AGENTIC_NUM_CONVERSATIONS") or max(8, 2 * CONCURRENCY)
+)
+# 24 turns carries each trajectory to 110-150k tokens of context in this corpus,
+# which is what makes the host tier the thing being measured: K3's fp8 MLA KV is
+# (kv_lora_rank 512 + qk_rope 64) bytes per token per full-attention layer over
+# 24 such layers, i.e. ~13.5 KiB/token, so the recipe's 145 GB tier holds ~11M
+# tokens -- about what 96 conversations at that context length occupy. Raising
+# this is the lever for pushing further into the 1M window.
+MAX_TURNS = int(os.environ.get("AGENTIC_MAX_TURNS", "24"))
+# Unset replays the corpus' own per-turn reply lengths, which is what keeps the
+# prompt growth faithful; set it to force a uniform decode length instead.
+OUTPUT_LEN = int(os.environ.get("AGENTIC_OUTPUT_LEN", "0")) or None
+KV_OFFLOADING = os.environ.get("AGENTIC_KV_OFFLOADING", "hicache")
+# The recipe's MTP_MODES=non_dspark arm. "auto" restores the DSPARK schedule.
+SPEC_DECODE = os.environ.get("AGENTIC_SPEC_DECODE", "false")
+SIMULATE_ACC_LEN = os.environ.get("AGENTIC_SIMULATE_ACC_LEN", "")
+DSPARK_DRAFT_PATH = os.environ.get("AGENTIC_DSPARK_DRAFT", "RadixArk/Kimi-K3-DSpark")
+DCP_SIZE = int(os.environ.get("AGENTIC_DCP_SIZE", "1"))
+
+# The uncapped corpus, because K3's native context is 1M tokens; see the module
+# docstring for why that is the right cap for this model.
+WEKA_TRACE_REPO = os.environ.get(
+    "AGENTIC_TRACE_REPO", "semianalysisai/cc-traces-weka-062126"
+)
+
+# AgentX scores its eval pass with lm-eval's gsm8k. This asks the same questions
+# through sglang's few-shot *completion* scorer, at the 8 shots
+# test_kimi_k3_eval_mi35x.py uses, so the score is comparable to that test's.
+# Completion rather than chat is not a style preference for K3: thinking is
+# permanently on and the chat path routes the answer through reasoning_content,
+# which would leave message.content empty and score 0. The gate sits below the
+# 0.92 the plain K3 accuracy test holds (it measured 0.956), since this recipe
+# also serves fp8 KV, the A4W4 MoE kernels and the aiter attention path.
+EVAL_NUM_EXAMPLES = int(os.environ.get("AGENTIC_EVAL_NUM_EXAMPLES", "1319"))
+EVAL_NUM_SHOTS = int(os.environ.get("AGENTIC_EVAL_NUM_SHOTS", "8"))
+EVAL_MAX_NEW_TOKENS = int(os.environ.get("AGENTIC_EVAL_MAX_NEW_TOKENS", "512"))
+EVAL_ACC_THRESHOLD = float(os.environ.get("AGENTIC_EVAL_ACC_THRESHOLD", "0.90"))
+
+# A clamped state pool means the server admitted fewer requests than the
+# concurrency this run reports, so the number would be mislabelled. Set to 1 to
+# report it and keep going instead.
+ALLOW_CLAMPED_BATCH = os.environ.get("AGENTIC_ALLOW_CLAMPED_BATCH", "0") == "1"
+
+SERVER_LAUNCH_TIMEOUT = int(os.environ.get("AGENTIC_SERVER_TIMEOUT", "9000"))
+
+RESULT_DIR = "performance_results_kimi_k3_mxfp4_agentic_mi35x"
+
+# Fixed columns of the recipe's per-concurrency table.
+MEM_FRACTION_STATIC = os.environ.get("AGENTIC_MEM_FRACTION_STATIC", "0.85")
+PAGE_SIZE = os.environ.get("AGENTIC_PAGE_SIZE", "128")
+CHUNKED_PREFILL_SIZE = os.environ.get("AGENTIC_CHUNKED_PREFILL_SIZE", "16384")
+MAX_PREFILL_TOKENS = os.environ.get("AGENTIC_MAX_PREFILL_TOKENS", "16384")
+CONTEXT_LENGTH = os.environ.get("AGENTIC_CONTEXT_LENGTH", "1048576")
+WATCHDOG_TIMEOUT = os.environ.get("AGENTIC_WATCHDOG_TIMEOUT", "3600")
+# The recipe's own ceiling on decode graph capture; K3 captures across 93
+# attention and 92 MoE layers, so capturing above the admission ceiling is
+# expensive and buys nothing.
+CUDA_GRAPH_CAP = 256
+# One state slot per running request, plus the retention/COW headroom and the
+# overlap scheduler's ping-pong track buffer, is 5 under the default
+# extra_buffer mamba radix strategy -- so the recipe's 5x multiplier is exactly
+# max_running_requests' worth of slots and nothing more. ReplaySSM keeps this
+# true under DSPARK: its intermediate states live on a fixed ring rather than on
+# the per-request slot budget.
+MAMBA_SLOTS_PER_REQUEST = int(os.environ.get("AGENTIC_MAMBA_SLOTS_PER_REQUEST", "5"))
+
+HICACHE_WRITE_POLICY = os.environ.get("HICACHE_WRITE_POLICY", "write_through")
+HICACHE_IO_BACKEND = os.environ.get("HICACHE_IO_BACKEND", "direct")
+HICACHE_MEM_LAYOUT = os.environ.get("HICACHE_MEM_LAYOUT", "page_first_direct")
+
+# Recipe env, restricted to what this tree reads. SGLANG_AITER_{MLA_GLUON,
+# MLA_PERSIST,FP8_PREFILL_ATTN} all default to on, so the recipe is explicitly
+# turning three aiter fast paths off; AITER_SITUV2_A4W4 selects the MXFP4-native
+# A4W4 SiTU expert kernels, where the K3 accuracy and perf tests take the W4A8
+# ones. PYTHONNOUSERSITE keeps a user site-packages directory from shadowing the
+# container's sglang, as in the AgentX launcher. AITER_FLYDSL_FORCE is read by
+# AITER itself rather than sglang and will not grep to anything in-tree.
+COMMON_ENV = {
+    "PYTHONNOUSERSITE": "1",
+    "SGLANG_USE_AITER": "1",
+    "SGLANG_AITER_K3_OPT": "1",
+    "AITER_FLYDSL_FORCE": "1",
+    "AITER_SITUV2_A4W4": "1",
+    "AITER_SITUV2_A8W4": "0",
+    "AITER_FLYDSL_DISABLE_MXMOE_V2": "0",
+    "SGLANG_AITER_MLA_PERSIST": "0",
+    "SGLANG_AITER_FP8_PREFILL_ATTN": "0",
+    "SGLANG_AITER_HONOR_EXPLICIT_MEM_FRACTION": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "0",
+    "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "0",
+    "ROCM_QUICK_REDUCE_QUANTIZATION": "INT4",
+    "SAFETENSORS_FAST_GPU": "1",
+    "TORCH_BLAS_PREFER_HIPBLASLT": "1",
+    "SGLANG_TIMEOUT_KEEP_ALIVE": "900",
+}
+
+# The in-tree half of the recipe's ENABLE_YUYUN_KERNEL_ENV block; the rest is
+# fork-only, see the module docstring. Pinning the FlyDSL source to "sglang"
+# rather than leaving it on "auto" also means a missing in-tree kernel fails the
+# run instead of silently measuring AITER's copy.
+YUYUN_KERNEL_ENV = {
+    "SGLANG_K3_FLYDSL_SOURCE": "sglang",
+    "SGLANG_K3_KDA_FUSED_BACKEND": "aiter",
+    "SGLANG_K3_RADIX4_TOPK": "1",
+    "SGLANG_MLA_DECODE_TUNE": "1",
+}
+ENABLE_YUYUN_KERNEL_ENV = os.environ.get("AGENTIC_YUYUN_KERNEL_ENV", "1") == "1"
+
+
+@dataclass(frozen=True)
+class RecipeArm:
+    """One row of the recipe's per-concurrency table.
+
+    ``concurrency`` is the workload; everything else is what the recipe derives
+    from it to serve that workload.
+    """
+
+    concurrency: int
+    max_running_requests: int
+    cuda_graph_max_bs: int
+    max_mamba_cache_size: int
+    hicache_size_gb: int
+    dcp_size: int
+    dcp_comm_backend: str
+    dspark_block_size: int
+    golden_accept_len: float
+
+    @property
+    def spec_enabled(self) -> bool:
+        return self.dspark_block_size > 0
+
+
+def _int_env(name: str, default: int) -> int:
+    """``${NAME:-default}``, so every derived number stays overridable."""
+    return int(os.environ.get(name) or default)
+
+
+def recipe_arm(
+    concurrency: int,
+    spec_decode: str = SPEC_DECODE,
+    dcp_size: int = DCP_SIZE,
+) -> RecipeArm:
+    """The recipe's arm for one concurrency point.
+
+    Reproduces the orchestrator's table::
+
+        CONC  mem   mrr  graph  mamba(=5*mrr)  page  chunk  spec  dcp
+          1   0.85    2      2        10        128  16384  off    1
+          4   0.85    8      8        40        128  16384  off    1
+          8   0.85   16     16        80        128  16384  off    1
+         16   0.85   32     32       160        128  16384  off    1
+         32   0.85   64     64       320        128  16384  off    1
+         48   0.85   96     96       480        128  16384  off    1
+    """
+    max_running_requests = _int_env("AGENTIC_MAX_RUNNING_REQUESTS", 2 * concurrency)
+    cuda_graph_max_bs = min(
+        _int_env("AGENTIC_CUDA_GRAPH_MAX_BS", max_running_requests), CUDA_GRAPH_CAP
+    )
+
+    # DSPARK's schedule in the orchestrator: the draft only pays for itself
+    # while decode is latency-bound, so it is off once the batch is large.
+    dspark_block_size, golden_accept_len = 0, 0.0
+    if spec_decode == "auto":
+        if concurrency <= 8:
+            dspark_block_size, golden_accept_len = 7, 3.84
+        elif concurrency <= 16:
+            dspark_block_size, golden_accept_len = 3, 3.00
+
+    # Host DRAM per rank. The low row is the recipe's own: at concurrency 4 the
+    # live working set is a fifth of what it is at 48, and the pinned host pool
+    # is not free.
+    hicache_size_gb = _int_env(
+        "AGENTIC_HICACHE_SIZE_GB", 80 if concurrency <= 4 else 145
+    )
+
+    return RecipeArm(
+        concurrency=concurrency,
+        max_running_requests=max_running_requests,
+        cuda_graph_max_bs=cuda_graph_max_bs,
+        max_mamba_cache_size=_int_env(
+            "AGENTIC_MAX_MAMBA_CACHE_SIZE",
+            MAMBA_SLOTS_PER_REQUEST * max_running_requests,
+        ),
+        hicache_size_gb=hicache_size_gb,
+        dcp_size=dcp_size,
+        # ag_rs is the recipe's choice at dcp1, where there is no cross-rank
+        # attention reduction to fuse and a2a would only add a hop.
+        dcp_comm_backend=os.environ.get("AGENTIC_DCP_COMM_BACKEND")
+        or ("ag_rs" if dcp_size == 1 else "a2a"),
+        dspark_block_size=dspark_block_size,
+        golden_accept_len=golden_accept_len,
+    )
+
+
+def build_server_args(arm: RecipeArm) -> list:
+    """Server flags from kimik3_fp4_mi355x_sglang_nomtp.sh."""
+    args = [
+        "--trust-remote-code",
+        "--dtype",
+        "bfloat16",
+        "--kv-cache-dtype",
+        "fp8_e4m3",
+        "--tp-size",
+        str(TP_SIZE),
+        "--dcp-size",
+        str(arm.dcp_size),
+        "--dcp-comm-backend",
+        arm.dcp_comm_backend,
+        "--prefill-attention-backend",
+        "aiter",
+        "--decode-attention-backend",
+        "aiter",
+        "--mem-fraction-static",
+        MEM_FRACTION_STATIC,
+        "--max-running-requests",
+        str(arm.max_running_requests),
+        "--cuda-graph-max-bs-decode",
+        str(arm.cuda_graph_max_bs),
+        "--max-mamba-cache-size",
+        str(arm.max_mamba_cache_size),
+        # bf16 halves the recurrent state against fp32 and so doubles the slots
+        # the same budget holds; it also moves the linear-attention decode
+        # backend on some platforms, which is why the recipe pins it explicitly.
+        "--mamba-ssm-dtype",
+        "bfloat16",
+        # 4x the default: a coarser decode-time state snapshot costs resume
+        # granularity, which an agentic workload spends on prefix hits rather
+        # than mid-decode resumes, and saves the state copies.
+        "--mamba-track-interval",
+        "1024",
+        "--page-size",
+        PAGE_SIZE,
+        "--chunked-prefill-size",
+        CHUNKED_PREFILL_SIZE,
+        "--max-prefill-tokens",
+        MAX_PREFILL_TOKENS,
+        "--context-length",
+        CONTEXT_LENGTH,
+        "--tool-call-parser",
+        "kimi_k3",
+        "--reasoning-parser",
+        "kimi_k3",
+        "--model-loader-extra-config",
+        '{"enable_multithread_load": true}',
+        "--watchdog-timeout",
+        WATCHDOG_TIMEOUT,
+        "--enable-metrics",
+    ]
+
+    if EP_SIZE > 1:
+        args += ["--ep-size", str(EP_SIZE)]
+
+    if arm.spec_enabled:
+        args += [
+            "--speculative-algorithm",
+            "DSPARK",
+            "--speculative-draft-model-path",
+            DSPARK_DRAFT_PATH,
+            "--speculative-dspark-block-size",
+            str(arm.dspark_block_size),
+            # Keeps the draft's intermediate KDA states on a fixed ring instead
+            # of the per-request state budget, which is what lets the 5x mamba
+            # multiplier stay correct under speculation.
+            "--enable-linear-replayssm-spec",
+        ]
+
+    if KV_OFFLOADING == "hicache":
+        args += [
+            "--enable-hierarchical-cache",
+            "--hicache-size",
+            str(arm.hicache_size_gb),
+            "--hicache-write-policy",
+            HICACHE_WRITE_POLICY,
+            "--hicache-io-backend",
+            HICACHE_IO_BACKEND,
+            "--hicache-mem-layout",
+            HICACHE_MEM_LAYOUT,
+            "--enable-cache-report",
+            "--skip-server-warmup",
+        ]
+
+    return args
+
+
+def build_server_env(arm: RecipeArm) -> dict:
+    env = os.environ.copy()
+    env.update(COMMON_ENV)
+    if ENABLE_YUYUN_KERNEL_ENV:
+        env.update(YUYUN_KERNEL_ENV)
+
+    # At dcp1 there is no Gluon DCP path to take, which is the arm this recipe
+    # pins; above 1 the recipe's other two DCP env vars are fork-only, so this
+    # measures the in-tree path.
+    env["SGLANG_AITER_MLA_GLUON"] = "1" if arm.dcp_size > 1 else "0"
+
+    if arm.spec_enabled:
+        env.setdefault("SGLANG_RAGGED_VERIFY_MODE", "static")
+        # AgentX pins acceptance on the throughput side only; its eval pass
+        # keeps real target-model verification, so a pinned length is dropped
+        # there.
+        if SIMULATE_ACC_LEN and MODE != "eval":
+            env["SGLANG_SIMULATE_ACC_LEN"] = SIMULATE_ACC_LEN
+            env["SGLANG_SIMULATE_ACC_METHOD"] = "match-expected"
+            env["SGLANG_SIMULATE_ACC_TOKEN_MODE"] = "real-draft-token"
+    return env
+
+
+def _trace_cache_dir() -> str:
+    """Prefer /sgl-data, the runners' persistent mount, so this converts once."""
+    override = os.environ.get("AGENTIC_TRACE_CACHE_DIR")
+    if override:
+        return override
+    if os.path.isdir("/sgl-data") and os.access("/sgl-data", os.W_OK):
+        return "/sgl-data/agentic-traces"
+    return os.path.join(tempfile.gettempdir(), "sglang-agentic-traces")
+
+
+def resolved_batch_limits(base_url: str) -> dict:
+    """What the server settled on, which is not always what it was asked for.
+
+    The state pool is worst-case reserved and fail-loud, so a budget too small
+    for ``--max-mamba-cache-size`` clamps ``max_running_requests`` down instead
+    of overcommitting. The shell recipe greps the launch log for this; the
+    server reports it directly.
+    """
+    try:
+        response = requests.get(base_url + "/server_info", timeout=30)
+        response.raise_for_status()
+        server_info = response.json()
+    except Exception as exc:  # pragma: no cover - reported, never fatal
+        return {"error": repr(exc)}
+
+    states = server_info.get("internal_states") or [{}]
+    return {
+        "max_running_requests": states[0].get("effective_max_running_requests_per_dp"),
+        "max_mamba_cache_size": server_info.get("max_mamba_cache_size"),
+        "max_total_num_tokens": server_info.get("max_total_num_tokens"),
+    }
+
+
+def _workload_rows(arm: RecipeArm, limits: dict) -> str:
+    spec_cell = (
+        f"DSPARK block {arm.dspark_block_size}"
+        + (f" (simulated accept {SIMULATE_ACC_LEN})" if SIMULATE_ACC_LEN else "")
+        if arm.spec_enabled
+        else "off (non_dspark arm)"
+    )
+    rows = (
+        f"| workload | value |\n| --- | --- |\n"
+        f"| parallelism | tp{TP_SIZE} / ep{EP_SIZE} / dcp{arm.dcp_size}"
+        f" ({arm.dcp_comm_backend}) |\n"
+        f"| concurrency | {arm.concurrency} |\n"
+        f"| max running requests | {arm.max_running_requests} |\n"
+        f"| mamba cache slots | {arm.max_mamba_cache_size} |\n"
+        f"| speculative decoding | {spec_cell} |\n"
+        f"| kv offloading | {KV_OFFLOADING}"
+    )
+    if KV_OFFLOADING == "hicache":
+        rows += f" ({arm.hicache_size_gb} GB host tier)"
+    rows += " |\n"
+    rows += f"| kernel env | {'recipe subset' if ENABLE_YUYUN_KERNEL_ENV else 'aiter only'} |\n"
+    if limits.get("max_running_requests") is not None:
+        rows += (
+            f"| resolved max running requests | {limits['max_running_requests']} |\n"
+        )
+    if limits.get("max_total_num_tokens") is not None:
+        rows += f"| kv pool (tokens) | {limits['max_total_num_tokens']} |\n"
+    return rows
+
+
+def render_report(
+    arm: RecipeArm, result: dict, trace_summary: str, limits: dict
+) -> str:
+    cache = result.get("cache_report") or {}
+    accept_length = result.get("accept_length")
+    if accept_length:
+        accept_cell = f"{accept_length:.2f}"
+        if arm.golden_accept_len:
+            accept_cell += f" (AgentX golden {arm.golden_accept_len})"
+    else:
+        accept_cell = "n/a (not reported)"
+
+    report = (
+        f"### Kimi-K3 MXFP4 agentic replay, no-DCP arm "
+        f"[{os.getenv('GPU_CONFIG', 'MI35x')}]\n\n"
+        f"{_workload_rows(arm, limits)}"
+        f"{trace_summary}"
+        f"| metric | value |\n| --- | --- |\n"
+        f"| completed turns | {result.get('completed')} |\n"
+        f"| duration (s) | {result.get('duration', 0):.1f} |\n"
+        f"| request throughput (turn/s) | {result.get('request_throughput', 0):.2f} |\n"
+        f"| input throughput (tok/s) | {result.get('input_throughput', 0):.1f} |\n"
+        f"| output throughput (tok/s) | {result.get('output_throughput', 0):.1f} |\n"
+        f"| total throughput (tok/s) | {result.get('total_throughput', 0):.1f} |\n"
+        f"| mean TTFT (ms) | {result.get('mean_ttft_ms', 0):.1f} |\n"
+        f"| p99 TTFT (ms) | {result.get('p99_ttft_ms', 0):.1f} |\n"
+        f"| median ITL (ms) | {result.get('median_itl_ms', 0):.2f} |\n"
+        f"| p99 ITL (ms) | {result.get('p99_itl_ms', 0):.2f} |\n"
+        f"| mean E2E latency (ms) | {result.get('mean_e2e_latency_ms', 0):.1f} |\n"
+        f"| accept length | {accept_cell} |\n"
+    )
+    if cache:
+        report += (
+            f"| prefix cache hit rate | {cache.get('cache_hit_rate_pct', 0):.1f}% |\n"
+            f"| cached tokens (device) | {cache.get('device_cached_tokens')} |\n"
+            f"| cached tokens (host) | {cache.get('host_cached_tokens')} |\n"
+        )
+    return report
+
+
+class _KimiK3AgenticServer(CustomTestCase):
+    """Shared launcher: both modes serve the same recipe arm."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.arm = recipe_arm(CONCURRENCY)
+        if KV_OFFLOADING != "hicache":
+            print(
+                f"WARNING: AGENTIC_KV_OFFLOADING={KV_OFFLOADING} -- a {CONTEXT_LENGTH}"
+                " token context without the host tier clamps the KV pool.",
+                flush=True,
+            )
+        print(f"Recipe arm: {cls.arm}", flush=True)
+
+    def launch(self):
+        return popen_launch_server(
+            MODEL_PATH,
+            self.base_url,
+            timeout=SERVER_LAUNCH_TIMEOUT,
+            other_args=build_server_args(self.arm),
+            env=build_server_env(self.arm),
+        )
+
+    def publish(self, report: str):
+        print(report, flush=True)
+        if is_in_ci():
+            write_github_step_summary(report)
+
+    def assert_batch_not_clamped(self, limits: dict):
+        resolved: Optional[int] = limits.get("max_running_requests")
+        if resolved is None or resolved >= self.arm.concurrency:
+            return
+        message = (
+            f"server resolved max_running_requests={resolved} below the measured "
+            f"concurrency {self.arm.concurrency}: the state pool clamped the "
+            f"batch, so raise AGENTIC_MAX_MAMBA_CACHE_SIZE (currently "
+            f"{self.arm.max_mamba_cache_size}) or lower the concurrency"
+        )
+        if ALLOW_CLAMPED_BATCH:
+            print(f"WARNING: {message}", flush=True)
+        else:
+            self.fail(message)
+
+
+@unittest.skipUnless(MODE == "replay", f"AGENTIC_MODE={MODE} skips the replay")
+class TestKimiK3Mxfp4AgenticMI35x(_KimiK3AgenticServer):
+    """AgentX coding-agent replay against the MI35x MXFP4 K3 serving recipe."""
+
+    def _prepare_trace(self, tokenizer):
+        """Convert the published AgentX corpus, or skip if it is unreachable."""
+        source = os.environ.get("AGENTIC_TRACE_SOURCE") or weka_trace_url(
+            WEKA_TRACE_REPO
+        )
+        try:
+            return ensure_agentic_trace_file(
+                tokenizer,
+                output_dir=_trace_cache_dir(),
+                num_conversations=NUM_CONVERSATIONS,
+                output_len=OUTPUT_LEN,
+                max_turns=MAX_TURNS,
+                source=source,
+            )
+        except Exception as exc:
+            # A corpus that cannot be fetched or converted is an infrastructure
+            # problem, not an engine regression; do not report it as one.
+            raise unittest.SkipTest(
+                f"AgentX trace corpus unavailable from {source}: {exc!r}"
+            )
+
+    def test_agentic_replay(self):
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH, trust_remote_code=True)
+        trace_path, stats = self._prepare_trace(tokenizer)
+        print(f"Agentic trace: {trace_path} ({stats})", flush=True)
+
+        os.makedirs(RESULT_DIR, exist_ok=True)
+        result_file = os.path.join(RESULT_DIR, "agentic_replay.jsonl")
+        if os.path.exists(result_file):
+            os.remove(result_file)
+
+        process = self.launch()
+        try:
+            limits = resolved_batch_limits(self.base_url)
+            print(f"Resolved batch limits: {limits}", flush=True)
+            result = run_agentic_replay(
+                base_url=self.base_url,
+                model=MODEL_PATH,
+                tokenizer=tokenizer,
+                trace_path=trace_path,
+                num_conversations=NUM_CONVERSATIONS,
+                max_turns=MAX_TURNS,
+                output_len=OUTPUT_LEN,
+                max_concurrency=self.arm.concurrency,
+                output_file=result_file,
+            )
+        finally:
+            kill_process_tree(process.pid)
+
+        self.publish(render_report(self.arm, result, stats.as_markdown_rows(), limits))
+
+        # No throughput gate: the numbers are tracked, and the run itself is the
+        # regression guard. A dropped turn takes the rest of its trajectory with
+        # it, so a partial replay is a failure and not a smaller benchmark.
+        self.assertEqual(
+            result["failed"], 0, f"{result['failed']} turns failed: {result['errors']}"
+        )
+        self.assertGreater(result["output_throughput"], 0, "No output tokens generated")
+        self.assert_batch_not_clamped(limits)
+
+
+@unittest.skipUnless(MODE == "eval", f"AGENTIC_MODE={MODE} skips the eval pass")
+class TestKimiK3Mxfp4AgenticEvalMI35x(_KimiK3AgenticServer):
+    """AgentX's EVAL_ONLY pass: score the same serving recipe on GSM8K."""
+
+    def test_gsm8k(self):
+        process = self.launch()
+        try:
+            limits = resolved_batch_limits(self.base_url)
+            requests.get(self.base_url + "/flush_cache")
+            metrics = run_eval(
+                SimpleNamespace(
+                    base_url=self.base_url,
+                    model=MODEL_PATH,
+                    eval_name="gsm8k",
+                    api="completion",
+                    num_shots=EVAL_NUM_SHOTS,
+                    max_tokens=EVAL_MAX_NEW_TOKENS,
+                    num_examples=EVAL_NUM_EXAMPLES,
+                    # More in flight than the server admits only queues; this
+                    # keeps the scorer's fan-out at the batch being measured.
+                    num_threads=self.arm.max_running_requests,
+                )
+            )
+        finally:
+            kill_process_tree(process.pid)
+
+        accuracy = metrics["score"]
+        passed = accuracy >= EVAL_ACC_THRESHOLD
+        self.publish(
+            f"### Kimi-K3 MXFP4 agentic recipe, GSM8K "
+            f"[{os.getenv('GPU_CONFIG', 'MI35x')}]\n\n"
+            f"{_workload_rows(self.arm, limits)}"
+            f"| metric | value |\n| --- | --- |\n"
+            f"| gsm8k questions | {EVAL_NUM_EXAMPLES} ({EVAL_NUM_SHOTS}-shot) |\n"
+            f"| gsm8k accuracy | {accuracy:.3f} |\n"
+            f"| threshold | {EVAL_ACC_THRESHOLD} |\n"
+            f"| status | {'PASS' if passed else 'FAIL'} |\n"
+        )
+
+        self.assertGreaterEqual(
+            accuracy,
+            EVAL_ACC_THRESHOLD,
+            f"Kimi-K3 agentic-recipe accuracy {accuracy:.3f} below threshold "
+            f"{EVAL_ACC_THRESHOLD}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/amd/agentic/test_kimi_k3_mxfp4_agentic_mi35x.py
+++ b/test/registered/amd/agentic/test_kimi_k3_mxfp4_agentic_mi35x.py
@@ -133,6 +133,10 @@ MODEL_PATH = os.environ.get("KIMI_K3_MODEL_PATH", "moonshotai/Kimi-K3")
 # configuration, and each skips the other's case rather than launching a second
 # 1.56 TB server it would not use.
 MODE = os.environ.get("AGENTIC_MODE", "replay")
+if MODE not in ("replay", "eval"):
+    # Both cases are skipUnless-gated on this, so a typo'd dispatch input would
+    # otherwise publish an empty run as a passing benchmark.
+    raise ValueError(f"AGENTIC_MODE must be 'replay' or 'eval', got {MODE!r}")
 
 # The recipe refuses anything but TP8: MXFP4 K3 is ~195 GB per GPU of the 288 GB
 # a gfx950 carries, so TP8 is the only topology it fits in. Not a knob.
@@ -532,7 +536,7 @@ def render_report(
         f"### Kimi-K3 MXFP4 agentic replay, no-DCP arm "
         f"[{os.getenv('GPU_CONFIG', 'MI35x')}]\n\n"
         f"{_workload_rows(arm, limits)}"
-        f"{trace_summary}"
+        f"{trace_summary}\n"
         f"| metric | value |\n| --- | --- |\n"
         f"| completed turns | {result.get('completed')} |\n"
         f"| duration (s) | {result.get('duration', 0):.1f} |\n"
@@ -699,7 +703,7 @@ class TestKimiK3Mxfp4AgenticEvalMI35x(_KimiK3AgenticServer):
         self.publish(
             f"### Kimi-K3 MXFP4 agentic recipe, GSM8K "
             f"[{os.getenv('GPU_CONFIG', 'MI35x')}]\n\n"
-            f"{_workload_rows(self.arm, limits)}"
+            f"{_workload_rows(self.arm, limits)}\n"
             f"| metric | value |\n| --- | --- |\n"
             f"| gsm8k questions | {EVAL_NUM_EXAMPLES} ({EVAL_NUM_SHOTS}-shot) |\n"
             f"| gsm8k accuracy | {accuracy:.3f} |\n"

--- a/test/registered/unit/bench/test_kimi_k3_agentic_recipe.py
+++ b/test/registered/unit/bench/test_kimi_k3_agentic_recipe.py
@@ -1,0 +1,303 @@
+"""Unit tests for the Kimi-K3 AgentX recipe port.
+
+``test/registered/amd/agentic/test_kimi_k3_mxfp4_agentic_mi35x.py`` only runs on
+an 8-GPU MI35x node behind a 1.56 TB checkpoint load, so a renamed server flag
+or a wrong derived number there costs a nightly slot to discover. Everything
+about that port which does not need a GPU is checked here: the recipe's
+per-concurrency table, the DSPARK and DCP switches, the kernel-env split between
+what this tree reads and what only the pinned fork does, and -- the reason most
+of this file exists -- that every flag it passes still parses against
+``ServerArgs``.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from sglang.srt.server_args import prepare_server_args
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+
+# ServerArgs resolution asks for the accelerator; the flags under test are not
+# CPU-backend flags, so the parse has to happen as if a GPU were present.
+_mock_device = patch(
+    "sglang.srt.arg_groups.serving_hook.get_device", return_value="cuda"
+)
+_mock_device.start()
+
+
+def _load_recipe_module():
+    """Import the AMD benchmark by path: ``test/registered`` is not a package.
+
+    Only the module object is bound here, so neither unittest nor pytest
+    collects the MI35x test cases it defines out of this file.
+    """
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "amd"
+        / "agentic"
+        / "test_kimi_k3_mxfp4_agentic_mi35x.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "_kimi_k3_agentic_recipe_under_test", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+recipe = _load_recipe_module()
+
+
+def _flag(args, name):
+    """The value ``name`` was passed, or ``None`` when it is a bare switch."""
+    index = args.index(name)
+    value = args[index + 1] if index + 1 < len(args) else None
+    return None if value is None or value.startswith("--") else value
+
+
+class TestRecipeTable(CustomTestCase):
+    """The orchestrator's per-concurrency table, reproduced row by row."""
+
+    # CONC, max_running_requests, cuda_graph_max_bs, mamba slots, hicache GB
+    ROWS = [
+        (1, 2, 2, 10, 80),
+        (4, 8, 8, 40, 80),
+        (8, 16, 16, 80, 145),
+        (16, 32, 32, 160, 145),
+        (32, 64, 64, 320, 145),
+        (48, 96, 96, 480, 145),
+    ]
+
+    def test_every_row_matches_the_recipe(self):
+        for concurrency, mrr, graph_bs, mamba, hicache_gb in self.ROWS:
+            with self.subTest(concurrency=concurrency):
+                arm = recipe.recipe_arm(concurrency)
+                self.assertEqual(arm.max_running_requests, mrr)
+                self.assertEqual(arm.cuda_graph_max_bs, graph_bs)
+                self.assertEqual(arm.max_mamba_cache_size, mamba)
+                self.assertEqual(arm.hicache_size_gb, hicache_gb)
+                self.assertFalse(arm.spec_enabled)
+
+    def test_state_slots_cover_the_admission_ceiling_exactly(self):
+        # The point of the 5x multiplier: the state pool holds one slot budget
+        # per admissible request and not one more, so a clamp below the
+        # concurrency being measured means something else took the memory.
+        for concurrency, mrr, _, mamba, _ in self.ROWS:
+            with self.subTest(concurrency=concurrency):
+                self.assertEqual(mamba // recipe.MAMBA_SLOTS_PER_REQUEST, mrr)
+
+    def test_decode_graph_capture_is_capped(self):
+        # 2x concurrency would ask for 400 captured batches at c200; K3 captures
+        # across 93 attention and 92 MoE layers, so the recipe caps it.
+        arm = recipe.recipe_arm(200)
+        self.assertEqual(arm.max_running_requests, 400)
+        self.assertEqual(arm.cuda_graph_max_bs, recipe.CUDA_GRAPH_CAP)
+
+    def test_derived_numbers_stay_overridable(self):
+        overrides = {
+            "AGENTIC_MAX_RUNNING_REQUESTS": "12",
+            "AGENTIC_CUDA_GRAPH_MAX_BS": "8",
+            "AGENTIC_MAX_MAMBA_CACHE_SIZE": "96",
+            "AGENTIC_HICACHE_SIZE_GB": "200",
+        }
+        with patch.dict(os.environ, overrides, clear=False):
+            arm = recipe.recipe_arm(48)
+        self.assertEqual(arm.max_running_requests, 12)
+        self.assertEqual(arm.cuda_graph_max_bs, 8)
+        self.assertEqual(arm.max_mamba_cache_size, 96)
+        self.assertEqual(arm.hicache_size_gb, 200)
+
+
+class TestSpeculativeSchedule(CustomTestCase):
+    def test_dspark_is_off_in_the_ported_arm(self):
+        for concurrency, *_ in TestRecipeTable.ROWS:
+            with self.subTest(concurrency=concurrency):
+                arm = recipe.recipe_arm(concurrency, spec_decode="false")
+                self.assertEqual(arm.dspark_block_size, 0)
+                self.assertNotIn(
+                    "--speculative-algorithm", recipe.build_server_args(arm)
+                )
+
+    def test_auto_restores_the_orchestrator_schedule(self):
+        expected = {1: (7, 3.84), 8: (7, 3.84), 16: (3, 3.00), 32: (0, 0.0)}
+        for concurrency, (block_size, accept_len) in expected.items():
+            with self.subTest(concurrency=concurrency):
+                arm = recipe.recipe_arm(concurrency, spec_decode="auto")
+                self.assertEqual(arm.dspark_block_size, block_size)
+                self.assertEqual(arm.golden_accept_len, accept_len)
+
+    def test_spec_arm_asks_for_replayssm_verification(self):
+        # Without ReplaySSM the draft's intermediate KDA states come out of the
+        # per-request slot budget, and the recipe's 5x mamba multiplier stops
+        # covering max_running_requests.
+        args = recipe.build_server_args(recipe.recipe_arm(8, spec_decode="auto"))
+        self.assertEqual(_flag(args, "--speculative-algorithm"), "DSPARK")
+        self.assertEqual(_flag(args, "--speculative-dspark-block-size"), "7")
+        self.assertIn("--enable-linear-replayssm-spec", args)
+        self.assertEqual(
+            _flag(args, "--speculative-draft-model-path"), recipe.DSPARK_DRAFT_PATH
+        )
+
+    def test_spec_arm_leaves_acceptance_measured_by_default(self):
+        env = recipe.build_server_env(recipe.recipe_arm(8, spec_decode="auto"))
+        self.assertEqual(env["SGLANG_RAGGED_VERIFY_MODE"], "static")
+        self.assertNotIn("SGLANG_SIMULATE_ACC_LEN", env)
+
+    def test_simulated_acceptance_restores_the_agentx_pin(self):
+        with patch.object(recipe, "SIMULATE_ACC_LEN", "3.84"):
+            env = recipe.build_server_env(recipe.recipe_arm(8, spec_decode="auto"))
+        self.assertEqual(env["SGLANG_SIMULATE_ACC_LEN"], "3.84")
+        self.assertEqual(env["SGLANG_SIMULATE_ACC_METHOD"], "match-expected")
+
+
+class TestDecodeContextParallel(CustomTestCase):
+    def test_dcp1_uses_allgather_reducescatter(self):
+        arm = recipe.recipe_arm(48, dcp_size=1)
+        self.assertEqual(arm.dcp_comm_backend, "ag_rs")
+        self.assertEqual(recipe.build_server_env(arm)["SGLANG_AITER_MLA_GLUON"], "0")
+
+    def test_dcp_above_one_switches_backend_and_gluon(self):
+        arm = recipe.recipe_arm(48, dcp_size=8)
+        self.assertEqual(arm.dcp_comm_backend, "a2a")
+        self.assertEqual(recipe.build_server_env(arm)["SGLANG_AITER_MLA_GLUON"], "1")
+
+
+class TestKernelEnv(CustomTestCase):
+    # Read only by the pinned yuychang/sglang + yuychang/aiter kimi_k3_mxmoe_16k
+    # branches the recipe runs against, so exporting them upstream would be dead
+    # configuration that reads as if it did something.
+    FORK_ONLY = [
+        "SGLANG_K3_AITER_M16384_PROFILE",
+        "SGLANG_K3_AITER_MLA_GATE",
+        "SGLANG_K3_AITER_KDA_GROUP64",
+        "SGLANG_K3_AITER_B2_FUSIONS",
+        "SGLANG_K3_AITER_MOE_PREROUTE_FP8",
+        "SGLANG_K3_PREROUTE_PREACTIVATED_SHARED",
+        "SGLANG_K3_AITER_LATENT_TAIL_FP8",
+        "SGLANG_K3_AITER_MLA_Q_CACHE_FUSION",
+        "SGLANG_K3_AITER_TUNED_MOE_FRONT",
+        "SGLANG_K3_MOE_LATENT_MXFP4",
+        "SGLANG_K3_PTPC_FP8",
+        "AITER_FLYDSL_STAGE1_SCRATCH_REUSE",
+    ]
+
+    def test_fork_only_flags_are_not_exported(self):
+        with patch.dict(os.environ, {}, clear=True):
+            env = recipe.build_server_env(recipe.recipe_arm(48))
+        for name in self.FORK_ONLY:
+            with self.subTest(name=name):
+                self.assertNotIn(name, env)
+
+    def test_in_tree_kernel_flags_are_exported(self):
+        with patch.dict(os.environ, {}, clear=True):
+            env = recipe.build_server_env(recipe.recipe_arm(48))
+        self.assertEqual(env["SGLANG_USE_AITER"], "1")
+        self.assertEqual(env["SGLANG_AITER_K3_OPT"], "1")
+        # MXFP4-native experts, where the K3 accuracy and perf tests take W4A8.
+        self.assertEqual(env["AITER_SITUV2_A4W4"], "1")
+        self.assertEqual(env["AITER_SITUV2_A8W4"], "0")
+        for name, value in recipe.YUYUN_KERNEL_ENV.items():
+            with self.subTest(name=name):
+                self.assertEqual(env[name], value)
+
+    def test_aiter_only_arm_drops_the_kernel_block(self):
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(recipe, "ENABLE_YUYUN_KERNEL_ENV", False),
+        ):
+            env = recipe.build_server_env(recipe.recipe_arm(48))
+        for name in recipe.YUYUN_KERNEL_ENV:
+            with self.subTest(name=name):
+                self.assertNotIn(name, env)
+        self.assertEqual(env["SGLANG_USE_AITER"], "1")
+
+
+class TestHiCacheArm(CustomTestCase):
+    def test_host_tier_flags_come_from_the_recipe(self):
+        arm = recipe.recipe_arm(48)
+        args = recipe.build_server_args(arm)
+        self.assertIn("--enable-hierarchical-cache", args)
+        self.assertEqual(_flag(args, "--hicache-size"), "145")
+        self.assertEqual(_flag(args, "--hicache-write-policy"), "write_through")
+        self.assertEqual(_flag(args, "--hicache-io-backend"), "direct")
+        self.assertEqual(_flag(args, "--hicache-mem-layout"), "page_first_direct")
+        # The replay asks every turn for its prefix-cache detail, which the
+        # server only answers when reporting is on.
+        self.assertIn("--enable-cache-report", args)
+
+    def test_gpu_resident_arm_drops_them(self):
+        with patch.object(recipe, "KV_OFFLOADING", "none"):
+            args = recipe.build_server_args(recipe.recipe_arm(48))
+        for flag in ("--enable-hierarchical-cache", "--hicache-size"):
+            with self.subTest(flag=flag):
+                self.assertNotIn(flag, args)
+
+
+class TestServerArgsParse(CustomTestCase):
+    """Every flag the recipe passes has to still exist and take its value.
+
+    This is the check that is worth a CPU job: the alternative place to learn
+    that a flag was renamed is an 8-GPU MI35x nightly, after a 1.56 TB load.
+    """
+
+    def _parse(self, args):
+        try:
+            return prepare_server_args(["--model-path", "dummy"] + args)
+        except SystemExit as exc:
+            self.fail(f"server args rejected by the CLI parser: SystemExit({exc.code})")
+
+    def test_ported_arm_parses(self):
+        arm = recipe.recipe_arm(48)
+        server_args = self._parse(recipe.build_server_args(arm))
+
+        self.assertEqual(server_args.tp_size, recipe.TP_SIZE)
+        self.assertEqual(server_args.dcp_size, 1)
+        self.assertEqual(server_args.dcp_comm_backend, "ag_rs")
+        self.assertEqual(server_args.kv_cache_dtype, "fp8_e4m3")
+        self.assertEqual(server_args.page_size, 128)
+        self.assertEqual(server_args.context_length, 1048576)
+        self.assertEqual(server_args.max_running_requests, arm.max_running_requests)
+        self.assertEqual(server_args.max_mamba_cache_size, arm.max_mamba_cache_size)
+        self.assertEqual(server_args.mamba_ssm_dtype, "bfloat16")
+        self.assertEqual(server_args.mamba_track_interval, 1024)
+        self.assertEqual(server_args.hicache_size, arm.hicache_size_gb)
+        self.assertEqual(server_args.prefill_attention_backend, "aiter")
+        self.assertEqual(server_args.decode_attention_backend, "aiter")
+        self.assertEqual(server_args.tool_call_parser, "kimi_k3")
+        self.assertEqual(server_args.reasoning_parser, "kimi_k3")
+        self.assertEqual(server_args.chunked_prefill_size, 16384)
+        self.assertEqual(server_args.max_prefill_tokens, 16384)
+
+    def test_dspark_arm_parses(self):
+        server_args = self._parse(
+            recipe.build_server_args(recipe.recipe_arm(8, spec_decode="auto"))
+        )
+        self.assertEqual(server_args.speculative_algorithm, "DSPARK")
+        self.assertEqual(server_args.speculative_dspark_block_size, 7)
+        self.assertTrue(server_args.enable_linear_replayssm_spec)
+
+    def test_dcp_arm_parses(self):
+        server_args = self._parse(
+            recipe.build_server_args(recipe.recipe_arm(48, dcp_size=8))
+        )
+        self.assertEqual(server_args.dcp_size, 8)
+        self.assertEqual(server_args.dcp_comm_backend, "a2a")
+
+
+class TestResolvedBatchLimits(CustomTestCase):
+    def test_an_unreachable_server_is_reported_not_raised(self):
+        # The report is written after the run, so a failed /server_info must not
+        # be what loses a completed benchmark.
+        limits = recipe.resolved_batch_limits("http://127.0.0.1:1")
+        self.assertIn("error", limits)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/bench/test_kimi_k3_agentic_recipe.py
+++ b/test/registered/unit/bench/test_kimi_k3_agentic_recipe.py
@@ -31,24 +31,28 @@ _mock_device = patch(
 _mock_device.start()
 
 
-def _load_recipe_module():
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "amd"
+    / "agentic"
+    / "test_kimi_k3_mxfp4_agentic_mi35x.py"
+)
+
+
+def _load_recipe_module(name="_kimi_k3_agentic_recipe_under_test"):
     """Import the AMD benchmark by path: ``test/registered`` is not a package.
 
     Only the module object is bound here, so neither unittest nor pytest
     collects the MI35x test cases it defines out of this file.
     """
-    module_path = (
-        Path(__file__).resolve().parents[2]
-        / "amd"
-        / "agentic"
-        / "test_kimi_k3_mxfp4_agentic_mi35x.py"
-    )
-    spec = importlib.util.spec_from_file_location(
-        "_kimi_k3_agentic_recipe_under_test", module_path
-    )
+    spec = importlib.util.spec_from_file_location(name, MODULE_PATH)
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(spec.name, None)
+        raise
     return module
 
 
@@ -297,6 +301,17 @@ class TestResolvedBatchLimits(CustomTestCase):
         # be what loses a completed benchmark.
         limits = recipe.resolved_batch_limits("http://127.0.0.1:1")
         self.assertIn("error", limits)
+
+
+class TestModeSelection(CustomTestCase):
+    def test_an_unknown_mode_fails_loudly(self):
+        # Both cases are skipUnless-gated on AGENTIC_MODE, so a typo'd dispatch
+        # input would otherwise publish an empty run as a passing benchmark.
+        with (
+            patch.dict(os.environ, {"AGENTIC_MODE": "relpay"}, clear=False),
+            self.assertRaises(ValueError),
+        ):
+            _load_recipe_module("_kimi_k3_agentic_recipe_bad_mode")
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/bench/test_kimi_k3_agentic_recipe.py
+++ b/test/registered/unit/bench/test_kimi_k3_agentic_recipe.py
@@ -189,6 +189,7 @@ class TestKernelEnv(CustomTestCase):
         "SGLANG_K3_AITER_TUNED_MOE_FRONT",
         "SGLANG_K3_MOE_LATENT_MXFP4",
         "SGLANG_K3_PTPC_FP8",
+        "AITER_FLYDSL_DISABLE_MXMOE_V2",
         "AITER_FLYDSL_STAGE1_SCRATCH_REUSE",
     ]
 

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -154,9 +154,10 @@ NIGHTLY_SUITES = {
         "nightly-amd-vlm",
         "nightly-amd-accuracy-8-gpu-deepseek-v4-flash",
         "nightly-amd-8-gpu-mi35x-deepseek-v4-flash",
-        # Reporting-only serving benchmark; dispatched by
+        # Reporting-only serving benchmarks; dispatched by
         # nightly-benchmark-amd.yml, not by the AMD nightly test workflow.
         "nightly-perf-mi35x-qwen35-mxfp4-agentic-mtp",
+        "nightly-perf-8-gpu-mi35x-kimi-k3-agentic",
         # MI35x 8-GPU suite (different model configs)
         "nightly-amd-8-gpu-mi35x",
     ],


### PR DESCRIPTION
## Motivation

Add nightly coverage for the Kimi-K3 MXFP4 AgentX coding-agent serving recipe on 8x MI35x.

The existing Kimi-K3 accuracy and performance jobs use fixed 4k-input/512-output requests with radix caching disabled. They do not cover the long, growing prompts, prefix reuse, HiCache host offload, or KDA state-pool sizing exercised by coding-agent conversations.

This PR is stacked on #38812, which adds the shared trace replay and conversion utilities.

## Modifications

Adds the `nightly-perf-8-gpu-mi35x-kimi-k3-agentic` suite for the no-DCP, no-DSPARK recipe arm. Each point launches a TP8 server with a 1M-token context window, FP8 KV cache, AITER attention and MXFP4 MoE kernels, `page_size=128`, HiCache, and the recipe-derived request, CUDA graph, and KDA state-pool limits.

The nightly workflow runs replay at concurrency 4 with an 80 GB host tier, replay at concurrency 48 with a 145 GB host tier, and an 8-shot GSM8K evaluation at concurrency 48. Manual dispatch supports the other recipe rows and workload overrides without changing the test.

A CPU test pins all six concurrency rows and checks the DSPARK and DCP switches, the upstream-versus-fork kernel environment split, HiCache flags, mode validation, and every server argument used by the recipe.

## Notes for reviewers

The port intentionally uses sglang's in-tree replay driver and omits environment variables read only by the recipe's pinned forks. Its absolute throughput is therefore not comparable to an external AgentX result; the nightly is intended to detect regressions against its own history.

The scheduled matrix keeps the two endpoint replay points plus one evaluation pass to limit repeated large checkpoint loads. Concurrencies 1, 8, 16, and 32 remain available through `AGENTIC_CONCURRENCY`.

No model, kernel, or runtime code is changed.

## Accuracy Tests

The GPU evaluation has not run yet. The workflow evaluates 1,319 GSM8K examples with 8-shot completion and a 0.90 accuracy threshold.

## Speed Tests and Profiling

The 8-GPU MI35x replay has not run yet. It reports throughput, latency, acceptance, and cache metrics without a fixed throughput threshold; dropped turns, zero generated tokens, or a state-pool clamp below the labelled concurrency fail the test.

## Test plan

[Lint passed](https://github.com/sgl-project/sglang/actions/runs/34765276154/job/103745022924). PR CI has not yet run the new CPU unit test or the 8-GPU MI35x replay/evaluation points because the draft gate stopped the downstream suites.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34826468602](https://github.com/sgl-project/sglang/actions/runs/34826468602)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34826468178](https://github.com/sgl-project/sglang/actions/runs/34826468178)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34826468546](https://github.com/sgl-project/sglang/actions/runs/34826468546)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
