### PR TITLE
[Fix] Don't write conv state from the fused KDA verify kernel

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/fused_kda_conv_recurrent_verify.py
+++ b/python/sglang/kernels/ops/attention/fla/fused_kda_conv_recurrent_verify.py
@@ -12,9 +12,13 @@ two transpose copies the unfused path needs to feed the conv kernel.
 
 Scope (v1): chain speculation only (``speculative_eagle_topk == 1``, i.e.
 ``retrieve_next_token is None``). The tree path keeps the unfused reference
-kernels. Requires ``T >= kernel_width - 1`` (the rolled conv state is then
-exactly the last ``kernel_width - 1`` input tokens, matching the reference
-kernel's store).
+kernels. Requires ``T >= kernel_width - 1``.
+
+State: conv_state and the SSM state are read-only here. Verify is speculative,
+and the commit scatter advances conv_state from the selected intermediate
+window, so writing it back is both redundant and unsafe -- all V tiles read
+the same Q/K conv history, so a tile in a later wave would read the rolled
+values.
 
 Numerics: deliberately bit-aligned with the unfused pair. The conv output is
 rounded to the activation dtype (bf16) before entering the recurrence —
@@ -318,19 +322,9 @@ def fused_kda_conv_gating_verify_kernel(
                 )
                 tl.store(cache_ptr, b_h.to(cache_ptr.dtype.element_ty), mask=mask_h)
 
-    # Rolled conv state after consuming T >= W-1 tokens is exactly the last
-    # W-1 input tokens — which are the current window registers. The verify
-    # pass never writes the ssm state back (rollback happens at commit).
-    if is_qk_owner:
-        tl.store(cs_base + q_ch + 0 * stride_cs_tok, q_c0, mask=mask_k)
-        tl.store(cs_base + q_ch + 1 * stride_cs_tok, q_c1, mask=mask_k)
-        tl.store(cs_base + q_ch + 2 * stride_cs_tok, q_c2, mask=mask_k)
-        tl.store(cs_base + k_ch + 0 * stride_cs_tok, k_c0, mask=mask_k)
-        tl.store(cs_base + k_ch + 1 * stride_cs_tok, k_c1, mask=mask_k)
-        tl.store(cs_base + k_ch + 2 * stride_cs_tok, k_c2, mask=mask_k)
-    tl.store(cs_base + v_ch + 0 * stride_cs_tok, v_c0, mask=mask_v)
-    tl.store(cs_base + v_ch + 1 * stride_cs_tok, v_c1, mask=mask_v)
-    tl.store(cs_base + v_ch + 2 * stride_cs_tok, v_c2, mask=mask_v)
+    # No conv-state writeback: every V tile reads the same Q/K history, so a
+    # tile scheduled in a later wave would read what i_v == 0 had overwritten.
+    # The commit scatter advances conv_state from the selected window instead.
 
 
 def fused_kda_conv_gating_verify(

--- a/python/sglang/kernels/ops/attention/fla/fused_kda_conv_recurrent_verify.py
+++ b/python/sglang/kernels/ops/attention/fla/fused_kda_conv_recurrent_verify.py
@@ -352,14 +352,14 @@ def fused_kda_conv_gating_verify(
     softplus_beta: float = 1.0,
     softplus_threshold: float = 20.0,
     use_qk_l2norm_in_kernel: bool = True,
-    # num_warps=4 is ~1.3x faster than the unfused pair in-graph; the output,
-    # conv_state and conv-window caches stay bit-identical to the reference.
-    # Only the fp32 intermediate-ssm rollback cache differs: the tl.sum
-    # reduction-order delta (~1 ulp/step) compounds through the delta-rule
-    # recurrence — measured ~6e-8 at T=4 standard gate (the production MTP
-    # shape), ~1.5e-5 at T=4 safe gate, ~2e-3 at T=8 safe gate. num_warps=1
-    # reproduces the reference reduction order exactly (all buffers
-    # bit-identical) but is ~2.4x slower in-graph — numerics debugging only.
+    # num_warps=4 is ~1.3x faster than the unfused pair in-graph. Output and
+    # conv-window cache stay bit-identical to the reference; conv_state is not
+    # comparable, since the reference advances it and verify leaves it alone.
+    # The fp32 intermediate-ssm rollback cache differs by a tl.sum
+    # reduction-order delta (~1 ulp/step) compounding through the recurrence --
+    # ~6e-8 at T=4 standard gate (the production MTP shape), ~2e-3 at T=8 safe
+    # gate. num_warps=1 restores the reference reduction order for those same
+    # buffers but is ~2.4x slower in-graph -- numerics debugging only.
     num_warps: int = 4,
 ) -> torch.Tensor:
     """Chain-verify fast path. Returns ``o`` of shape [1, seq_len, HV, V],

--- a/python/sglang/kernels/ops/attention/fla/fused_kda_conv_recurrent_verify.py
+++ b/python/sglang/kernels/ops/attention/fla/fused_kda_conv_recurrent_verify.py
@@ -14,17 +14,14 @@ Scope (v1): chain speculation only (``speculative_eagle_topk == 1``, i.e.
 ``retrieve_next_token is None``). The tree path keeps the unfused reference
 kernels. Requires ``T >= kernel_width - 1``.
 
-State: conv_state and the SSM state are read-only here. Verify is speculative,
-and the commit scatter advances conv_state from the selected intermediate
-window, so writing it back is both redundant and unsafe -- all V tiles read
-the same Q/K conv history, so a tile in a later wave would read the rolled
-values.
+State: conv_state and the SSM state are read-only. Verify is speculative, and
+the commit scatter advances them from the selected intermediate window.
 
-Numerics: deliberately bit-aligned with the unfused pair. The conv output is
-rounded to the activation dtype (bf16) before entering the recurrence —
-exactly what the unfused path does through its intermediate tensor — and all
-expressions mirror the reference kernels line by line, with the same
-num_warps so reduction order matches.
+Numerics: aligned with the unfused pair. The conv output is rounded to the
+activation dtype (bf16) before entering the recurrence — exactly what the
+unfused path does through its intermediate tensor — and all expressions mirror
+the reference kernels line by line. Reduction order still splits differently
+where many V heads share one Q/K head, worth ~1 ulp on the output.
 """
 
 from typing import Optional
@@ -323,8 +320,7 @@ def fused_kda_conv_gating_verify_kernel(
                 tl.store(cache_ptr, b_h.to(cache_ptr.dtype.element_ty), mask=mask_h)
 
     # No conv-state writeback: every V tile reads the same Q/K history, so a
-    # tile scheduled in a later wave would read what i_v == 0 had overwritten.
-    # The commit scatter advances conv_state from the selected window instead.
+    # tile in a later wave would read what i_v == 0 had overwritten.
 
 
 def fused_kda_conv_gating_verify(
@@ -352,14 +348,11 @@ def fused_kda_conv_gating_verify(
     softplus_beta: float = 1.0,
     softplus_threshold: float = 20.0,
     use_qk_l2norm_in_kernel: bool = True,
-    # num_warps=4 is ~1.3x faster than the unfused pair in-graph. Output and
-    # conv-window cache stay bit-identical to the reference; conv_state is not
-    # comparable, since the reference advances it and verify leaves it alone.
-    # The fp32 intermediate-ssm rollback cache differs by a tl.sum
-    # reduction-order delta (~1 ulp/step) compounding through the recurrence --
-    # ~6e-8 at T=4 standard gate (the production MTP shape), ~2e-3 at T=8 safe
-    # gate. num_warps=1 restores the reference reduction order for those same
-    # buffers but is ~2.4x slower in-graph -- numerics debugging only.
+    # num_warps=4 is ~1.3x faster than the unfused pair in-graph; 1 restores the
+    # reference reduction order but is ~2.4x slower, for numerics debugging only.
+    # The fp32 intermediate-ssm rollback cache carries the reduction-order delta
+    # furthest: ~6e-8 at T=4 standard gate (the production MTP shape), ~2e-3 at
+    # T=8 safe gate. conv_state is not comparable to the reference at all.
     num_warps: int = 4,
 ) -> torch.Tensor:
     """Chain-verify fast path. Returns ``o`` of shape [1, seq_len, HV, V],

--- a/test/registered/kernels/test_fused_kda_conv_recurrent_verify.py
+++ b/test/registered/kernels/test_fused_kda_conv_recurrent_verify.py
@@ -199,6 +199,9 @@ def test_output_does_not_depend_on_cta_scheduling():
     full = _run_fused(inp, B, T, H, HV, K, V, lower_bound, 4)[0]
 
     streams, _ = split_device_green_ctx_by_sm_count(torch.device("cuda:0"), [8])
+    # The green stream is non-blocking, so it must be told to wait for the
+    # inputs produced above; synchronize() afterwards only waits on the consumer.
+    streams[0].wait_stream(torch.cuda.current_stream())
     with torch.cuda.stream(streams[0]):
         squeezed = _run_fused(inp, B, T, H, HV, K, V, lower_bound, 4)[0]
     streams[0].synchronize()

--- a/test/registered/kernels/test_fused_kda_conv_recurrent_verify.py
+++ b/test/registered/kernels/test_fused_kda_conv_recurrent_verify.py
@@ -170,9 +170,7 @@ def _compare_case(case, num_warps):
     o_ref_v = o_ref.reshape(B, T, HV, V)[valid_rows]
     o_fus_v = o_fus.reshape(B, T, HV, V)[valid_rows]
     assert torch.equal(o_ref_v, o_fus_v)
-    # Verify is speculative: conv_state stays at its pre-verify value and the
-    # commit scatter advances it from the selected window. Writing it here also
-    # races the V tiles that still need the old Q/K history.
+    # conv_state is read-only in verify; the commit scatter advances it.
     assert torch.equal(inp["conv_pool"], conv_fus)
     assert torch.equal(win_ref[valid_rows], win_fus[valid_rows])
     torch.testing.assert_close(
@@ -186,9 +184,8 @@ def test_matches_unfused_reference(case):
 
 
 def test_output_does_not_depend_on_cta_scheduling():
-    """Every V tile reads the same Q/K conv history, so a writeback inside the
-    verify kernel corrupts tiles that start in a later wave. H=1 with HV=16
-    maximizes the sharing; 8 SMs force the waves to serialize."""
+    """The verify output must not change with how the CTAs happen to be
+    scheduled. H=1 with HV=16 shares one Q/K history across 16 V tiles."""
     if torch.cuda.get_device_capability()[0] < 9:
         pytest.skip("green contexts need SM90 or newer")
     from flashinfer.green_ctx import split_device_green_ctx_by_sm_count
@@ -196,14 +193,14 @@ def test_output_does_not_depend_on_cta_scheduling():
     case = (1, 6, 1, 16, 128, 128, 4, False, None, False, 1)
     B, T, H, HV, K, V, W, has_bias, lower_bound, neg_slot, seed = case
     inp = _make_inputs(B, T, H, HV, K, V, W, has_bias, neg_slot, seed)
-    full = _run_fused(inp, B, T, H, HV, K, V, lower_bound, 4)[0]
+    full = _run_fused(inp, B, T, H, HV, K, V, lower_bound, num_warps=4)[0]
 
     streams, _ = split_device_green_ctx_by_sm_count(torch.device("cuda:0"), [8])
     # The green stream is non-blocking, so it must be told to wait for the
     # inputs produced above; synchronize() afterwards only waits on the consumer.
     streams[0].wait_stream(torch.cuda.current_stream())
     with torch.cuda.stream(streams[0]):
-        squeezed = _run_fused(inp, B, T, H, HV, K, V, lower_bound, 4)[0]
+        squeezed = _run_fused(inp, B, T, H, HV, K, V, lower_bound, num_warps=4)[0]
     streams[0].synchronize()
     assert torch.equal(full, squeezed)
 

--- a/test/registered/kernels/test_fused_kda_conv_recurrent_verify.py
+++ b/test/registered/kernels/test_fused_kda_conv_recurrent_verify.py
@@ -166,12 +166,14 @@ def _compare_case(case, num_warps):
 
     idx_vals = inp["idx_vals"]
     valid_rows = [i for i, slot in enumerate(idx_vals) if slot >= 0]
-    touched_slots = [slot for slot in idx_vals if slot >= 0]
 
     o_ref_v = o_ref.reshape(B, T, HV, V)[valid_rows]
     o_fus_v = o_fus.reshape(B, T, HV, V)[valid_rows]
     assert torch.equal(o_ref_v, o_fus_v)
-    assert torch.equal(conv_ref[touched_slots], conv_fus[touched_slots])
+    # Verify is speculative: conv_state stays at its pre-verify value and the
+    # commit scatter advances it from the selected window. Writing it here also
+    # races the V tiles that still need the old Q/K history.
+    assert torch.equal(inp["conv_pool"], conv_fus)
     assert torch.equal(win_ref[valid_rows], win_fus[valid_rows])
     torch.testing.assert_close(
         ic_ref[valid_rows], ic_fus[valid_rows], atol=4e-3, rtol=0
@@ -181,6 +183,26 @@ def _compare_case(case, num_warps):
 @pytest.mark.parametrize("case", _CASES)
 def test_matches_unfused_reference(case):
     _compare_case(case, num_warps=4)
+
+
+def test_output_does_not_depend_on_cta_scheduling():
+    """Every V tile reads the same Q/K conv history, so a writeback inside the
+    verify kernel corrupts tiles that start in a later wave. H=1 with HV=16
+    maximizes the sharing; 8 SMs force the waves to serialize."""
+    if torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("green contexts need SM90 or newer")
+    from flashinfer.green_ctx import split_device_green_ctx_by_sm_count
+
+    case = (1, 6, 1, 16, 128, 128, 4, False, None, False, 1)
+    B, T, H, HV, K, V, W, has_bias, lower_bound, neg_slot, seed = case
+    inp = _make_inputs(B, T, H, HV, K, V, W, has_bias, neg_slot, seed)
+    full = _run_fused(inp, B, T, H, HV, K, V, lower_bound, 4)[0]
+
+    streams, _ = split_device_green_ctx_by_sm_count(torch.device("cuda:0"), [8])
+    with torch.cuda.stream(streams[0]):
+        squeezed = _run_fused(inp, B, T, H, HV, K, V, lower_bound, 4)[0]
+    streams[0].synchronize()
+    assert torch.equal(full, squeezed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> Reland of #39219, which was reverted in #39405 because it was merged by mistake.

## Motivation

`fused_kda_conv_gating_verify` rolled the conv state back into `conv_state` at the end of the kernel. Every V tile loads that same Q/K conv history at entry, but only `i_v == 0` writes it, so a tile scheduled in a later wave reads what the owner already overwrote.

The writeback is also dead: verify is speculative, and the commit scatter sets `conv_state` from the selected intermediate window. `accept_lens` is at least 1, so `last_correct_step_indices` is never negative for a real request and the scatter always overwrites.

So the stores are removed rather than guarded. `conv_state` and the SSM state are read-only in verify.

## Modifications

| | |
| --- | --- |
| kernel | drop the 9 `tl.store(cs_base, ...)` at the end of `fused_kda_conv_gating_verify_kernel` |
| docstring | state ownership: conv and SSM state are read-only, the commit scatter advances them |
| tests | `conv_state` must come back untouched; output must not vary with CTA scheduling |

Reached only with `SGLANG_OPT_FUSED_KDA_VERIFY=1` (default off), on the KDA Triton verify path at `topk == 1`.

## How the race shows

H=1 with HV=16, so 16 V tiles share one Q/K history. Same inputs, against the unfused pair:

| | max abs | max rel |
| --- | --- | --- |
| full GB300, one wave | 2.98e-8 | 7.2e-3 |
| 8-SM green context, waves serialized | **5.0e-2** | **188** |

Removing the stores makes both configurations identical. The residual ~1 ulp is reduction-order difference and is unaffected by the fix.

## Accuracy Tests

Ling-3.0-flash BF16, 4x GB300 TP4, NEXTN, fused verify on. Full GSM8K, thinking on, `temperature=1.0`, `top_p=0.95`, `max_tokens=8192`, 1 repeat.

| | score | stop | error |
| --- | --- | --- | --- |
| before | 96.06% | 99.70% | 0.00% |
| after | 95.83% | 99.17% | 0.00% |

Unchanged — the gap is inside the ~0.55pp 1-sigma band at n=1319. The race is below eval resolution when the grid fits one wave.

## Speed Tests and Profiling

Same server, 8192 in / 1024 out at concurrency 1, 64 warmup, `--flush-cache`, 3 runs per arm. Accept length 3.01 on all six.

| | runs (tok/s) | mean |
| --- | --- | --- |
| before | 355.23, 361.47, 363.72 | 360.14 |
| after | 370.64, 369.38, 375.18 | **371.73** |

**+3.22%**, arms disjoint. The kernel does strictly less work with the stores gone.

## Checklist

- [x] `pre-commit` clean
- [x] 9 cases in `test_fused_kda_conv_recurrent_verify.py`; all 9 fail against the unfixed kernel
- [x] Accuracy and speed measured above

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35569381582](https://github.com/sgl-project/sglang/actions/runs/35569381582)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35569381392](https://github.com/sgl-project/sglang/actions/runs/35569381392)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35569381525](https://github.com/sgl-project/sglang/actions/runs/35569381525)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->