### PR TITLE
[NPU][Diffusion] FA MXFP8 and modelslim w4a4f8 and w8a8f8 support for Wan2.2 and FLUX

### DIFF
--- a/python/sglang/multimodal_gen/configs/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/wanvideo.py
@@ -30,6 +30,10 @@ class WanVideoArchConfig(DiTArchConfig):
             r"^blocks\.(\d+)\.ffn\.net\.0\.proj\.(.*)$": r"blocks.\1.ffn.fc_in.\2",
             r"^blocks\.(\d+)\.ffn\.net\.2\.(.*)$": r"blocks.\1.ffn.fc_out.\2",
             r"^blocks\.(\d+)\.norm2\.(.*)$": r"blocks.\1.self_attn_residual_norm.norm.\2",
+            r"^blocks\.(\d+)\.attn1\.to_q_rot$": r"blocks.\1.q_rot",
+            r"^blocks\.(\d+)\.attn1\.to_k_rot$": r"blocks.\1.k_rot",
+            r"^blocks\.(\d+)\.attn1\.q_rot$": r"blocks.\1.q_rot",
+            r"^blocks\.(\d+)\.attn1\.k_rot$": r"blocks.\1.k_rot",
         }
     )
 

--- a/python/sglang/multimodal_gen/envs.py
+++ b/python/sglang/multimodal_gen/envs.py
@@ -228,6 +228,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "SGLANG_DIFFUSION_ATTENTION_BACKEND": _lazy_str(
         "SGLANG_DIFFUSION_ATTENTION_BACKEND"
     ),
+    # MXFP8 Attention quantization
+    # Applies to both online ``MXFP8Config`` and offline ``ModelSlimConfig`` (W8A8_MXFP8)
+    # Q/K/V are getting offline rotating in case of rotation matrices in quant_config
+    # Otherwise rotation matrix are generating online
+    # Default value for MXFP8Config false, for ``ModelSlimConfig`` true
+    "SGLANG_DIFFUSION_ENABLE_MXFP8_ATTENTION": _lazy_bool(
+        "SGLANG_DIFFUSION_FA_MXFP8", "false"
+    ),
     # Use dedicated multiprocess context for workers.
     # Both spawn and fork work
     "SGLANG_DIFFUSION_WORKER_MULTIPROC_METHOD": _lazy_str(

--- a/python/sglang/multimodal_gen/envs.py
+++ b/python/sglang/multimodal_gen/envs.py
@@ -234,7 +234,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Otherwise rotation matrix are generating online
     # Default value for MXFP8Config false, for ``ModelSlimConfig`` true
     "SGLANG_DIFFUSION_ENABLE_MXFP8_ATTENTION": _lazy_bool(
-        "SGLANG_DIFFUSION_FA_MXFP8", "false"
+        "SGLANG_DIFFUSION_ENABLE_MXFP8_ATTENTION", "false"
     ),
     # Use dedicated multiprocess context for workers.
     # Both spawn and fork work

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/ascend_fa.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/ascend_fa.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -10,10 +11,42 @@ from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend i
     AttentionMetadata,
     AttentionMetadataBuilder,
 )
-from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+from sglang.multimodal_gen.runtime.platforms import (
+    AttentionBackendEnum,
+    current_platform,
+)
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.srt.environ import envs
 
 logger = init_logger(__name__)
+
+_is_npu = current_platform.is_npu()
+if _is_npu:
+    import torch_npu
+
+
+def resolve_mx_fa_scheme(quant_config) -> str | None:
+    """Resolve the opt-in MXFP8 attention scheme for an NPU quant config."""
+    if (
+        quant_config is None
+        or not _is_npu
+        or not envs.SGLANG_DIFFUSION_ENABLE_MXFP8_ATTENTION.get()
+    ):
+        return None
+    if type(quant_config).__name__ not in ("MXFP8Config", "ModelSlimConfig"):
+        return None
+    required_apis = (
+        "npu_dynamic_mx_quant",
+        "npu_fused_infer_attention_score_v2",
+    )
+    missing_apis = [name for name in required_apis if not hasattr(torch_npu, name)]
+    if missing_apis:
+        logger.warning_once(
+            "MXFP8 attention is disabled because torch_npu lacks: "
+            + ", ".join(missing_apis)
+        )
+        return None
+    return "MXFP8"
 
 
 def _packed_boundaries(
@@ -173,6 +206,7 @@ class AscendFAMetadataBuilder(AttentionMetadataBuilder):
 
 
 class AscendFABackend(AttentionBackend):
+
     @staticmethod
     def get_enum() -> AttentionBackendEnum:
         return AttentionBackendEnum.FA
@@ -197,6 +231,18 @@ class AscendFABackend(AttentionBackend):
 
 
 class AscendFAImpl(AttentionImpl):
+
+    _MXFP8_FA_PARAMS = {
+        "q_quant_mode": 6,
+        "k_quant_mode": 6,
+        "v_quant_mode": 8,
+        "qk_quant_axis": -1,
+        "v_quant_axis": 0,
+        "layout": "TND",
+    }
+    _rot_matrices: dict[int, torch.Tensor] = {}
+    _use_sub_head = int(os.getenv("USE_SUB_HEAD", "5"))
+
     def __init__(
         self,
         num_heads: int,
@@ -209,6 +255,46 @@ class AscendFAImpl(AttentionImpl):
     ) -> None:
         self.causal = causal
         self.softmax_scale = softmax_scale
+        self._quant_scheme = resolve_mx_fa_scheme(
+            extra_impl_args.get("quant_config")
+        )
+        self._is_cross_attention = bool(
+            extra_impl_args.get("is_cross_attention", False)
+        )
+        if self._quant_scheme is not None:
+            self._head_size = head_size
+            self._ensure_rot_matrix(head_size)
+            self._rot_device: torch.Tensor | None = None
+
+    @classmethod
+    def _ensure_rot_matrix(cls, head_size: int) -> None:
+        if head_size in cls._rot_matrices:
+            return
+        generator = torch.Generator(device="cpu")
+        generator.manual_seed(42)
+        rotation, _ = torch.linalg.qr(
+            torch.randn(
+                head_size,
+                head_size,
+                generator=generator,
+                device="cpu",
+                dtype=torch.float32,
+            )
+        )
+        cls._rot_matrices[head_size] = rotation
+
+    def _get_rotation(
+        self, device: torch.device, dtype: torch.dtype
+    ) -> torch.Tensor:
+        if (
+            self._rot_device is None
+            or self._rot_device.device != device
+            or self._rot_device.dtype != dtype
+        ):
+            self._rot_device = self._rot_matrices[self._head_size].to(
+                device=device, dtype=dtype
+            )
+        return self._rot_device
 
     def forward(
         self,
@@ -218,17 +304,51 @@ class AscendFAImpl(AttentionImpl):
         attn_metadata: AttentionMetadata,
         return_softmax_lse: bool = False,
     ) -> torch.Tensor:
+        if (
+            self._quant_scheme == "MXFP8"
+            and not self.causal
+            and not self._is_cross_attention
+            and query.shape[1:3] == key.shape[1:3]
+            and key.shape == value.shape
+            and (query.shape[0] * query.shape[1]) % 64 == 0
+        ):
+            batch_size, query_length, num_heads, head_size = query.shape
+            key_length = key.shape[1]
+            actual_seq_qlen = torch.arange(
+                query_length,
+                query_length * (batch_size + 1),
+                query_length,
+                dtype=torch.int64,
+                device=query.device,
+            )
+            actual_seq_kvlen = torch.arange(
+                key_length,
+                key_length * (batch_size + 1),
+                key_length,
+                dtype=torch.int64,
+                device=key.device,
+            )
+            output = self._forward_mxfp8_tnd(
+                query.reshape(-1, num_heads, head_size),
+                key.reshape(-1, key.shape[2], head_size),
+                value.reshape(-1, value.shape[2], head_size),
+                actual_seq_qlen=actual_seq_qlen,
+                actual_seq_kvlen=actual_seq_kvlen,
+                return_softmax_lse=return_softmax_lse,
+            )
+            return output.reshape(batch_size, query_length, num_heads, head_size)
+
         mask = None
         num_heads, num_key_value_heads = query.shape[2], key.shape[2]
         if self.causal:
             seq_len = query.shape[1]
             mask = torch.triu(
                 torch.ones(seq_len, seq_len, device=query.device), diagonal=1
-            ).bool()
+            ).bool()[None]
         # transpose to bs, heads, seq_len, head_dim
         query = query.transpose(1, 2)
