### PR TITLE
[NPU][DSV4]dsv4 enable cpp

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py
@@ -486,7 +486,7 @@ class DSV4NPUTokenToKVPool(DeepSeekV4TokenToKVPool):
         item = self.layer_mapping[layer_id]
         ratio = item.compress_ratio
         if ratio == 0:
-            return self.swa_kv_pool.kv_buffer[item.compress_layer_id]
+            return self.swa_kv_pool.kv_buffer[self._swa_local_layer_id(layer_id)]
         if ratio == 4:
             return self.c4_kv_pool.kv_buffer[item.compress_layer_id]
         if ratio == 128:
@@ -509,9 +509,10 @@ class DSV4NPUTokenToKVPool(DeepSeekV4TokenToKVPool):
         flatten across (num_pages, page_size) and gather the matching tokens —
         shape becomes (num_tokens, 1, dim).
         """
-        # Index by RAW layer_id, not compress_layer_id (a per-bucket counter that
-        # would collide across ratios). swa_kv_pool is sized layer_num=total_layers.
-        kv = self.swa_kv_pool.kv_buffer[layer_id]
+        # Index by PP-stage-local layer_id, not compress_layer_id (a per-bucket
+        # counter that would collide across ratios). swa_kv_pool is sized
+        # layer_num=stage_layer_num (only this PP stage's layers).
+        kv = self.swa_kv_pool.kv_buffer[self._swa_local_layer_id(layer_id)]
         if loc is not None:
             kv = kv.flatten(0, 1)[loc]
         return kv
@@ -556,8 +557,8 @@ class DSV4NPUTokenToKVPool(DeepSeekV4TokenToKVPool):
         (num_pages, page_size, 1, dim) so we flatten the first two dims and
         index_put.
         """
-        # Index by raw layer_id (see get_swa_buffer) to avoid bucket collision.
-        buf = self.swa_kv_pool.kv_buffer[layer_id]
+        # Index by PP-stage-local layer_id (see get_swa_buffer).
+        buf = self.swa_kv_pool.kv_buffer[self._swa_local_layer_id(layer_id)]
         if is_npu_arch35():
             self._write_a5_packed_kv(buf=buf, loc=loc, cache=cache)
             return

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2810,7 +2810,7 @@ class DeepseekV4Model(nn.Module):
         super().__init__()
         self.pp_group = get_pp_group()
         self.hidden_size = config.hidden_size
-        if self.pp_group.is_first_rank:
+        if self.pp_group.is_first_rank or (_is_npu and self.pp_group.is_last_rank):
             embedding_quant_config = (
                 quant_config
                 if quant_config is not None and quant_config.get_name() == "expert_pack"

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -23,7 +23,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.models.deepseek_v4 import (
     DeepseekV4DecoderLayer,
     DeepseekV4ForCausalLM,
@@ -124,6 +124,7 @@ class DeepseekV4ModelNextN(nn.Module):
         positions: torch.Tensor,
         forward_batch: ForwardBatch,
         input_embeds: torch.Tensor = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> torch.Tensor:
         if input_embeds is None:
             hidden_states = self.embed_tokens(input_ids)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Core CPP (chunked pipeline parallelism) capabilities already supported on sglang. The primary goal of this PR is to enable Prefill (PP) + Decode (DSpark) on DSV4(pro/flash) on npu.
Previous CI has passed all npu test

## Modifications
in 4 files
python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
When prefill node enable pp + decode node enable dspark on long seqs, prefill node would have tiling problem with sparse_attn_sharedkv op. In that case we use op from  haisi kernel rather than sgl-kernel-npu.
python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py


## Accuracy Tests
**gpqa**
dsv4 flash p(pp) + d(dspark) 
<img width="657" height="88" alt="image" src="https://github.com/user-attachments/assets/6ae96709-68f9-4e63-8464-9754abd40afc" />

**longbench-v2:**
dsv4 flash: before pp:
<img width="551" height="72" alt="image" src="https://github.com/user-attachments/assets/29ecb6cf-60dc-4b67-b96d-a1953712143a" />
dsv4 flash: after pp:
<img width="538" height="68" alt="image" src="https://github.com/user-attachments/assets/9126e6b5-8ef8-44f0-9d46-70e363d921ff" />
dsv4 pro before pp:
<img width="474" height="65" alt="image" src="https://github.com/user-attachments/assets/43212f5c-28b3-4ad4-a785-f3d9bbdd3d9a" />
dsv4 pro after pp:
<img width="394" height="62" alt="image" src="https://github.com/user-attachments/assets/14b04cbb-7658-4499-99f5-a3c1633a0e3f" />


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35349873174](https://github.com/sgl-project/sglang/actions/runs/35349873174)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35349873022](https://github.com/sgl-project/sglang/actions/runs/35349873022)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35349873216](https://github.com/sgl-project/sglang/actions/runs/35349873216)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->