### PR TITLE
[DSA] Support group-scaled FP8 NoPE KV reads for CUDA TileLang

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/dequant_k_cache.py
+++ b/python/sglang/kernels/ops/attention/dsa/dequant_k_cache.py
@@ -9,6 +9,35 @@ def dequantize_k_cache(quant_k_cache):
     return _dequantize_k_cache_fast_wrapped(quant_k_cache)
 
 
+def dequantize_sparse_nope_cache(
+    quant_k_cache: torch.Tensor, indices: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Read 528-byte FP8 KV with four FP32 scales, preserving sparse masks.
+
+    Materialize the smaller of the physical pool and the selected-token table.
+    The gathered form may duplicate shared tokens, but bounds BF16 workspace by
+    ``min(physical_tokens, indices.numel()) * 1024`` bytes without a host sync
+    or data-dependent unique operation. Returned indices address this workspace.
+    """
+    if (
+        quant_k_cache.ndim != 3
+        or quant_k_cache.shape[1:] != (1, 528)
+        or quant_k_cache.dtype != torch.float8_e4m3fn
+    ):
+        raise ValueError("expected [physical tokens, 1, 528] group-scaled FP8 NoPE KV")
+    if indices.numel() >= quant_k_cache.shape[0]:
+        return dequantize_k_cache(quant_k_cache), indices
+    valid = (indices >= 0) & (indices < quant_k_cache.shape[0])
+    # The existing paged reader requires in-bounds physical indices. Invalid
+    # entries gather an in-bounds row but retain -1 in the new table. The
+    # attention consumer must still mask invalid entries before reading KV.
+    safe_indices = torch.where(valid, indices, 0).flatten()
+    kv = dequantize_k_cache_paged(quant_k_cache, safe_indices)
+    remapped = torch.arange(indices.numel(), device=indices.device, dtype=indices.dtype)
+    remapped = torch.where(valid, remapped.view_as(indices), -1)
+    return kv, remapped
+
+
 def _dequantize_k_cache_ref(
     quant_k_cache: torch.Tensor,  # (num_blocks, block_size, 1, bytes_per_token)
     dv: int = 512,
@@ -63,7 +92,7 @@ def _dequantize_k_cache_fast_wrapped(
         quant_k_cache = quant_k_cache.unsqueeze(1)
     num_blocks, block_size, _, dim_quant = quant_k_cache.shape
     assert dv == 512
-    assert dim_quant == 656
+    assert dim_quant in (528, 656), "expected NoPE or 64-RoPE group-scaled FP8 KV"
     assert tile_size == 128
     quant_k_cache = quant_k_cache.view((-1, dim_quant))
 
@@ -80,9 +109,9 @@ def _dequantize_k_cache_fast(quant_k_cache, group_size: int = 128):
 
     assert quant_k_cache.dtype == torch.float8_e4m3fn
     dim_nope = 512
-    dim_rope = 64
+    dim_rope = (dim_quant - dim_nope - (dim_nope // group_size) * 4) // 2
     num_tiles = dim_nope // group_size
-    assert dim_quant == 656
+    assert dim_quant in (528, 656)
 
     output = torch.empty(
         (num_tokens, dim_nope + dim_rope),
@@ -91,7 +120,7 @@ def _dequantize_k_cache_fast(quant_k_cache, group_size: int = 128):
     )
 
     num_blocks_per_token = triton.cdiv(dim_nope + dim_rope, group_size)
-    assert num_blocks_per_token == 5
+    assert num_blocks_per_token in (4, 5)
 
     assert dim_nope % group_size == 0
 
@@ -181,8 +210,8 @@ def dequantize_k_cache_paged(
         output: [num_tokens, 1, dim_nope + dim_rope], the de-quantized k-cache
     """
     dim_quant = quant_k_cache.shape[-1]
-    assert dim_quant == 656, (
-        f"dim_quant: {dim_quant} != 656 detected in dequantize_k_cache_paged"
+    assert dim_quant in (528, 656), (
+        f"expected NoPE or 64-RoPE group-scaled FP8 KV, got width {dim_quant}"
     )
     quant_k_cache = quant_k_cache.view((-1, dim_quant))
 
@@ -191,7 +220,7 @@ def dequantize_k_cache_paged(
     num_tokens = page_table_1_flattened.shape[0]
     assert quant_k_cache.dtype == torch.float8_e4m3fn
     dim_nope = 512
-    dim_rope = 64
+    dim_rope = (dim_quant - dim_nope - (dim_nope // group_size) * 4) // 2
     num_tiles = dim_nope // group_size  # 512 // 128 = 4
 
     output = torch.empty(
@@ -200,9 +229,9 @@ def dequantize_k_cache_paged(
         device=quant_k_cache.device,
     )
 
-    # cdiv(512 + 64, 128) = 5
+    # Four NoPE blocks, plus one RoPE block for the 656-byte layout.
     num_blocks_per_token = triton.cdiv(dim_nope + dim_rope, group_size)
-    assert num_blocks_per_token == 5
+    assert num_blocks_per_token in (4, 5)
 
     assert dim_nope % group_size == 0
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -622,6 +622,8 @@ def _check_dsa_backend_constraints(
     decode_backend: Optional[str],
     *,
     hip: bool,
+    nope_group_scaled: bool = False,
+    dcp_size: int = 1,
 ) -> None:
     """Validate DSA backend / platform / kv-cache-dtype constraints."""
     chosen = {prefill_backend, decode_backend}
@@ -636,10 +638,18 @@ def _check_dsa_backend_constraints(
 
     cuda_fp8_unsupported = {"tilelang"} & chosen
     if not hip and kv_cache_dtype == "fp8_e4m3" and cuda_fp8_unsupported:
+        # Both phases must consume the same group-scaled NoPE layout. Mixed
+        # backend pairs can select a raw KV pool or a RoPE-only consumer.
+        if (
+            nope_group_scaled
+            and prefill_backend == decode_backend == "tilelang"
+            and dcp_size == 1
+        ):
+            return
         raise ValueError(
-            f"The {'/'.join(sorted(cuda_fp8_unsupported))} DSA prefill/decode kernels "
-            "only support an fp8_e4m3 KV cache on ROCm/HIP; on CUDA they require "
-            "a bfloat16 KV cache. Use --kv-cache-dtype bfloat16, or keep "
+            "CUDA TileLang DSA with fp8_e4m3 KV requires BF16 queries, "
+            "latent512/RoPE0 group-scaled KV, both DSA backends set to tilelang, "
+            "and --dcp-size 1. Use --kv-cache-dtype bfloat16, or keep "
             "--kv-cache-dtype fp8_e4m3 and pick an fp8-capable DSA backend "
             "(flashmla_kv on Hopper, trtllm on Blackwell)."
         )
@@ -783,7 +793,16 @@ def _dsa_split_backend_resolution(view: Any) -> dict:
     prefill = declared.get("dsa_prefill_backend", view.dsa_prefill_backend)
     decode = declared.get("dsa_decode_backend", view.dsa_decode_backend)
     _check_dsa_backend_constraints(
-        kv_cache_dtype, prefill, decode, hip=get_platform().is_hip
+        kv_cache_dtype,
+        prefill,
+        decode,
+        hip=get_platform().is_hip,
+        nope_group_scaled=(
+            getattr(model_config_of(view), "kv_lora_rank", None) == 512
+            and getattr(model_config_of(view), "qk_rope_head_dim", None) == 0
+            and getattr(model_config_of(view), "dtype", None) == torch.bfloat16
+        ),
+        dcp_size=getattr(view, "dcp_size", 1),
     )
     logger.warning(
         f"Set DSA backends for {kv_cache_dtype} KV Cache: "

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -3083,6 +3083,22 @@ class DeepseekSparseAttnBackend(
     ) -> torch.Tensor:
         from sglang.kernels.ops.attention.dsa.tilelang_kernel import tilelang_sparse_fwd
 
+        if (
+            not _is_hip
+            and q_all.is_cuda
+            and q_all.dtype == torch.bfloat16
+            and q_all.shape[-1] == v_head_dim == 512
+            and kv_cache.dtype == torch.float8_e4m3fn
+            and kv_cache.shape[-1] == 528
+        ):
+            from sglang.kernels.ops.attention.dsa.dequant_k_cache import (
+                dequantize_sparse_nope_cache,
+            )
+
+            kv_cache, page_table_1 = dequantize_sparse_nope_cache(
+                kv_cache, page_table_1
+            )
+
         # KPool appends up to index_kpool - 1 live tail tokens to the fixed
         # index_topk columns. TileLang processes indices in 64-column blocks,
         # so mask-pad the tail-extended table to the next complete block.

--- a/test/registered/kernel/attention/test_dsa_nope_dequant.py
+++ b/test/registered/kernel/attention/test_dsa_nope_dequant.py
@@ -158,3 +158,7 @@ def test_tilelang_consumer_and_graph(pool_size, queries):
     q.mul_(0.5)
     graph.replay()
     check(output)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/kernel/attention/test_dsa_nope_dequant.py
+++ b/test/registered/kernel/attention/test_dsa_nope_dequant.py
@@ -67,6 +67,8 @@ def test_full_and_paged_readers(rope_dim):
     )
     graph, output = capture(lambda: dequantize_k_cache_paged(cache, pages))
     pages[0] = 7
+    cache[:, :, 512:528].view(torch.float32).mul_(0.5)
+    expected[:, :, :512].mul_(0.5)
     graph.replay()
     torch.testing.assert_close(output, expected[pages.long()], rtol=0, atol=0)
 
@@ -88,6 +90,8 @@ def test_sparse_reader_mapping_and_graph(pool_size):
     check(dequantize_sparse_nope_cache(cache, indices))
     graph, output = capture(lambda: dequantize_sparse_nope_cache(cache, indices))
     indices[0, 0] = 5
+    cache[:, :, 512:528].view(torch.float32).mul_(0.5)
+    expected.mul_(0.5)
     graph.replay()
     check(output)
 

--- a/test/registered/kernels/ops/attention/test_dsa_nope_dequant.py
+++ b/test/registered/kernels/ops/attention/test_dsa_nope_dequant.py
@@ -1,0 +1,160 @@
+"""Group-scaled NoPE readers and the CUDA BF16 TileLang consumer.
+
+Consumer tests use valid, fixed-width physical indices. Invalid-index attention
+masking and KPool prefix/tail expansion are separate kernel contracts.
+"""
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.dsa.dequant_k_cache import (
+    dequantize_k_cache,
+    dequantize_k_cache_paged,
+    dequantize_sparse_nope_cache,
+)
+from sglang.kernels.ops.attention.dsa.quant_k_cache import quantize_k_cache_separate
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.version.hip is not None,
+    reason="requires CUDA",
+)
+
+
+def make_cache(tokens, rope_dim=0):
+    generator = torch.Generator(device="cuda").manual_seed(528 + rope_dim)
+    nope = torch.randn(tokens, 1, 512, device="cuda", generator=generator)
+    nope.view(tokens, 4, 128).mul_(
+        torch.tensor([0.01, 0.5, 2.0, 8.0], device="cuda")[None, :, None]
+    )
+    rope = torch.randn(
+        tokens, 1, rope_dim, device="cuda", generator=generator
+    ).bfloat16()
+    packed, packed_rope = quantize_k_cache_separate(nope.bfloat16(), rope)
+    cache = torch.cat((packed, packed_rope), -1).view(torch.float8_e4m3fn)
+    values = packed[:, :, :512].view(torch.float8_e4m3fn).float().view(tokens, 4, 128)
+    scales = packed[:, :, 512:].view(torch.float32).view(tokens, 4, 1)
+    expected = torch.cat(((values * scales).bfloat16().view(tokens, 1, 512), rope), -1)
+    return cache, expected
+
+
+def capture(run):
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            run()
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        output = run()
+    return graph, output
+
+
+@pytest.mark.parametrize("rope_dim", [0, 64])
+def test_full_and_paged_readers(rope_dim):
+    cache, expected = make_cache(18, rope_dim)
+    torch.testing.assert_close(dequantize_k_cache(cache), expected, rtol=0, atol=0)
+    blocked = cache.view(2, 9, 1, -1)
+    torch.testing.assert_close(
+        dequantize_k_cache(blocked).view_as(expected), expected, rtol=0, atol=0
+    )
+    # Repeated physical indices and more selected entries than physical rows.
+    pages = torch.tensor([17, 0, 3, 3, 8] * 4, device="cuda", dtype=torch.int32)
+    torch.testing.assert_close(
+        dequantize_k_cache_paged(blocked, pages), expected[pages.long()], rtol=0, atol=0
+    )
+    graph, output = capture(lambda: dequantize_k_cache_paged(cache, pages))
+    pages[0] = 7
+    graph.replay()
+    torch.testing.assert_close(output, expected[pages.long()], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("pool_size", [8, 32])
+def test_sparse_reader_mapping_and_graph(pool_size):
+    cache, expected = make_cache(pool_size)
+    indices = torch.tensor(
+        [[7, 2, 2, 1], [3, 0, 1, 2]], device="cuda", dtype=torch.int32
+    )
+
+    def check(output):
+        kv, mapped = output
+        assert kv.shape == (min(pool_size, indices.numel()), 1, 512)
+        torch.testing.assert_close(
+            kv[mapped.long()], expected[indices.long()], rtol=0, atol=0
+        )
+
+    check(dequantize_sparse_nope_cache(cache, indices))
+    graph, output = capture(lambda: dequantize_sparse_nope_cache(cache, indices))
+    indices[0, 0] = 5
+    graph.replay()
+    check(output)
+
+
+def test_selected_reader_preserves_invalid_mask():
+    cache, expected = make_cache(32)
+    indices = torch.tensor(
+        [[-1, 32, 7, 7], [0, -2, 31, 33]], device="cuda", dtype=torch.int32
+    )
+    kv, mapped = dequantize_sparse_nope_cache(cache, indices)
+    valid = (indices >= 0) & (indices < 32)
+    assert (mapped[~valid] == -1).all()
+    torch.testing.assert_close(
+        kv[mapped[valid].long()], expected[indices[valid].long()], rtol=0, atol=0
+    )
+
+
+def test_empty_selection():
+    cache, _ = make_cache(32)
+    indices = torch.empty((0, 64), device="cuda", dtype=torch.int32)
+    kv, mapped = dequantize_sparse_nope_cache(cache, indices)
+    assert kv.shape == (0, 1, 512)
+    assert mapped.shape == indices.shape
+
+
+@pytest.mark.parametrize(
+    "width,dtype",
+    [(512, torch.float8_e4m3fn), (656, torch.float8_e4m3fn), (528, torch.bfloat16)],
+)
+def test_sparse_reader_rejects_other_formats(width, dtype):
+    cache = torch.empty((32, 1, width), device="cuda", dtype=dtype)
+    indices = torch.zeros((1, 64), device="cuda", dtype=torch.int32)
+    with pytest.raises(ValueError, match="group-scaled FP8 NoPE KV"):
+        dequantize_sparse_nope_cache(cache, indices)
+
+
+@pytest.mark.parametrize("pool_size", [32, 512])
+@pytest.mark.parametrize("queries", [1, 4])
+def test_tilelang_consumer_and_graph(pool_size, queries):
+    if torch.cuda.get_device_capability()[0] != 9:
+        pytest.skip("TileLang consumer integration is validated on SM90")
+    from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
+
+    cache, expected_kv = make_cache(pool_size)
+    q = torch.randn((queries, 16, 512), device="cuda", dtype=torch.bfloat16) * 0.05
+    indices = (
+        torch.arange(queries * 64, device="cuda", dtype=torch.int32).view(queries, 64)
+        % pool_size
+    )
+    scale = 512**-0.5
+
+    def run():
+        return DeepseekSparseAttnBackend._forward_tilelang(
+            None, q, cache, 512, indices, scale
+        )
+
+    def check(output):
+        selected = expected_kv[indices.long(), 0].float()
+        logits = torch.einsum("qhd,qkd->qhk", q.float(), selected) * scale
+        expected = torch.einsum("qhk,qkd->qhd", logits.softmax(-1), selected)
+        torch.testing.assert_close(
+            output.view_as(q).float(), expected, rtol=0.02, atol=0.03
+        )
+
+    check(run())
+    graph, output = capture(run)
+    indices.copy_((indices + 3) % pool_size)
+    q.mul_(0.5)
+    graph.replay()
+    check(output)

--- a/test/registered/unit/test_dsa_tilelang_fp8_validation.py
+++ b/test/registered/unit/test_dsa_tilelang_fp8_validation.py
@@ -1,4 +1,4 @@
-"""Rejecting an fp8_e4m3 KV cache with the tilelang DSA backend on CUDA.
+"""Validate the CUDA TileLang group-scaled NoPE capability and its boundaries.
 
 Regression: the combination used to boot the server and crash at decode
 CUDA-graph capture with ``kernel main input KV dtype expected bfloat16,
@@ -6,8 +6,18 @@ but got float8_e4m3fn``.
 """
 
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
-from sglang.srt.arg_groups.overrides import _check_tilelang_dsa_fp8_kv
+import torch
+
+from sglang.srt.arg_groups.overrides import (
+    ResolvedView,
+    _check_dsa_backend_constraints,
+    _check_tilelang_dsa_fp8_kv,
+    _dsa_split_backend_resolution,
+)
+from sglang.srt.runtime_context import override_platform
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -15,6 +25,79 @@ register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 
 
 class TestDsaTilelangFp8Validation(CustomTestCase):
+    def test_cuda_group_scaled_nope_allowed(self):
+        _check_dsa_backend_constraints(
+            "fp8_e4m3", "tilelang", "tilelang", hip=False, nope_group_scaled=True
+        )
+
+    def test_cuda_group_scaled_requires_matching_consumers(self):
+        for prefill, decode in (
+            ("tilelang", "trtllm"),
+            ("flashmla_kv", "tilelang"),
+            ("tilelang", "fa3"),
+            ("tilelang", None),
+        ):
+            with self.subTest(prefill=prefill, decode=decode):
+                with self.assertRaises(ValueError):
+                    _check_dsa_backend_constraints(
+                        "fp8_e4m3", prefill, decode, hip=False, nope_group_scaled=True
+                    )
+
+    def test_cuda_group_scaled_dcp_rejected(self):
+        with self.assertRaisesRegex(ValueError, "dcp-size 1"):
+            _check_dsa_backend_constraints(
+                "fp8_e4m3",
+                "tilelang",
+                "tilelang",
+                hip=False,
+                nope_group_scaled=True,
+                dcp_size=2,
+            )
+
+    def test_cuda_triton_still_rejected(self):
+        with self.assertRaisesRegex(ValueError, "only supported on ROCm/HIP"):
+            _check_dsa_backend_constraints(
+                "fp8_e4m3", "triton", "tilelang", hip=False, nope_group_scaled=True
+            )
+
+    def test_production_resolution_checks_model_geometry(self):
+        def make_view(rank=512, rope=0, dtype=torch.bfloat16, **kwargs):
+            model = SimpleNamespace(
+                hf_config=SimpleNamespace(
+                    architectures=["Glm5NextForConditionalGeneration"]
+                ),
+                kv_lora_rank=rank,
+                qk_rope_head_dim=rope,
+                dtype=dtype,
+            )
+            options = dict(
+                _model_config=model,
+                kv_cache_dtype="fp8_e4m3",
+                dsa_prefill_backend="tilelang",
+                dsa_decode_backend="tilelang",
+                enable_hisparse=False,
+                dcp_size=1,
+            )
+            options.update(kwargs)
+            return ResolvedView(SimpleNamespace(**options))
+
+        with (
+            patch("sglang.srt.configs.model_config.is_deepseek_dsa", return_value=True),
+            patch("torch.cuda.get_device_capability", return_value=(9, 0)),
+            override_platform(is_npu=False, is_xpu=False, is_hip=False),
+        ):
+            self.assertEqual(_dsa_split_backend_resolution(make_view()), {})
+            for options in (
+                {"rank": 256},
+                {"rope": 64},
+                {"dtype": torch.float16},
+                {"dcp_size": 2},
+                {"enable_hisparse": True},
+            ):
+                with self.subTest(options=options):
+                    with self.assertRaises(ValueError):
+                        _dsa_split_backend_resolution(make_view(**options))
+
     def test_cuda_fp8_tilelang_decode_rejected(self):
         with self.assertRaises(ValueError):
             _check_tilelang_dsa_fp8_kv("fp8_e4m3", "flashmla_kv", "tilelang", hip=False)


### PR DESCRIPTION
## Motivation

Enable CUDA TileLang DSA to consume group528 FP8 NoPE KV rows for GLM-5.3-Flash. Related to #36830.

## Modifications

- Add full/paged readers for the existing 528-byte layout (512 FP8 values + four FP32 scales), using selected-row dequantization when smaller than the full pool.
- Connect the reader to the BF16 TileLang consumer and enable the supported CUDA configuration in startup validation. Backend defaults and existing RoPE/HIP paths are preserved; this is not native FP8 attention.

## Accuracy Tests

Validated commit `223a88446464` on H20, 2026-09-20:

- **34 tests + 15 subtests passed**; pre-commit passed.
- Both BF16 and FP8: **GSM8K 63/64**, same incorrect question, no errors or truncations; eight short exact answers, 128K generation and 130K known-answer retrieval passed.
- **128/128 benchmark requests succeeded per arm**, with matching request bodies and exact token counts.

## Speed Tests and Profiling

GLM-5.3-Flash, **4×H20, TP4/EP4**, same clean wheel/model; only KV dtype differs. Static-memory fraction **0.92**, automatic KV capacity, context 262144, max-running 32, Mamba slots 64, chunk 8192, decode Graph 32; MTP/radix off. Each workload generates 1024 output tokens.

At **8.524 GiB KV allocation per GPU** in both arms, capacity increases from **719,680 to 1,260,544 tokens (+75.15%)**. Observed simultaneous long requests increase **10→18 at 64K/C32** and **5→8 at 128K/C8**.

Changes are FP8 relative to BF16: **higher throughput is better; lower TTFT/TPOT is better**. TTFT and TPOT below are means; TPOT includes prefill-induced stalls, not just decode-kernel time.

| Input / concurrency | Output tok/s, BF16→FP8 | Change | TTFT s, BF16→FP8 | Change | TPOT ms, BF16→FP8 | Change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 64K / 8 | 121.83→116.52 | -4.36% | 26.94→27.40 | +1.70% | 29.57→31.72 | +7.27% |
| 64K / 16 | 132.96→134.62 | +1.25% | 64.93→51.74 | -20.31% | 36.91→58.04 | +57.25% |
| 64K / 32 | 137.37→139.79 | +1.76% | 154.60→134.49 | -13.00% | 37.28→63.28 | +69.74% |
| 128K / 8 | 65.04→65.15 | +0.18% | 71.74→57.62 | -19.68% | 31.82→50.36 | +58.27% |

**Result: more usable capacity, not a material throughput improvement.** At capacity-constrained points, observed P95 completion improves 11–21% and mean TTFT improves 13–20%, while mean completion worsens 3–8% and mean TPOT worsens 57–70%.

Single-run, two-wave burst measurements (16/32/64/16 requests), not warmed steady-state or an SLO guarantee. No fatal OOM or request retractions; BF16 had recoverable allocator-OOM warnings. **This compares against BF16, not existing raw512 FP8.** PD/MTP/prefix, broader quality, invalid/all-empty attention masks and unfused KPool widths remain unvalidated.

## Checklist

- [x] Registered tests and pre-commit pass.
- [x] Paired full-model correctness and capacity/performance results provided.

Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35497208819](https://github.com/sgl-project/sglang/actions/runs/35497208819)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35497208693](https://github.com/sgl-project/sglang/actions/runs/35497208693)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35497208759](https://github.com/sgl-project/sglang/actions/runs/35497208759)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->