-        key = key.transpose(1, 2)
-        value = value.transpose(1, 2)
+        key = key.transpose(1, 2).contiguous()
+        value = value.transpose(1, 2).contiguous()
         output, lse = torch.ops.npu.npu_fused_infer_attention_score(
             query,
             key,
@@ -256,6 +376,36 @@ class AscendFAImpl(AttentionImpl):
         cu_seqlens_host: tuple[int, ...] | None = None,
     ) -> torch.Tensor:
         del max_seqlen
+        if (
+            self._quant_scheme == "MXFP8"
+            and not self.causal
+            and query.shape == key.shape
+            and key.shape == value.shape
+            and query.shape[0] % 64 == 0
+        ):
+            boundaries = _packed_boundaries(
+                cu_seqlens, cu_seqlens_host, query.shape[0], "cu_seqlens"
+            )
+            actual_seq_lengths = [
+                stop
+                for start, stop in zip(boundaries[:-1], boundaries[1:])
+                if stop > start
+            ]
+            if not actual_seq_lengths:
+                return torch.empty_like(query)
+            actual_seq_lengths_tensor = torch.tensor(
+                actual_seq_lengths,
+                dtype=torch.int64,
+                device=query.device,
+            )
+            return self._forward_mxfp8_tnd(
+                query,
+                key,
+                value,
+                actual_seq_qlen=actual_seq_lengths_tensor,
+                actual_seq_kvlen=actual_seq_lengths_tensor,
+            )
+
         if self.causal:
             bounds = (
                 cu_seqlens_host
@@ -285,6 +435,110 @@ class AscendFAImpl(AttentionImpl):
             cu_seqlens_k_host=cu_seqlens_host,
             softmax_scale=self.softmax_scale,
         )
