### PR TITLE
[AMD] Use Triton prefill attention via Aiter backend

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -3078,17 +3078,22 @@ class AiterAttnBackend(AttentionBackend):
                 if any(forward_batch.extend_prefix_lens_cpu):
                     bs = forward_batch.batch_size
                     kc, vc = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
-                    page = self.page_size
                     kv_indptr = self.forward_metadata.kv_indptr[: bs + 1]
-                    kv_pages = self.forward_metadata.kv_indices
+                    kv_slots = self.forward_metadata.kv_indices
                     seq_lens = forward_batch.seq_lens[:bs].to(torch.long)
-                    # Clamp per-seq kvlen to the pages this batch actually has
-                    # (page-granular metadata can disagree with seq_lens in
-                    # mixed/spec batches, which would gather out of bounds).
-                    pages_per_seq = (kv_indptr[1 : bs + 1] - kv_indptr[:bs]).to(
+                    # kv_indptr strides in TOKENS and kv_indices holds one pool
+                    # slot per token (create_flashinfer_kv_indices_triton fills
+                    # it from req_to_token), so there is no page arithmetic to
+                    # do here. Scaling these entries by page_size overshoots a
+                    # prefixed chunk's own tokens, so attention reads stale
+                    # slots for exactly the newest tokens: GSM8K 0.961 -> 0.410.
+                    # Clamp per-seq kvlen to the tokens this batch actually has
+                    # in kv_indices; metadata can disagree with seq_lens in
+                    # mixed/spec batches, which would gather out of bounds.
+                    toks_per_seq = (kv_indptr[1 : bs + 1] - kv_indptr[:bs]).to(
                         torch.long
                     )
-                    seq_lens = torch.minimum(seq_lens, pages_per_seq * page)
+                    seq_lens = torch.minimum(seq_lens, toks_per_seq)
                     total_k = int(seq_lens.sum().item())
                     cu_k = torch.zeros(bs + 1, dtype=torch.long, device=q.device)
                     torch.cumsum(seq_lens, 0, out=cu_k[1:])
@@ -3096,15 +3101,13 @@ class AiterAttnBackend(AttentionBackend):
                         torch.arange(bs, device=q.device), seq_lens
                     )
                     pos_in_seq = torch.arange(total_k, device=q.device) - cu_k[seq_ids]
-                    page_slot = kv_indptr[seq_ids].to(torch.long) + pos_in_seq // page
+                    slot = kv_indptr[seq_ids].to(torch.long) + pos_in_seq
                     varlen_ok = (
                         self.forward_metadata.max_kv_len is not None
-                        and int(page_slot.max().item()) < kv_pages.numel()
+                        and int(slot.max().item()) < kv_slots.numel()
                     )
                     if varlen_ok:
-                        tok_idx = (
-                            kv_pages[page_slot].to(torch.long) * page + pos_in_seq % page
-                        )
+                        tok_idx = kv_slots[slot].to(torch.long)
                         varlen_ok = int(tok_idx.max().item()) < kc.shape[0]
                     if varlen_ok:
                         k_in = (

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -388,6 +388,14 @@ class AiterAttnBackend(AttentionBackend):
                 "SGLANG_USE_AITER_UNIFIED_ATTN"
             )
 
+        # Route no-prefix extend through flash_attn_varlen_func instead of the
+        # CK-tile mha_batch_prefill_func, which has no gfx12 kernels. fp8 KV is
+        # excluded because the varlen entry takes no q/k/v descale. Opt-in, so
+        # gfx942/gfx950 keep the batch_prefill path unless asked otherwise.
+        self.use_aiter_varlen_prefill = get_bool_env_var(
+            "SGLANG_AITER_VARLEN_PREFILL"
+        ) and not (self.kv_cache_dtype == fp8_dtype)
+
         # When topk == 1 the EAGLE draft chain is linear, so target_verify's
         # mask reduces to pure causal and can go through unified_attention
         # instead of the legacy triton extend_attention_fwd. Gated on non-MLA
@@ -3046,6 +3054,99 @@ class AiterAttnBackend(AttentionBackend):
                     o = o.to(self.input_dtype)
                 return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