+
+    def _forward_mxfp8_tnd(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        *,
+        actual_seq_qlen: torch.Tensor,
+        actual_seq_kvlen: torch.Tensor,
+        return_softmax_lse: bool = False,
+    ) -> torch.Tensor:
+        if return_softmax_lse:
+            raise NotImplementedError(
+                "MXFP8 attention does not support returning softmax LSE"
+            )
+
+        logger.info_once("Using online MXFP8 quantized Ascend Flash Attention.")
+        rotation = self._get_rotation(query.device, query.dtype)
+        query = torch.matmul(query, rotation)
+        key = torch.matmul(key, rotation)
+
+        num_heads = query.shape[1]
+        num_kv_heads = key.shape[1]
+        if num_heads != num_kv_heads:
+            raise NotImplementedError("MXFP8 attention currently requires MHA")
+
+        sub_heads = self._use_sub_head
+        if sub_heads > 0 and num_heads > sub_heads:
+            head_groups = [sub_heads] * (num_heads // sub_heads)
+            if remainder := num_heads % sub_heads:
+                head_groups.append(remainder)
+            outputs = [
+                self._run_mxfp8_attention(
+                    query_chunk,
+                    key_chunk,
+                    value_chunk,
+                    actual_seq_qlen=actual_seq_qlen,
+                    actual_seq_kvlen=actual_seq_kvlen,
+                )
+                for query_chunk, key_chunk, value_chunk in zip(
+                    query.split(head_groups, dim=1),
+                    key.split(head_groups, dim=1),
+                    value.split(head_groups, dim=1),
+                )
+            ]
+            return torch.cat(outputs, dim=1)
+
+        return self._run_mxfp8_attention(
+            query,
+            key,
+            value,
+            actual_seq_qlen=actual_seq_qlen,
+            actual_seq_kvlen=actual_seq_kvlen,
+        )
+
+    def _run_mxfp8_attention(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        *,
+        actual_seq_qlen: torch.Tensor,
+        actual_seq_kvlen: torch.Tensor,
+    ) -> torch.Tensor:
+        params = self._MXFP8_FA_PARAMS
+        quant_dtype = torch.float8_e4m3fn
+        scale_dtype = torch_npu.float8_e8m0fnu
+        query = query.contiguous()
+        key = key.contiguous()
+        value = value.contiguous()
+        query_fp8, query_scale = torch_npu.npu_dynamic_mx_quant(
+            query, dst_type=quant_dtype, axis=params["qk_quant_axis"]
+        )
+        key_fp8, key_scale = torch_npu.npu_dynamic_mx_quant(
+            key, dst_type=quant_dtype, axis=params["qk_quant_axis"]
+        )
+        value_fp8, value_scale = torch_npu.npu_dynamic_mx_quant(
+            value, dst_type=quant_dtype, axis=params["v_quant_axis"]
+        )
+        return torch_npu.npu_fused_infer_attention_score_v2(
+            query_fp8,
+            key_fp8,
+            value_fp8,
+            input_layout=params["layout"],
+            num_query_heads=query.shape[1],
+            num_key_value_heads=key.shape[1],
+            softmax_scale=self.softmax_scale,
+            dequant_scale_query=query_scale,
+            dequant_scale_key=key_scale,
+            dequant_scale_value=value_scale,
+            actual_seq_qlen=actual_seq_qlen,
+            actual_seq_kvlen=actual_seq_kvlen,
+            sparse_mode=0,
+            query_quant_mode=params["q_quant_mode"],
+            key_quant_mode=params["k_quant_mode"],
+            value_quant_mode=params["v_quant_mode"],
+            query_dtype=quant_dtype,
+            key_dtype=quant_dtype,
+            value_dtype=quant_dtype,
+            dequant_scale_query_dtype=scale_dtype,
+            dequant_scale_key_dtype=scale_dtype,
+            dequant_scale_value_dtype=scale_dtype,
+            out_dtype=query.dtype,
+        )[0]
 
     def forward_ring_kv_chunk(
         self,

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/ascend_fa.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/ascend_fa.py
@@ -16,7 +16,7 @@ from sglang.multimodal_gen.runtime.platforms import (
     current_platform,
 )
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.srt.environ import envs
+from sglang.multimodal_gen import envs
 
 logger = init_logger(__name__)
 
@@ -30,7 +30,7 @@ def resolve_mx_fa_scheme(quant_config) -> str | None:
     if (
         quant_config is None
         or not _is_npu
-        or not envs.SGLANG_DIFFUSION_ENABLE_MXFP8_ATTENTION.get()
+        or not envs.SGLANG_DIFFUSION_ENABLE_MXFP8_ATTENTION
     ):
         return None
     if type(quant_config).__name__ not in ("MXFP8Config", "ModelSlimConfig"):

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/ascend_fa.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/ascend_fa.py
@@ -255,8 +255,12 @@ class AscendFAImpl(AttentionImpl):
     ) -> None:
         self.causal = causal
         self.softmax_scale = softmax_scale
-        self._quant_scheme = resolve_mx_fa_scheme(
-            extra_impl_args.get("quant_config")
+        quant_config = extra_impl_args.get("quant_config")
+        self._quant_scheme = resolve_mx_fa_scheme(quant_config)
+        self.use_offline_qk_rotation = (
+            quant_config.use_offline_qk_rotation
+            if hasattr(quant_config, "use_offline_qk_rotation")
+            else False
         )
         self._is_cross_attention = bool(
             extra_impl_args.get("is_cross_attention", False)
@@ -451,10 +455,11 @@ class AscendFAImpl(AttentionImpl):
                 "MXFP8 attention does not support returning softmax LSE"
             )
 
-        logger.info_once("Using online MXFP8 quantized Ascend Flash Attention.")
-        rotation = self._get_rotation(query.device, query.dtype)
-        query = torch.matmul(query, rotation)
-        key = torch.matmul(key, rotation)
+        logger.info_once("Using MXFP8 quantized Ascend Flash Attention.")
+        if not self.use_offline_qk_rotation:
+            rotation = self._get_rotation(query.device, query.dtype)
+            query = torch.matmul(query, rotation)
+            key = torch.matmul(key, rotation)
 
         num_heads = query.shape[1]
         num_kv_heads = key.shape[1]

--- a/python/sglang/multimodal_gen/runtime/layers/quantization/modelslim.py
+++ b/python/sglang/multimodal_gen/runtime/layers/quantization/modelslim.py
@@ -144,7 +144,11 @@ class ModelSlimConfig(QuantizationConfig):
                 ModelSlimMXFP4Scheme,
             )
 
-            return ModelSlimMXFP4Scheme()
+            return ModelSlimMXFP4Scheme(
+                quant_config=self.quant_description,
+                prefix=prefix,
+                quant_type=quant_type,
+            )
         raise NotImplementedError(
             f"No modelslim compatible scheme was found for layer '{layer_name}'. "
             f"quant_description['{layer_name}.weight'] = '{quant_type}'"

--- a/python/sglang/multimodal_gen/runtime/layers/quantization/modelslim_mxfp4_scheme.py
+++ b/python/sglang/multimodal_gen/runtime/layers/quantization/modelslim_mxfp4_scheme.py
@@ -201,7 +201,7 @@ class ModelSlimMXFP4Scheme(ModelSlimLinearScheme):
         if not self.is_dual_scale:
             if getattr(layer, "use_mul_scale", False):
                 x = x * layer.mul_scale.to(x.dtype)
-            return self.single_level_kernel.apply_weights(layer, x, bias)
+            return self.single_level_kernel.apply(layer, x, bias)
 
         original_dtype = x.dtype
         if original_dtype not in (torch.float16, torch.bfloat16):

--- a/python/sglang/multimodal_gen/runtime/layers/quantization/modelslim_mxfp4_scheme.py
+++ b/python/sglang/multimodal_gen/runtime/layers/quantization/modelslim_mxfp4_scheme.py
@@ -32,9 +32,41 @@ MXFP4_BLOCK_SIZE = 32
 # L1 (dual) scale groups this many L0 blocks together.
 # L1 block covers 16 * 32 = 512 elements.
 MXFP4_DUAL_LEVEL_RATIO = 16
-
+MXFP4_PACK_FACTOR = 2
 
 class ModelSlimMXFP4Scheme(ModelSlimLinearScheme):
+
+    def __init__(
+        self,
+        quant_config: dict,
+        prefix: str,
+        quant_type: str,
+    ):
+        self.quant_config = quant_config
+        self.prefix = prefix
+        self.quant_type = quant_type
+
+        self.is_dual_scale = quant_type == "W4A4_MXFP4_DUALSCALE"
+        self.dual_scale_key = prefix + ".weight_dual_scale"
+        self.mul_scale_key = prefix + ".mul_scale"
+        self.legacy_mul_scale_key = prefix + ".div.mul_scale"
+        self.has_mul_scale = (
+            self.legacy_mul_scale_key in quant_config
+            and self.mul_scale_key in quant_config
+        )
+        self.single_level_kernel = None
+        if not self.is_dual_scale:
+            from sglang.srt.hardware_backend.npu.quantization.linear_method_npu import (
+                NPUSingleLevelMXFP4OfflineLinearMethod
+            )
+            self.single_level_kernel = NPUSingleLevelMXFP4OfflineLinearMethod()
+        else:
+            if self.is_dual_scale_key not in self.quant_config:
+                raise ValueError(
+                    f"Dual-level MXFP4 quantization requires missing '{self.dual_scale_key}' in quant_config."
+                    "Check that the model was exported with dual-level quantization."
+                )
+
     def create_weights(
         self,
         layer: torch.nn.Module,
@@ -53,8 +85,8 @@ class ModelSlimMXFP4Scheme(ModelSlimLinearScheme):
         # (npu_dtype_cast → float4_e2m1fn_x2) happens in process_weights_after_loading.
         weight = ModelWeightParameter(
             data=torch.empty(
-                (output_size_per_partition, input_size_per_partition),
-                dtype=torch.float8_e4m3fn,
+                (output_size_per_partition, input_size_per_partition // MXFP4_PACK_FACTOR),
+                dtype=torch.uint8,
             ),
             input_dim=1,
             output_dim=0,
@@ -74,40 +106,51 @@ class ModelSlimMXFP4Scheme(ModelSlimLinearScheme):
             weight_loader=weight_loader,
         )
         layer.register_parameter("weight_scale", weight_scale)
+        if self.is_dual_scale:
+            # L0 (coarse) scale for dual-level quantization matmul.
+            # Each L0 block covers MXFP4_DUAL_LEVEL_RATIO L1 blocks = 16 * 32 = 512 elements.
+            dual_scale_dim = scale_dim // MXFP4_DUAL_LEVEL_RATIO  # in/32 / 16 = in/512
+            weight_dual_scale = GroupQuantScaleParameter(
+                data=torch.empty(
+                    (output_size_per_partition, dual_scale_dim, 1),
+                    dtype=torch.float32,
+                ),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+            )
+            weight_dual_scale.missing_param_init = "error"
+            layer.register_parameter("weight_dual_scale", weight_dual_scale)
 
-        # L0 (coarse) scale for dual-level quantization matmul.
-        # Each L0 block covers MXFP4_DUAL_LEVEL_RATIO L1 blocks = 16 * 32 = 512 elements.
-        dual_scale_dim = scale_dim // MXFP4_DUAL_LEVEL_RATIO  # in/32 / 16 = in/512
-        weight_dual_scale = GroupQuantScaleParameter(
-            data=torch.empty(
-                (output_size_per_partition, dual_scale_dim, 1),
-                dtype=torch.float32,
-            ),
-            input_dim=1,
-            output_dim=0,
-            weight_loader=weight_loader,
-        )
-        layer.register_parameter("weight_dual_scale", weight_dual_scale)
-
-        # Smooth quant activation scale (mul_scale) from NonFusionSmoothQuantWrapper.
-        # msmodelslim exports this as `<prefix>.div.mul_scale` with shape [in].
-        # After repack, it becomes `<prefix>.mul_scale`.
-        # This is CRITICAL: the offline-quantized weights were calibrated with
-        # x * mul_scale applied to the activation. Omitting it causes mosaic output.
-        mul_scale = BasevLLMParameter(
-            data=torch.empty(
-                (input_size_per_partition,),
-                dtype=torch.float32,
-            ),
-            weight_loader=weight_loader,
-        )
-        # If mul_scale is not in the checkpoint (e.g. non-smooth-quant model
-        # or old repack without .div. handling), initialize to ones so that
-        # x * 1.0 = x (no-op). fsdp_load.py checks this attribute.
-        mul_scale.missing_param_init = "ones"
-        layer.register_parameter("mul_scale", mul_scale)
+        if self.has_mul_scale:
+            # Smooth quant activation scale (mul_scale) from NonFusionSmoothQuantWrapper.
+            # msmodelslim exports this as `<prefix>.div.mul_scale` with shape [in].
+            # After repack, it becomes `<prefix>.mul_scale`.
+            # This is CRITICAL: the offline-quantized weights were calibrated with
+            # x * mul_scale applied to the activation. Omitting it causes mosaic output.
+            mul_scale = BasevLLMParameter(
+                data=torch.empty(
+                    (input_size_per_partition,),
+                    dtype=torch.float32,
+                ),
+                weight_loader=weight_loader,
+            )
+            mul_scale.missing_param_init = "error"
+            layer.register_parameter("mul_scale", mul_scale)
 
     def process_weights_after_loading(self, layer: torch.nn.Module):
+        if not self.is_dual_scale:
+            self.single_level_kernel.process_weights_after_loading(layer)
+            if self.has_mul_scale:
+                mul_scale = layer.mul_scale.data
+                if not mul_scale.is_npu:
+                    mul_scale = mul_scale.to(f"npu:{torch.npu.current_device()}")
+                layer.mul_scale = torch.nn.Parameter(mul_scale, requires_grad=False)
+                layer.use_mul_scale = not torch.all(mul_scale == 1.0).item()
+            else:
+                layer.use_mul_scale = False
+            return
+
         # Cast weight from fp8 container to FP4 packed format
         weight = layer.weight.data
         if not weight.is_npu:
@@ -127,23 +170,27 @@ class ModelSlimMXFP4Scheme(ModelSlimLinearScheme):
         weight_scale = weight_scale.reshape(weight_scale.shape[0], -1, 2)
         layer.weight_scale = torch.nn.Parameter(weight_scale, requires_grad=False)
 
-        # Transform weight_dual_scale: [out, in/512, 1] -> [in/512, out]
-        weight_dual_scale = layer.weight_dual_scale.data
-        if not weight_dual_scale.is_npu:
-            weight_dual_scale = weight_dual_scale.to(
-                f"npu:{torch.npu.current_device()}"
+        if self.is_dual_scale:
+            # Transform weight_dual_scale: [out, in/512, 1] -> [in/512, out]
+            weight_dual_scale = layer.weight_dual_scale.data
+            if not weight_dual_scale.is_npu:
+                weight_dual_scale = weight_dual_scale.to(
+                    f"npu:{torch.npu.current_device()}"
+                )
+            weight_dual_scale = weight_dual_scale.squeeze(-1).transpose(0, 1).contiguous()
+            layer.weight_dual_scale = torch.nn.Parameter(
+                weight_dual_scale, requires_grad=False
             )
-        weight_dual_scale = weight_dual_scale.squeeze(-1).transpose(0, 1).contiguous()
-        layer.weight_dual_scale = torch.nn.Parameter(
-            weight_dual_scale, requires_grad=False
-        )
 
-        # Move mul_scale to NPU if present and not already there
-        mul_scale = layer.mul_scale.data
-        if not mul_scale.is_npu:
-            mul_scale = mul_scale.to(f"npu:{torch.npu.current_device()}")
-        layer.mul_scale = torch.nn.Parameter(mul_scale, requires_grad=False)
-        layer.use_mul_scale = not torch.all(mul_scale == 1.0).item()
+        if self.has_mul_scale:
+            # Move mul_scale to NPU if present and not already there
+            mul_scale = layer.mul_scale.data
+            if not mul_scale.is_npu:
+                mul_scale = mul_scale.to(f"npu:{torch.npu.current_device()}")
+            layer.mul_scale = torch.nn.Parameter(mul_scale, requires_grad=False)
+            layer.use_mul_scale = not torch.all(mul_scale == 1.0).item()
+        else:
+            layer.use_mul_scale = False
 
     def apply_weights(
         self,
@@ -151,6 +198,10 @@ class ModelSlimMXFP4Scheme(ModelSlimLinearScheme):
         x: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        if not self.is_dual_scale:
+            if getattr(layer, "use_mul_scale", False):
+                x = x * layer.mul_scale.to(x.dtype)
+            return self.single_level_kernel.apply_weights(layer, x, bias)
 
         original_dtype = x.dtype
         if original_dtype not in (torch.float16, torch.bfloat16):
@@ -165,7 +216,7 @@ class ModelSlimMXFP4Scheme(ModelSlimLinearScheme):
         # The offline-quantized weights were calibrated under x * mul_scale,
         # so we MUST apply it here for scale alignment.
         mul_scale = layer.mul_scale
-        if getattr(layer, "use_mul_scale", True):
+        if getattr(layer, "use_mul_scale", False):
             x_2d = x_2d * mul_scale.to(x_2d.dtype)
 
         # Dual-level MXFP4 activation quantization

--- a/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
+++ b/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
@@ -201,7 +201,25 @@ def _maybe_dequantize_fp8(
     scale_key = target_param_name.rsplit(".", 1)[0] + ".weight_scale"
     scale_tensor = param_sd.get(scale_key)
     if scale_tensor is not None:
-        full_tensor = full_tensor.to(torch.float32) * scale_tensor.float()
+        if (
+            scale_tensor.dtype == torch.uint8
+            and full_tensor.ndim == scale_tensor.ndim
+            and full_tensor.shape[:1] == scale_tensor.shape[:1]
+            and full_tensor.shape[-1] == scale_tensor.shape[-1] * 32
+        ):
+            scale = torch.exp2(scale_tensor.float() - 127.0)
+            blocked_shape = (
+                *full_tensor.shape[:-1],
+                scale_tensor.shape[-1],
+                32
+            )
+            full_tensor = (
+                full_tensor.float().reshape(blocked_shape)
+                * scale.unsqueeze(-1)
+            ).reshape(full_tensor.shape)
+        else:
+            full_tensor = full_tensor.to(torch.float32) * scale_tensor.float()
+
         logger.debug(
             "Auto-dequantized FP8 weight %s using %s",
             target_param_name,

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux.py
@@ -620,6 +620,7 @@ class FluxAttention(torch.nn.Module, AttentionModuleMixin):
                 prefix=f"{prefix}.to_add_out" if prefix else "",
             )
 
+        # TODO Need to create mxfp8 attention scheme and refactor the code below
         quant_description = getattr(quant_config, "quant_description", {})
         self.use_offline_qk_rotation = (
             quant_description.get(f"{prefix}.q_rot") == "FLOAT"
@@ -726,10 +727,11 @@ class FluxAttention(torch.nn.Module, AttentionModuleMixin):
                 allow_inplace=True,
             )
 
-        # TODO pass rot matrices to the attention cls to avoid extra matmuls here.
         if self.use_offline_qk_rotation:
-            query = torch.matmul(query, self.q_rot.to(query))
-            key = torch.matmul(key, self.k_rot.to(key))
+            self.q_rot = self.q_rot.to(device=query.device, dtype=query.dtype)
+            self.k_rot = self.k_rot.to(device=key.device, dtype=key.dtype)
+            query = torch.matmul(query, self.q_rot)
+            key = torch.matmul(key, self.k_rot)
 
         x = self.attn(
             query,

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux.py
@@ -620,12 +620,39 @@ class FluxAttention(torch.nn.Module, AttentionModuleMixin):
                 prefix=f"{prefix}.to_add_out" if prefix else "",
             )
 
+        quant_description = getattr(quant_config, "quant_description", {})
+        self.use_offline_qk_rotation = (
+            quant_description.get(f"{prefix}.q_rot") == "FLOAT"
+            and quant_description.get(f"{prefix}.k_rot") == "FLOAT"
+        )
+        if self.use_offline_qk_rotation:
+            self.register_buffer(
+                "q_rot",
+                torch.empty(
+                    self.head_dim,
+                    self.head_dim,
+                    dtype=torch.bfloat16,
+                ),
+                persistent=True,
+            )
+            self.register_buffer(
+                "k_rot",
+                torch.empty(
+                    self.head_dim,
+                    self.head_dim,
+                    dtype=torch.bfloat16,
+                ),
+                persistent=True,
+            )
+            quant_config.use_offline_qk_rotation = True
+
         self.attn = USPAttention(
             num_heads=self.local_heads if self.shard_qkv else num_heads,
             head_size=self.head_dim,
             dropout_rate=0,
             softmax_scale=None,
             causal=False,
+            quant_config=quant_config,
         )
 
     def forward(
@@ -698,6 +725,11 @@ class FluxAttention(torch.nn.Module, AttentionModuleMixin):
                 is_neox=False,
                 allow_inplace=True,
             )
+
+        # TODO pass rot matrices to the attention cls to avoid extra matmuls here.
+        if self.use_offline_qk_rotation:
+            query = torch.matmul(query, self.q_rot.to(query))
+            key = torch.matmul(key, self.k_rot.to(key))
 
         x = self.attn(
             query,

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -667,6 +667,14 @@ def _minimax_h3_attention_core_impl(
         return out
 
     if ring_active:
+        if (
+            attention._quant_attn_backend is not None
+            and current_platform.is_npu()
+        ):
+            raise NotImplementedError(
+                "MiniMax H3 MXFP8 attention does not support ring parallelism"
+                "FA-v2 does not return the softmax LSE used by ring merge"
+            )
         ring_ws, _ = get_ring_ctx()
         if attention._attention_backend_enum is not AttentionBackendEnum.FA:
             raise NotImplementedError(
@@ -758,6 +766,17 @@ class MiniMaxH3Attention(nn.Module):
         self.local_inner_dim = self.num_heads * self.head_dim
         self.softmax_scale = self.head_dim**-0.5
         self.prefix = prefix
+        self.quant_config = quant_config
+        self._quant_attn_backend: AttentionBackendEnum | None = None
+
+        if current_platform.is_npu():
+            from sglang.multimodal_gen.runtime.layers.attention.backends.ascend_fa import (
+                resolve_mx_fa_scheme,
+            )
+
+            if resolve_mx_fa_scheme(quant_config) is not None:
+                self._quant_attn_backend = AttentionBackendEnum.FA
+
         self._attention_impl = None
         self._attention_backend_enum: AttentionBackendEnum | None = None
         # attention initializes on the first real QKV tensors, after the
@@ -847,6 +866,7 @@ class MiniMaxH3Attention(nn.Module):
             num_kv_heads=self.num_heads,
             prefix=self.prefix,
             packed_trailing_padding=True,
+            quant_config=self.quant_config,
         )
         # Ring only supports FA (see _minimax_h3_attention_core_impl); keep
         # the resolved enum alongside the impl instance instead of a second

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -1303,8 +1303,11 @@ class QwenImageTransformerBlock(nn.Module):
             hidden_size=dim, eps=eps, elementwise_affine=False
         )
 
-        self.use_offline_qk_rotation = self._has_modelslim_qk_rotation(
-            quant_config, prefix
+        # TODO Need to create mxfp8 attention scheme and refactor the code below
+        quant_description = getattr(quant_config, "quant_description", {})
+        self.use_offline_qk_rotation = (
+            quant_description.get(f"{prefix}.q_rot") == "FLOAT"
+            and quant_description.get(f"{prefix}.k_rot") == "FLOAT"
         )
         if self.use_offline_qk_rotation:
             self.register_buffer(
@@ -1439,28 +1442,6 @@ class QwenImageTransformerBlock(nn.Module):
         self._fp8_img_mlp_norm_quant = False
         self._fp8_txt_mlp_norm_quant = False
 
-    def _has_modelslim_qk_rotation(
-        self,
-        quant_config: Optional[QuantizationConfig],
-        prefix: str,
-    ):
-        quant_description = getattr(quant_config, "quant_description")
-        if not isinstance(quant_config, dict):
-            return False
-
-        q_rot_key = f"{prefix}.q_rot"
-        k_rot_key = f"{prefix}.k_rot"
-
-        has_q_rot = q_rot_key in quant_description
-        has_k_rot = k_rot_key in quant_description
-
-        if has_q_rot != has_k_rot:
-            raise ValueError(
-                f"Quantization description must contain both {q_rot_key} and {k_rot_key} or neither."
-                "Probably you should requantize your model. "
-            )
-
-        return has_q_rot
 
     @staticmethod
     def _valid_modelopt_fp8_linear(linear: nn.Module) -> bool:

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -901,6 +901,7 @@ class QwenImageCrossAttention(nn.Module):
                 AttentionBackendEnum.SAGE_ATTN_3,
                 AttentionBackendEnum.SPARGE_ATTN,
             },
+            quant_config=quant_config,
         )
 
     def _get_added_qkv_projections(
@@ -1105,6 +1106,14 @@ class QwenImageCrossAttention(nn.Module):
             joint_key = join_seqs(txt_key, img_key, sp_txt_pad)
             joint_value = join_seqs(txt_value, img_value, sp_txt_pad)
 
+        # TODO pass rot matrices to the attention cls to avoid extra matmuls here.
+        if "q_rot" in cross_attention_kwargs and "k_rot" in cross_attention_kwargs:
+            q_rot = cross_attention_kwargs["q_rot"].to(device=joint_query.devce, dtype=joint_query.dtype)
+            k_rot = cross_attention_kwargs["k_rot"].to(device=joint_key.devce, dtype=joint_key.dtype)
+
+            joint_query = torch.matmul(joint_query, q_rot)
+            joint_key = torch.matmul(joint_key, k_rot)
+
         # Compute joint attention
         joint_hidden_states = self.attn(
             joint_query,
@@ -1294,6 +1303,30 @@ class QwenImageTransformerBlock(nn.Module):
             hidden_size=dim, eps=eps, elementwise_affine=False
         )
 
+        self.use_offline_qk_rotation = self._has_modelslim_qk_rotation(
+            quant_config, prefix
+        )
+        if self.use_offline_qk_rotation:
+            self.register_buffer(
+                "q_rot",
+                torch.empty(
+                    attention_head_dim,
+                    attention_head_dim,
+                    dtype=torch.bfloat16,
+                ),
+                persistent=True,
+            )
+            self.register_buffer(
+                "k_rot",
+                torch.empty(
+                    attention_head_dim,
+                    attention_head_dim,
+                    dtype=torch.bfloat16,
+                ),
+                persistent=True,
+            )
+            quant_config.use_offline_qk_rotation=True
+
         self.attn = QwenImageCrossAttention(
             dim=dim,
             num_heads=num_attention_heads,
@@ -1405,6 +1438,29 @@ class QwenImageTransformerBlock(nn.Module):
         self._fp8_txt_attn_norm_quant = False
         self._fp8_img_mlp_norm_quant = False
         self._fp8_txt_mlp_norm_quant = False
+
+    def _has_modelslim_qk_rotation(
+        self,
+        quant_config: Optional[QuantizationConfig],
+        prefix: str,
+    ):
+        quant_description = getattr(quant_config, "quant_description")
+        if not isinstance(quant_config, dict):
+            return False
+
+        q_rot_key = f"{prefix}.q_rot"
+        k_rot_key = f"{prefix}.k_rot"
+
+        has_q_rot = q_rot_key in quant_description
+        has_k_rot = k_rot_key in quant_description
+
+        if has_q_rot != has_k_rot:
+            raise ValueError(
+                f"Quantization description must contain both {q_rot_key} and {k_rot_key} or neither."
+                "Probably you should requantize your model. "
+            )
+
+        return has_q_rot
 
     @staticmethod
     def _valid_modelopt_fp8_linear(linear: nn.Module) -> bool:
@@ -1876,6 +1932,9 @@ class QwenImageTransformerBlock(nn.Module):
         # 3. Concatenates and runs joint attention
         # 4. Splits results back to separate streams
         joint_attention_kwargs = joint_attention_kwargs or {}
+        if self.use_offline_qk_rotation:
+            joint_attention_kwargs["q_rot"] = self.q_rot
+            joint_attention_kwargs["k_rot"] = self.k_rot
         attn_output = self.attn(
             # Image stream (will be processed as "sample")
             hidden_states=img_modulated,

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -513,11 +513,11 @@ class WanTransformerBlock(nn.Module):
                 prefix=add_prefix("attn1", prefix),
             )
         else:
-
+            # TODO Need to create mxfp8 attention scheme and refactor the code below
             quant_description = getattr(quant_config, "quant_description", {})
             self.use_offline_qk_rotation = (
-                quant_description.get(f"{prefix}.q_rot") == "FLOAT"
-                and quant_description.get(f"{prefix}.k_rot") == "FLOAT"
+                quant_description.get(f"{prefix}.attn1.q_rot") == "FLOAT"
+                and quant_description.get(f"{prefix}.attn1.k_rot") == "FLOAT"
             )
             if self.use_offline_qk_rotation:
                 self.register_buffer(
@@ -713,8 +713,11 @@ class WanTransformerBlock(nn.Module):
             )
 
         if self.use_offline_qk_rotation:
-            query = torch.matmul(query, self.q_rot.to(device=query.device, dtype=query.dtype))
-            key = torch.matmul(key, self.k_rot.to(device=key.device, dtype=key.dtype))
+            self.q_rot = self.q_rot.to(device=query.device, dtype=query.dtype)
+            self.k_rot = self.k_rot.to(device=key.device, dtype=key.dtype)
+            query = torch.matmul(query, self.q_rot)
+            key = torch.matmul(key, self.k_rot)
+
         attn_output = self.attn1(query, key, value)
         attn_output = attn_output.flatten(2)
         attn_output, _ = self.to_out(attn_output)

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -492,6 +492,10 @@ class WanTransformerBlock(nn.Module):
             quant_config=quant_config,
             prefix=add_prefix("to_out", prefix),
         )
+        self.hidden_dim = dim
+        self.num_attention_heads = num_heads
+        self.dim_head = dim // num_heads
+
         tp_size = get_tp_world_size()
         self.local_num_heads = divide(num_heads, tp_size)
         self_attn_backends = supported_attention_backends
@@ -509,6 +513,33 @@ class WanTransformerBlock(nn.Module):
                 prefix=add_prefix("attn1", prefix),
             )
         else:
+
+            quant_description = getattr(quant_config, "quant_description", {})
+            self.use_offline_qk_rotation = (
+                quant_description.get(f"{prefix}.q_rot") == "FLOAT"
+                and quant_description.get(f"{prefix}.k_rot") == "FLOAT"
+            )
+            if self.use_offline_qk_rotation:
+                self.register_buffer(
+                    "q_rot",
+                    torch.empty(
+                        self.dim_head,
+                        self.dim_head,
+                        dtype=torch.bfloat16,
+                    ),
+                    persistent=True,
+                )
+                self.register_buffer(
+                    "k_rot",
+                    torch.empty(
+                        self.dim_head,
+                        self.dim_head,
+                        dtype=torch.bfloat16,
+                    ),
+                    persistent=True,
+                )
+                quant_config.use_offline_qk_rotation = True
+
             self.attn1 = USPAttention(
                 num_heads=self.local_num_heads,
                 head_size=dim // num_heads,
@@ -519,9 +550,6 @@ class WanTransformerBlock(nn.Module):
                 is_cross_attention=False,
             )
 
-        self.hidden_dim = dim
-        self.num_attention_heads = num_heads
-        self.dim_head = dim // num_heads
         if qk_norm == "rms_norm":
             self.norm_q = RMSNorm(self.dim_head, eps=eps)
             self.norm_k = RMSNorm(self.dim_head, eps=eps)
@@ -683,6 +711,10 @@ class WanTransformerBlock(nn.Module):
                 _apply_rotary_emb(query, cos, sin, is_neox_style=False),
                 _apply_rotary_emb(key, cos, sin, is_neox_style=False),
             )
+
+        if self.use_offline_qk_rotation:
+            query = torch.matmul(query, self.q_rot.to(device=query.device, dtype=query.dtype))
+            key = torch.matmul(key, self.k_rot.to(device=key.device, dtype=key.dtype))
         attn_output = self.attn1(query, key, value)
         attn_output = attn_output.flatten(2)
         attn_output, _ = self.to_out(attn_output)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
This PR adds Ascend NPU support for **ModelSlim W4A4F8 and W8A8F8 diffusion checkpoints**, targeting **Wan2.2-I2V-A14B**, **FLUX.1-dev**.

The main goal is to support mxfp8 attention and the complete offline quantization flow produced by ModelSlim :

* quantized linear layers using MXFP4/MXFP8 formats;
* MXFP8 Flash Attention for self-attention;
* offline Q/K rotation matrices (`q_rot` / `k_rot`) stored in the quantized checkpoint.

The MXFP8 attention path is also available for online MXFP8 quantization.

## Modifications

### MXFP8 Flash Attention

Add an MXFP8 path to the Ascend FA backend using:

* `torch_npu.npu_dynamic_mx_quant` for dynamic Q/K/V quantization;
* `torch_npu.npu_fused_infer_attention_score_v2` for MXFP8 attention;

MXFP8 attention is enabled through:

```bash
SGLANG_DIFFUSION_ENABLE_MXFP8_ATTENTION=1
```

The optimized path is currently used for supported non-causal self-attention cases. Unsupported layouts, cross-attention, and other incompatible cases continue to use the existing attention path. 

For online quantization, Q and K are rotated with a shared rotation matrix generated deterministically with a fixed seed before MXFP8 quantization.

The implementation also keeps the existing heads splitting optimization controlled by `SGLANG_DIFFUSION_MXFP8_FA_HEAD_CHUNK_SIZE` to improve performance for large head counts.

For Wan2.2-I2V-A14B, the best performance for 720P video generation is achieved with ```SGLANG_DIFFUSION_MXFP8_FA_HEAD_CHUNK_SIZE=5```. The default value of 4 may lead to the slight performance degradation for small image generation tasks (e.g., FLUX.1-dev 1024x1024). In such cases, it is better to set ```SGLANG_DIFFUSION_MXFP8_FA_HEAD_CHUNK_SIZE=0```. Currently, there is no automatic configuration for this variable.

#### MXFP8  FA limitations:
* Ascend 950, is not available for A2/A3
* CANN >= 9.1.1
* The total number of tokens should be divisible by 64; 
* Does not support causal mask
* Does not support ring attention (return_lse)

### Offline ModelSlim Q/K rotation

ModelSlim W4A4F8/W8A8F8 checkpoints can contain pre-generated `q_rot` and `k_rot` tensors.

This PR:

* detects these tensors through `quant_model_description.json`;
* registers and loads them for Wan2.2 and FLUX attention blocks;
* applies the offline rotations before entering the MXFP8 FA backend;
* adds the required Wan2.2 checkpoint-name mappings.

When offline rotation tensors are present, the FA backend does not generate or apply an additional online rotation.

Currently the rotation tensors are registered at the model attention level. A follow-up refactor will move this handling into a dedicated MXFP8 attention quantization scheme.

### ModelSlim MXFP4 linear support

Extend `ModelSlimMXFP4Scheme` so that the scheme has access to the quantization description, layer prefix, and quantization type.

This enables loading ModelSlim MXFP4 checkpoint metadata required by W4A4F8 models, including:

* packed MXFP4 weights;
* block scales;
* dual-level weight scales;
* activation `mul_scale` generated by ModelSlim smooth quantization.

The existing single-level MXFP4 path is preserved.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
Environment:
* Ascend 950 PR
* torch 2.10.0
* torch_npu 2.10.0.post4
* CANN 9.1.1

Tested with msmodelslim-quantized models:

- Wan2.2-I2V-A14B-Diffusers
- Wan2.2-I2V-A14B-Diffusers-w8a8f8
- Wan2.2-I2V-A14B-Diffusers-w4a4f8
- FLUX.1-dev
- FLUX.1-dev-w8a8f8

- FLUX launch server command:
```
SGLANG_DIFFUSION_ENABLE_MXFP8_ATTENTION=1 SGLANG_CACHE_DIT_FN=2 SGLANG_CACHE_DIT_BN=1 SGLANG_CACHE_DIT_WARMUP=4 SGLANG_CACHE_DIT_RDT=0.4 SGLANG_CACHE_DIT_MC=4 SGLANG_CACHE_DIT_TAYLORSEER=true SGLANG_CACHE_DIT_TS_ORDER=2 SGLANG_CACHE_DIT_ENABLED=true  sglang serve --model-path ~/models/black-forest-labs/FLUX.1-dev-w8a8f8 --ulysses-degree 1 --num-gpus 1 --attention-backend fa --port 30088  --dit-cpu-offload false --warmup-resolutions 1024x1024 --warmup-steps 50 --warmup-mode server
```
- FLUX request:
```
 curl -sS -X POST "http://localhost:30088/v1/images/generations" -H "Content-Type: application/json" -d '{"prompt": "Curious raccoon", "size": "2048x2048", "num_inference_steps": 50}'
```
- Wan2.2 launch server command:
```
SGLANG_DIFFUSION_ENABLE_MXFP8_ATTENTION=1 SGLANG_CACHE_DIT_FN=2 SGLANG_CACHE_DIT_BN=1 SGLANG_CACHE_DIT_WARMUP=4 SGLANG_CACHE_DIT_RDT=0.4 SGLANG_CACHE_DIT_MC=4 SGLANG_CACHE_DIT_TAYLORSEER=true SGLANG_CACHE_DIT_TS_ORDER=2 SGLANG_CACHE_DIT_ENABLED=true  sglang serve --model-path ~/models/Wan-AI/Wan2.2-I2V-A14B-Diffusers-w8a8f8 --tp-size 2    --sp-degree 2   --ulysses-degree 2 --num-gpus 4  --attention-backend fa --port 30088  --warmup-resolutions 1280x720 --warmup-steps 40 --warmup-num-frames 13 --warmup-mode server
```
- Wan2.2 request:
```
curl -sS -X POST http://127.0.0.1:30088/v1/videos -F "model=~/models/Wan-AI/Wan2.2-I2V-A14B-Diffusers-w8a8f8" -F "input_reference=@raccoon.jpg" -F "prompt=Curious raccoon" -F "size=1280x720" -F "num_frames=77" -F "num_inference_steps=40"
```
* The only difference in commands is `SGLANG_DIFFUSION_ENABLE_MXFP8_ATTENTION` and model weights
* Quantized models will be available in modelscope soon, is it possible to quantize it locally, read msmodelslim docs https://gitcode.com/Ascend/msmodelslim

#### FLUX PR Benchmarks

| Configuration | Denoising Stage (s) | Generation time (s)| Peak memory usage, (MB) |
| :--- | :---: | :---: | :---: |
| **bf16** | 31.62 | 32.38 | 48298 |
| **fp8 + attn bf16** | 28.97 | 29.73 | 43188 |
| **fp8 + attn fp8** | 19.46 | 20.19 | 43190 |

#### Wan2.2 PR Benchmarks
| Configuration | Denoising Stage (s) | Generation time (s)| Peak memory usage, (MB) |
| :--- | :---: | :---: | :---: |
| bf16 | 289.28 | 299.46 | 42758 |
| fp8 + attn bf16 | 267.32 | 278.26 | 36020 |
| fp4 + attn bf16 | 261.66 | 271.33 | 34488 |
| fp8 + attn fp8 | 191.08 | 201.67 | 36024 |
| fp4 + attn fp8 | 193.66 | 203.7 | 33678 |


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #35190930979](https://github.com/sgl-project/sglang/actions/runs/35190930979)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35190930764](https://github.com/sgl-project/sglang/actions/runs/35190930764)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:hourglass_flowing_sand: [Run #35190930843](https://github.com/sgl-project/sglang/actions/runs/35190930843)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->