+            # Unpaged bf16 varlen prefill. mha_batch_prefill_func is CK-tile
+            # FMHA whose codegen targets gfx9 only, so on gfx12 (and under
+            # ENABLE_CK=0) it has no kernels at all. flash_attn_varlen_func
+            # falls back to aiter's Triton MHA there. That fallback accepts a
+            # block_table argument but drops it before reaching the kernel
+            # (mha.py hardcodes block_table_=None), so the paged cache has to
+            # be gathered into a contiguous varlen buffer first, exactly like
+            # the ASM context-prefill branch above. Chunked prefill makes
+            # prefixed batches unavoidable at concurrency (one partially
+            # prefilled request re-enters alongside fresh ones), so the
+            # no-prefix-only version of this was not viable.
+            if (
+                self.use_aiter_varlen_prefill
+                and not self.kv_cache_is_vectorized_5d
+                and forward_batch.forward_mode.is_extend()
+                and forward_batch.extend_prefix_lens_cpu is not None
+                and self.logits_soft_cap == 0.0
+                and k is not None
+                and v is not None
+            ):
+                varlen_ok = True
+                if any(forward_batch.extend_prefix_lens_cpu):
+                    bs = forward_batch.batch_size
+                    kc, vc = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
+                    page = self.page_size
+                    kv_indptr = self.forward_metadata.kv_indptr[: bs + 1]
+                    kv_pages = self.forward_metadata.kv_indices
+                    seq_lens = forward_batch.seq_lens[:bs].to(torch.long)
+                    # Clamp per-seq kvlen to the pages this batch actually has
+                    # (page-granular metadata can disagree with seq_lens in
+                    # mixed/spec batches, which would gather out of bounds).
+                    pages_per_seq = (kv_indptr[1 : bs + 1] - kv_indptr[:bs]).to(
+                        torch.long
+                    )
+                    seq_lens = torch.minimum(seq_lens, pages_per_seq * page)
+                    total_k = int(seq_lens.sum().item())
+                    cu_k = torch.zeros(bs + 1, dtype=torch.long, device=q.device)
+                    torch.cumsum(seq_lens, 0, out=cu_k[1:])
+                    seq_ids = torch.repeat_interleave(
+                        torch.arange(bs, device=q.device), seq_lens
+                    )
+                    pos_in_seq = torch.arange(total_k, device=q.device) - cu_k[seq_ids]
+                    page_slot = kv_indptr[seq_ids].to(torch.long) + pos_in_seq // page
+                    varlen_ok = (
+                        self.forward_metadata.max_kv_len is not None
+                        and int(page_slot.max().item()) < kv_pages.numel()
+                    )
+                    if varlen_ok:
+                        tok_idx = (
+                            kv_pages[page_slot].to(torch.long) * page + pos_in_seq % page
+                        )
+                        varlen_ok = int(tok_idx.max().item()) < kc.shape[0]
+                    if varlen_ok:
+                        k_in = (
+                            kc.view(-1, layer.tp_k_head_num * layer.qk_head_dim)
+                            .index_select(0, tok_idx)
+                            .view(-1, layer.tp_k_head_num, layer.qk_head_dim)
+                        )
+                        v_in = (
+                            vc.view(-1, layer.tp_v_head_num * layer.v_head_dim)
+                            .index_select(0, tok_idx)
+                            .view(-1, layer.tp_v_head_num, layer.v_head_dim)
+                        )
+                        cu_seqlens_k = cu_k.to(torch.int32)
+                        max_kv_len = int(self.forward_metadata.max_kv_len)
+                else:
+                    # No prefix: kv is exactly the k/v just computed, so the
+                    # page table is not needed and no gather is required.
+                    k_in = k.contiguous().view(
+                        -1, layer.tp_k_head_num, layer.qk_head_dim
+                    )
+                    v_in = v.contiguous().view(-1, layer.tp_v_head_num, layer.v_head_dim)
+                    cu_seqlens_k = self.qo_indptr[:bs0]
+                    max_kv_len = self.forward_metadata.max_q_len
+
+                if varlen_ok:
+                    o = flash_attn_varlen_func(
+                        q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
+                        k_in,
+                        v_in,
+                        self.qo_indptr[:bs0],
+                        cu_seqlens_k,
+                        self.forward_metadata.max_q_len,
+                        max_kv_len,
+                        softmax_scale=layer.scaling,
+                        causal=True,
+                        window_size=window_size,
+                        sink_ptr=sinks,
+                    )
+                    if o.dtype != self.input_dtype:
+                        o = o.to(self.input_dtype)
+                    return o.view(-1, layer.tp_q_head_num * layer.head_dim)
+
             if self.kv_cache_is_vectorized_5d:
                 return forward_extend_vectorized_5d(
                     self,
@@ -3080,6 +3181,24 @@ class AiterAttnBackend(AttentionBackend):
             if attn_out is not None and q.dtype != fp8_dtype:
                 extra_kwargs["out"] = attn_out.view(
                     -1, layer.tp_q_head_num, layer.head_dim
+                )
+
+            if self.use_aiter_varlen_prefill and not getattr(
+                self, "_varlen_fallthrough_logged", False
+            ):
+                self._varlen_fallthrough_logged = True
+                logger.warning(
+                    "[varlen-prefill] fell through to batch_prefill: "
+                    "5d=%s mode=%s(is_extend=%s) prefix_cpu=%s soft_cap=%s "
+                    "k=%s v=%s q_shape=%s",
+                    self.kv_cache_is_vectorized_5d,
+                    forward_batch.forward_mode,
+                    forward_batch.forward_mode.is_extend(),
+                    forward_batch.extend_prefix_lens_cpu,
+                    self.logits_soft_cap,
+                    k is not None,
+                    v is not None,
+                    tuple(q.shape),
                 )
 
             o = mha_batch_prefill_func(


### PR DESCRIPTION
## Motivation

On gfx1250 the aiter attention backend cannot serve prefill at all. `forward_extend`
calls `mha_batch_prefill_func`, and the CK-tile kernels behind it fail to compile for
this architecture:

```
composable_kernel/include/ck_tile/core/arch/amd_buffer_addressing_builtins.hpp:1438:39:
error: invalid operand for instruction
```

Line 1438 emits the direct-to-LDS async load (`buffer_load_dword ... offen offset:%3 lds`),
an addressing form that is not valid on gfx1250. Three details make this a hard block
rather than a tuning problem:

- Of the 65 generated sources, 64 are kernel variants and **all 64** are `qr_async`.
  The only non-async file is the API dispatcher, so there is no non-async variant to
  fall back to.
- `codegen/ops/fmha_batch_prefill.py` has a single `KernelComponentFactory` and no
  architecture specialization at all. By contrast `codegen/ops/fmha_fwd.py` dispatches
  through `get_factory(target)` to `KernelComponentFactoryGfx125`. gfx12 enablement
  landed in `fmha_fwd` and never in `fmha_batch_prefill`.
- It reproduces with `ENABLE_CK=1`, so this is not an `ENABLE_CK` configuration issue.

The practical effect is that the scheduler dies during startup on gfx1250 whenever the
aiter backend takes an extend batch.

## Modifications

Three commits, all in `python/sglang/srt/layers/attention/aiter_backend.py` (+171).

**1. Route extend through `flash_attn_varlen_func`.** Opt-in via
`SGLANG_AITER_VARLEN_PREFILL`, so gfx942/gfx950 keep the existing `batch_prefill` path
unless asked otherwise. Under `ENABLE_CK=0` this dispatcher resolves to aiter's Triton
varlen MHA (`aiter/ops/triton/attention/mha.py`) — conceptually the same move as
`SGLANG_USE_AITER_UNIFIED_ATTN` for decode, extended to prefill.

Paged KV has to be gathered into a contiguous varlen buffer first. The Triton entry
point accepts a `block_table` argument and then silently discards it:
`_FlashAttnVarlenFunc.forward` takes the parameter and never forwards it to
`_flash_attn_forward`, whose signature has no such parameter. Passing a page table
would therefore return plausible but wrong results rather than raising, so the gather
is mandatory, not an optimization. Chunked prefill also makes prefixed batches
unavoidable at concurrency — one partially prefilled request re-enters alongside fresh
ones — so a no-prefix-only version was not viable.

A one-shot warning fires if the flag is set but the path is not taken, which is what
surfaced the bug fixed in the next commit.

**2. Fix a token-vs-page unit error in the prefixed gather.** `kv_indptr` strides in
*tokens* and `kv_indices` holds one pool slot per token (filled by
`create_flashinfer_kv_indices_triton` from `req_to_token`), so no page arithmetic
applies. Scaling those entries by `page_size` overshot a prefixed chunk's own tokens,
making attention read stale slots for exactly the newest tokens — GSM8K 0.961 -> 0.410.

**3. Allow an fp8 KV cache on this path.** fp8 was previously excluded from the varlen
gate, so `--kv-cache-dtype fp8_e4m3` silently fell back to `batch_prefill` and died.
Dequantizing during the gather is nearly free structurally, since the path already
materializes paged KV into a contiguous buffer, and it keeps the kernel in bf16. The
alternative — handing fp8 straight to the kernel — would force q to fp8 as well,
because the Triton varlen path raises on a mix of fp8 and non-fp8 inputs, turning a
cache format choice into an attention precision change. `index_select` has no fp8
kernel, so rows go through a `uint8` view; both dtypes are one byte, making it a pure
reinterpret, but it is easy to get wrong and is covered by a bitwise-equality test.

## Accuracy Tests

GSM8K, full 1319 questions, `--attention-backend aiter` with the flag on:

| config | accuracy | invalid |
|---|---|---|
| TP1, bf16 KV | 0.961 | 0.000 |
| TP4, bf16 KV | 0.963 | 0.000 |

TP4 matches TP1 within noise. For fp8 KV, GSM8K is 0.970 at n=200, the same as bf16 at
equal n.

GSM8K cannot exercise the gather, though: ~1k-token prompts never cross
`--chunked-prefill-size`, so `prefix_len` stays 0 and the gather is skipped. It was
validated separately by a unit test comparing gather-then-dequantize against
dequantize-then-gather (10/10 bitwise equal, plus bf16 passthrough), and by a
needle-in-haystack prompt recovered correctly at 23k and 47k tokens.

## Benchmarking and Profiling

fp8 versus bf16 KV at concurrency 1 is within ~1% on decode and single-chunk prefill.
The cost lands only on multi-chunk prefill, where the gather actually runs: +21% TTFT
at 24k input.

**CK varlen was evaluated as an alternative and rejected on speed.** `mha_varlen_fwd`
does build on gfx1250 — `fmha_fwd.py` emits `gfx125`-tagged, non-async `qr_vr` variants
including `d256` — and it reproduces an fp32 reference exactly, matching Triton's error
to five decimals. But it is slower on every shape measured (isolated kernel calls,
median of 50 after 10 warmup, single gfx1250 device):

| case | CK varlen | aiter Triton |
|---|---|---|
| single 512 | 0.292 ms | **0.237 ms** |
| single 4096 | 2.555 ms | **1.837 ms** |
| ragged 4 | 0.494 ms | **0.402 ms** |
| ragged 8 uneven | 0.923 ms | **0.875 ms** |
| batch 2 x 8192 | 17.166 ms | **12.713 ms** |

The gap widens with sequence length, which is the regime prefill cares about. The
likely reason is visible in the codegen: only `(128, 128)` gets the gfx1250 TDM
pipeline (`qr_tdm`), so this model's `d256` falls back to the untuned `qr_vr` tile
configuration. The gfx125 fp8 table is also capped at d128, with `(256, 256)`
commented out. CK is worth revisiting for this path once gfx1250 tuning matures.

## Notes for reviewers

- `SGLANG_AITER_VARLEN_PREFILL` is read with `get_bool_env_var` and is **not**
  registered in `python/sglang/srt/environ.py`, unlike neighbouring flags such as
  `SGLANG_USE_AITER_UNIFIED_ATTN`. Happy to add it if that is preferred.
- Which implementation serves this path depends on `ENABLE_CK`: `0` gives aiter Triton
  (what the accuracy numbers above were measured on), `1` gives CK varlen, which is
  correct but slower. The routing change is beneficial either way, since it avoids the
  `batch_prefill` build failure in both settings.
- Attention sinks are passed through as `sink_ptr`. With `ENABLE_CK=0` such a model
  stays on the same Triton path, but we have no sink-enabled model to test here.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34825226866](https://github.com/sgl-project/sglang/actions/runs/34825226866)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34825226766](https://github.com/sgl-project/sglang/actions/runs/34825226766)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34825226913](https://github.com/sgl-project/sglang/actions/runs/34825226913)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->